### PR TITLE
Keymap: Rework X11 detection

### DIFF
--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -273,7 +273,7 @@
 ## Keyboard related settings
 
 # Keyboard layout: default: 'auto' (which tries to generate the table from
-# the current Linux console settings)
+# reading the current Linux console settings or the X11 keymap)
 # or one of: finnish(-latin1), de(-latin1), be, it, us, uk, dk(-latin1),
 # keyb-no, no-latin1, dvorak, pl, po, sg(-latin1), fr(-latin1), sf(-latin1),
 # es(-latin1), sw, hu(-latin2), hu-cwi, keyb-user, hr-cp852, hr-latin2,

--- a/src/plugin/kbd_unicode/keymaps.c
+++ b/src/plugin/kbd_unicode/keymaps.c
@@ -2516,7 +2516,7 @@ void setup_default_keytable()
 
   /* Now copy parameters for the linux kernel keymap */
   if(read_kbd_table(kt, altkt)) {
-    k_printf("setup_default_keytable: failed\n");
+    k_printf("setup_default_keytable: failed to read kernel console keymap\n");
     kt->name = NULL;
   }
 


### PR DESCRIPTION
1/ Simplified the detection to just check the plain and shifted keycodes, as
incorrect selections(UK) were being made due to no alt keys being available in
the plain X11 keymap data.

2/ Added the ability to use Xkb keyboard extension if available.

3/ Tweaked kernel console keymap access error message.

4/ Clarified comments in dosemu.conf

Tested both Xkb and plain X11 versions with:
a) UK primary and FR secondary -> uk, fr-latin
b) DE primary and US secondary -> de-latin, us

It would be nice if you could test with whatever keyboards you have before applying?

Thanks