### PR TITLE
Autoconf - check for alsa and sdl with pkg-config

### DIFF
--- a/src/plugin/alsa/configure.ac
+++ b/src/plugin/alsa/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 AC_INIT
 AC_CONFIG_FILES([Makefile.conf])
-AM_PATH_ALSA(0,,
+PKG_CHECK_MODULES([ALSA], alsa,,
     AC_MSG_ERROR([alsa development libs not found]))
 AC_SUBST(ALSA_CFLAGS)
 AC_SUBST(ALSA_LIBS)

--- a/src/plugin/sdl/configure.ac
+++ b/src/plugin/sdl/configure.ac
@@ -3,7 +3,7 @@ AC_INIT
 
 dnl Check for SDL
 SDL_VERSION=2.0.2
-AM_PATH_SDL2($SDL_VERSION,,
+PKG_CHECK_MODULES([SDL], sdl2 >= $SDL_VERSION,,
 	    AC_MSG_ERROR([*** SDL version $SDL_VERSION not found!])
 )
 


### PR DESCRIPTION
On systems that don't have the alsa and sdl development libraries installed we
see errors as below:

Generating configure script for src/plugin/alsa...
configure.ac:4: warning: macro 'AM_PATH_ALSA' not found in library
configure.ac:4: error: possibly undefined macro: AM_PATH_ALSA

Generating configure script for src/plugin/sdl...
configure.ac:6: warning: macro 'AM_PATH_SDL2' not found in library
configure.ac:6: error: possibly undefined macro: AM_PATH_SDL2

So replace the macro references in each plugin's configure.ac with
PKG_CHECK_MODULES as that is used elsewhere.