### PR TITLE
Keymap: Rework X11 detection

### DIFF
--- a/src/plugin/kbd_unicode/keymaps.c
+++ b/src/plugin/kbd_unicode/keymaps.c
@@ -2516,7 +2516,7 @@ void setup_default_keytable()
 
   /* Now copy parameters for the linux kernel keymap */
   if(read_kbd_table(kt, altkt)) {
-    k_printf("setup_default_keytable: failed\n");
+    k_printf("setup_default_keytable: failed to read kernel console keymap\n");
     kt->name = NULL;
   }
 


### PR DESCRIPTION
1/ Simplified the detection to just check the plain and shifted keycodes, as
incorrect selections(UK) were being made due to no alt keys being available in
the plain X11 keymap data.

2/ Added the ability to use Xkb keyboard extension if available.

3/ Tweaked kernel console keymap access error message.

Tested both Xkb and plain X11 versions with:
a) UK primary and FR secondary -> uk, fr-latin
b) DE primary and US secondary -> de-latin, us