### PR TITLE
Xrandr fullscreen

### DIFF
--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -194,7 +194,7 @@ void dump_config_status(void (*printfunc)(const char *, ...))
         config.X_bilin_filt, config.X_mode13fact, config.X_winsize_x);
     (*print)("X_winsize_y %d\nX_gamma %d\nX_fullscreen %d\nX_fullscreen_hw_switch %d\n",
         config.X_winsize_y, config.X_gamma, config.X_fullscreen,
-				config.X_fullscreen_hw_switch);
+        config.X_fullscreen_hw_switch);
     (*print)("vgaemu_memsize 0x%x\nvesamode_list %p\nX_lfb %d\nX_pm_interface %d\n",
         config.vgaemu_memsize, config.vesamode_list, config.X_lfb, config.X_pm_interface);
     (*print)("X_keycode %d\nX_font \"%s\"\n",

--- a/src/base/init/lexer.l.in
+++ b/src/base/init/lexer.l.in
@@ -616,7 +616,7 @@ pm_interface		RETURN(X_PM_INTERFACE);
 mgrab_key		RETURN(X_MGRAB_KEY);
 background_pause	RETURN(X_BACKGROUND_PAUSE);
 fullscreen		RETURN(X_FULLSCREEN);
-fullscreen_hw_switch		RETURN(X_FULLSCREEN_HW_SWITCH);
+fullscreen_hw_switch	RETURN(X_FULLSCREEN_HW_SWITCH);
 
         /* Sound stuff */
 

--- a/src/base/init/parser.y.in
+++ b/src/base/init/parser.y.in
@@ -1039,8 +1039,8 @@ x_flag		: UPDATELINES expression	{ config.X_updatelines = $2; }
                      config.X_winsize_y = $4;
                    }
 		| X_GAMMA expression  { config.X_gamma = $2; }
-		| X_FULLSCREEN bool   { config.X_fullscreen = $2; }
-		| X_FULLSCREEN_HW_SWITCH bool   { config.X_fullscreen_hw_switch = $2; }
+		| X_FULLSCREEN bool   { config.X_fullscreen = ($2!=0); }
+		| X_FULLSCREEN_HW_SWITCH bool   { config.X_fullscreen_hw_switch = ($2!=0); }
 		| VGAEMU_MEMSIZE expression	{ config.vgaemu_memsize = $2; }
 		| VESAMODE INTEGER INTEGER { set_vesamodes($2,$3,0);}
 		| VESAMODE INTEGER INTEGER INTEGER { set_vesamodes($2,$3,$4);}

--- a/src/plugin/X/X.c
+++ b/src/plugin/X/X.c
@@ -1743,7 +1743,7 @@ static int __X_handle_events(void)
 	    set_mouse_buttons(e.xcrossing.state);
 	    mouse_really_left_window = 0;
 	    /* Grab keyboard if fullscreen (i.e., entering window from another
-	     * CRTC in a multihead system.  Otherwise we can't type.*/
+	     * CRTC in a multihead system.  Otherwise we can't type. */
 	    if (mainwindow == fullscreenwindow && !kbd_grab_active) {
 	      toggle_kbd_grab();
 	      force_kbd_grab = 1;
@@ -2406,14 +2406,14 @@ static void X_vidmode(int w, int h, int *new_x, int *new_y, int *new_width, int 
       /* Return to window. */
       X_printf("X: RandR leaving fullscreen mode\n");
       X_randr_exit_fullscreen();
-			dosemu_x = xrandr_win_xpos;
-			dosemu_y = xrandr_win_ypos;
+      dosemu_x = xrandr_win_xpos;
+      dosemu_y = xrandr_win_ypos;
     } else if (mainwindow != fullscreenwindow) {
       X_printf("X: RandR entering fullscreen mode\n");
       /* Find which CRTC 'window' dosemu's upper left corner is within. */
       XRRScreenResources *sr = XRRGetScreenResourcesCurrent(display, mainwindow);
       RRCrtc crtc = None;
-			int i;
+      int i;
       for (i = 0; i < sr->ncrtc; i++) {
         XRRCrtcInfo *ci = XRRGetCrtcInfo(display, sr, sr->crtcs[i]);
         if (ci->mode == None) {
@@ -2440,8 +2440,8 @@ static void X_vidmode(int w, int h, int *new_x, int *new_y, int *new_width, int 
       }
       XRRCrtcInfo *ci = XRRGetCrtcInfo(display, sr, crtc);
 
-			/* XXX: Use the first Output attached to this CRTC always.  In what
- 			 * display configurations could this break? */
+      /* XXX: Use the first Output attached to this CRTC always.  In what
+       * display configurations could this break? */
       int output_idx = 0;
       XRROutputInfo *oi = XRRGetOutputInfo(display, sr, ci->outputs[output_idx]);
 
@@ -2506,6 +2506,13 @@ static void X_vidmode(int w, int h, int *new_x, int *new_y, int *new_width, int 
       XRRFreeScreenResources(sr);
       /* Callers always set this themselves, but anyway ... */
       mainwindow = fullscreenwindow;
+    } else { /* Just changing gfx mode. */
+      XRRScreenResources *sr = XRRGetScreenResourcesCurrent(display, mainwindow);
+      XRRCrtcInfo *ci = XRRGetCrtcInfo(display, sr, xrandr_win_crtc);
+      nw = ci->width;
+      nh = ci->height;
+      XRRFreeCrtcInfo(ci);
+      XRRFreeScreenResources(sr);
     }
   } else /* Only attempt VidMode or non-modechange fullscreen if RandR is disabled. */
 #endif /* HAVE_XRANDR */


### PR DESCRIPTION
I forgot handling of the default case in X_vidmode() (non-fullscreen change).

Also, disallow ungrabbing keyboard unless we know it can be regrabbed (by EnterNotify event).  It's not easy to just restore window decorations temporarily because the fullscreen window is created with override_redirect.