### PR TITLE
Rename sigcontext_struct references to sigcontext

### DIFF
--- a/src/arch/linux/async/sigsegv.c
+++ b/src/arch/linux/async/sigsegv.c
@@ -25,7 +25,7 @@
 
 
 /* Function prototypes */
-void print_exception_info(struct sigcontext_struct *scp);
+void print_exception_info(struct sigcontext *scp);
 
 
 /*
@@ -47,7 +47,7 @@ void print_exception_info(struct sigcontext_struct *scp);
 
 
 /*
- * DANG_BEGIN_FUNCTION dosemu_fault(int, struct sigcontext_struct);
+ * DANG_BEGIN_FUNCTION dosemu_fault(int, struct sigcontext);
  *
  * All CPU exceptions (except 13=general_protection from V86 mode,
  * which is directly scanned by the kernel) are handled here.
@@ -58,7 +58,7 @@ void print_exception_info(struct sigcontext_struct *scp);
 __attribute__((no_instrument_function))
 static int dosemu_fault1(
 #ifdef __linux__
-int signal, struct sigcontext_struct *scp
+int signal, struct sigcontext *scp
 #endif /* __linux__ */
 )
 {
@@ -357,7 +357,7 @@ bad:
   }
 }
 
-int _dosemu_fault(int signal, struct sigcontext_struct *scp)
+int _dosemu_fault(int signal, struct sigcontext *scp)
 {
   int ret;
   fault_cnt++;
@@ -368,7 +368,7 @@ int _dosemu_fault(int signal, struct sigcontext_struct *scp)
 
 /* noinline is to prevent gcc from moving TLS access around init_handler() */
 __attribute__((noinline))
-static void dosemu_fault0(int signal, struct sigcontext_struct *scp)
+static void dosemu_fault0(int signal, struct sigcontext *scp)
 {
   int retcode;
   pid_t tid;
@@ -445,8 +445,8 @@ static void dosemu_fault0(int signal, struct sigcontext_struct *scp)
 __attribute__((no_instrument_function))
 void dosemu_fault(int signal, siginfo_t *si, void *uc)
 {
-  struct sigcontext_struct *scp =
-	(struct sigcontext_struct *)&((ucontext_t *)uc)->uc_mcontext;
+  struct sigcontext *scp =
+	(struct sigcontext *)&((ucontext_t *)uc)->uc_mcontext;
   /* need to call init_handler() before any syscall.
    * Additionally, TLS access should be done in a separate no-inline
    * function, so that gcc not to move the TLS access around init_handler(). */
@@ -466,7 +466,7 @@ void dosemu_fault(int signal, siginfo_t *si, void *uc)
  *
  */
 __attribute__((no_instrument_function))
-void print_exception_info(struct sigcontext_struct *scp)
+void print_exception_info(struct sigcontext *scp)
 {
   int i;
 

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -963,7 +963,6 @@ void vga_memsetl(dosaddr_t dst, unsigned val, size_t len)
  * description:
  * vga_emu_fault() is used to catch video access, and handle it.
  * This function is called from arch/linux/async/sigsegv.c::dosemu_fault1().
- * The sigcontext_struct is defined in include/cpu.h.
  * Now it catches only changes in a 4K page, but maybe it is useful to
  * catch each video access. The problem when you do that is, you have to
  * simulate each instruction which could write to the video memory.
@@ -980,13 +979,13 @@ void vga_memsetl(dosaddr_t dst, unsigned val, size_t len)
  * simulated.
  *
  * arguments:
- * scp - A pointer to a struct sigcontext_struct holding some relevant data.
+ * scp - A pointer to a struct sigcontext holding some relevant data.
  *
  * DANG_END_FUNCTION
  *
  */
 
-int vga_emu_fault(struct sigcontext_struct *scp, int pmode)
+int vga_emu_fault(struct sigcontext *scp, int pmode)
 {
   int i, j;
   dosaddr_t lin_addr;

--- a/src/base/misc/dump.c
+++ b/src/base/misc/dump.c
@@ -154,7 +154,7 @@ show_ints(int min, int max)
 
 #define IsSegment32(s)			(Segments[(s) >> 3].is_32)
 
-char *DPMI_show_state(struct sigcontext_struct *scp)
+char *DPMI_show_state(struct sigcontext *scp)
 {
     static char buf[4096];
     int pos = 0;

--- a/src/base/video/instremu.c
+++ b/src/base/video/instremu.c
@@ -2352,7 +2352,7 @@ static inline int instr_sim(x86_regs *x86, int pmode)
   return 1;
 }
 
-static void scp_to_x86_regs(x86_regs *x86, struct sigcontext_struct *scp, int pmode)
+static void scp_to_x86_regs(x86_regs *x86, struct sigcontext *scp, int pmode)
 {
   if(pmode) {
     x86->eax = _eax;
@@ -2407,7 +2407,7 @@ static void scp_to_x86_regs(x86_regs *x86, struct sigcontext_struct *scp, int pm
   prepare_x86(x86);
 }
 
-static void x86_regs_to_scp(x86_regs *x86, struct sigcontext_struct *scp, int pmode)
+static void x86_regs_to_scp(x86_regs *x86, struct sigcontext *scp, int pmode)
 {
   if(pmode) {
     _cs = x86->cs;
@@ -2449,14 +2449,14 @@ static void x86_regs_to_scp(x86_regs *x86, struct sigcontext_struct *scp, int pm
  * state in the x86 structure.
  *
  * arguments:
- * scp - A pointer to a struct sigcontext_struct holding some relevant data.
+ * scp - A pointer to a struct sigcontext holding some relevant data.
  * pmode - flags protected mode
  * cnt - number of instructions to be simulated
  *
  * DANG_END_FUNCTION
  */
 
-int instr_emu(struct sigcontext_struct *scp, int pmode, int cnt)
+int instr_emu(struct sigcontext *scp, int pmode, int cnt)
 {
 #if DEBUG_INSTR >= 1
   unsigned int ref;
@@ -2513,7 +2513,7 @@ int instr_emu(struct sigcontext_struct *scp, int pmode, int cnt)
   return True;
 }
 
-int decode_modify_segreg_insn(struct sigcontext_struct *scp, int pmode,
+int decode_modify_segreg_insn(struct sigcontext *scp, int pmode,
     unsigned int *new_val)
 {
   unsigned char *mem;

--- a/src/doc/DANG/DANG.sgml
+++ b/src/doc/DANG/DANG.sgml
@@ -839,7 +839,6 @@ Arguments are:
 <Para>
 vga_emu_fault() is used to catch video access, and handle it.
 This function is called from arch/linux/async/sigsegv.c::dosemu_fault1().
-The sigcontext_struct is defined in include/cpu.h.
 Now it catches only changes in a 4K page, but maybe it is useful to
 catch each video access. The problem when you do that is, you have to 
 simulate each instruction which could write to the video memory.
@@ -868,7 +867,7 @@ Arguments are:
 <ListItem>
 
 <Para>
-  scp - A pointer to a struct sigcontext_struct holding some relevant data.
+  scp - A pointer to a struct sigcontext holding some relevant data.
 </Para>
 </ListItem>
 
@@ -1633,7 +1632,6 @@ Arguments are:
 <Para>
 vga_emu_fault() is used to catch video access, and handle it.
 This function is called from arch/linux/async/sigsegv.c::dosemu_fault1().
-The sigcontext_struct is defined in include/cpu.h.
 Now it catches only changes in a 4K page, but maybe it is useful to
 catch each video access. The problem when you do that is, you have to 
 simulate each instruction which could write to the video memory.
@@ -1662,7 +1660,7 @@ Arguments are:
 <ListItem>
 
 <Para>
-  scp - A pointer to a struct sigcontext_struct holding some relevant data.
+  scp - A pointer to a struct sigcontext holding some relevant data.
 </Para>
 </ListItem>
 
@@ -2076,7 +2074,7 @@ Arguments are:
 <ListItem>
 
 <Para>
-  scp - A pointer to a struct sigcontext_struct holding some relevant data.
+  scp - A pointer to a struct sigcontext holding some relevant data.
 </Para>
 </ListItem>
 <ListItem>
@@ -2687,7 +2685,7 @@ These are the functions defined in arch/linux/async/sigsegv.c.
 </Para>
 
 <Sect3>
-<Title>dosemu_fault(int, struct sigcontext_struct);</Title>
+<Title>dosemu_fault(int, struct sigcontext);</Title>
 
 <Para>
 All CPU exceptions (except 13=general_protection from V86 mode,
@@ -3999,7 +3997,7 @@ These are the functions defined in emu-i386/simx86/sigsegv.c.
 </Para>
 
 <Sect3>
-<Title>dosemu_fault(int, struct sigcontext_struct);</Title>
+<Title>dosemu_fault(int, struct sigcontext);</Title>
 
 <Para>
 All CPU exceptions (except 13=general_protection from V86 mode,

--- a/src/dosext/dpmi/dpmi.h
+++ b/src/dosext/dpmi/dpmi.h
@@ -104,7 +104,7 @@ typedef struct {
 } RealModeCallBack;
 
 struct DPMIclient_struct {
-  struct sigcontext_struct stack_frame;
+  struct sigcontext stack_frame;
   /* fpu_state needs to be paragraph aligned for fxrstor/fxsave */
   struct _fpstate fpu_state __attribute__ ((aligned(16)));
   int is_32;
@@ -156,13 +156,13 @@ extern unsigned char *ldt_alias;
 
 void dpmi_get_entry_point(void);
 #ifdef __x86_64__
-extern void dpmi_iret_setup(struct sigcontext_struct *);
+extern void dpmi_iret_setup(struct sigcontext *);
 #else
 #define dpmi_iret_setup(x)
 #endif
-int indirect_dpmi_switch(struct sigcontext_struct *);
+int indirect_dpmi_switch(struct sigcontext *);
 #ifdef __linux__
-int dpmi_fault(struct sigcontext_struct *);
+int dpmi_fault(struct sigcontext *);
 #endif
 void dpmi_realmode_hlt(unsigned int);
 void run_pm_int(int);
@@ -200,12 +200,12 @@ void GetFreeMemoryInformation(unsigned int *lp);
 int GetDescriptor(u_short selector, unsigned int *lp);
 unsigned int GetSegmentBase(unsigned short);
 unsigned int GetSegmentLimit(unsigned short);
-int CheckSelectors(struct sigcontext_struct *scp, int in_dosemu);
+int CheckSelectors(struct sigcontext *scp, int in_dosemu);
 int ValidAndUsedSelector(unsigned short selector);
 int dpmi_is_valid_range(dosaddr_t addr, int len);
 
-extern char *DPMI_show_state(struct sigcontext_struct *scp);
-extern void dpmi_sigio(struct sigcontext_struct *scp);
+extern char *DPMI_show_state(struct sigcontext *scp);
+extern void dpmi_sigio(struct sigcontext *scp);
 extern void run_dpmi(void);
 
 extern int ConvertSegmentToDescriptor(unsigned short segment);
@@ -217,14 +217,14 @@ extern int SetSegmentBaseAddress(unsigned short selector,
 extern int SetSegmentLimit(unsigned short, unsigned int);
 extern DPMI_INTDESC dpmi_get_interrupt_vector(unsigned char num);
 extern void dpmi_set_interrupt_vector(unsigned char num, DPMI_INTDESC desc);
-extern void save_pm_regs(struct sigcontext_struct *);
-extern void restore_pm_regs(struct sigcontext_struct *);
+extern void save_pm_regs(struct sigcontext *);
+extern void restore_pm_regs(struct sigcontext *);
 extern unsigned short AllocateDescriptors(int);
 extern int SetSelector(unsigned short selector, dosaddr_t base_addr, unsigned int limit,
                        unsigned char is_32, unsigned char type, unsigned char readonly,
                        unsigned char is_big, unsigned char seg_not_present, unsigned char useable);
 extern int FreeDescriptor(unsigned short selector);
-extern void FreeSegRegs(struct sigcontext_struct *scp, unsigned short selector);
+extern void FreeSegRegs(struct sigcontext *scp, unsigned short selector);
 extern far_t DPMI_allocate_realmode_callback(u_short sel, int offs, u_short rm_sel,
 	int rm_offs);
 extern int DPMI_free_realmode_callback(u_short seg, u_short off);
@@ -234,15 +234,15 @@ extern void dpmi_reset(void);
 extern void dpmi_cleanup(void);
 extern int get_ldt(void *buffer);
 void dpmi_return_request(void);
-void dpmi_return(struct sigcontext_struct *scp, int retval);
-int dpmi_check_return(struct sigcontext_struct *scp);
+void dpmi_return(struct sigcontext *scp, int retval);
+int dpmi_check_return(struct sigcontext *scp);
 void dpmi_init(void);
-extern void copy_context(struct sigcontext_struct *d,
-    struct sigcontext_struct *s, int copy_fpu);
+extern void copy_context(struct sigcontext *d,
+    struct sigcontext *s, int copy_fpu);
 extern unsigned short dpmi_sel(void);
 extern unsigned short dpmi_data_sel(void);
-//extern void pm_to_rm_regs(struct sigcontext_struct *scp, unsigned int mask);
-//extern void rm_to_pm_regs(struct sigcontext_struct *scp, unsigned int mask);
+//extern void pm_to_rm_regs(struct sigcontext *scp, unsigned int mask);
+//extern void rm_to_pm_regs(struct sigcontext *scp, unsigned int mask);
 
 static inline int DPMIValidSelector(unsigned short selector)
 {

--- a/src/dosext/dpmi/msdos.c
+++ b/src/dosext/dpmi/msdos.c
@@ -254,7 +254,7 @@ static void restore_ems_frame(void)
     ems_frame_mapped = 0;
 }
 
-static void get_ext_API(struct sigcontext_struct *scp)
+static void get_ext_API(struct sigcontext *scp)
 {
     struct pmaddr_s pma;
     char *ptr = SEL_ADR_CLNT(_ds, _esi, MSDOS_CLIENT.is_32);
@@ -521,7 +521,7 @@ static void do_retf(struct RealModeCallStructure *rmreg, int rmask)
   _RMREG(sp) += 4;
 }
 
-static void old_dos_terminate(struct sigcontext_struct *scp, int i,
+static void old_dos_terminate(struct sigcontext *scp, int i,
 			      struct RealModeCallStructure *rmreg, int rmask)
 {
     unsigned short psp_seg_sel, parent_psp = 0;
@@ -595,7 +595,7 @@ static void old_dos_terminate(struct sigcontext_struct *scp, int i,
  * DANG_END_FUNCTION
  */
 
-static int _msdos_pre_extender(struct sigcontext_struct *scp, int intr,
+static int _msdos_pre_extender(struct sigcontext *scp, int intr,
 			       struct RealModeCallStructure *rmreg,
 			       int *r_mask)
 {
@@ -1232,7 +1232,7 @@ static int _msdos_pre_extender(struct sigcontext_struct *scp, int intr,
     return ret;
 }
 
-int msdos_pre_extender(struct sigcontext_struct *scp, int intr,
+int msdos_pre_extender(struct sigcontext *scp, int intr,
 		       struct RealModeCallStructure *rmreg, int *r_mask)
 {
     int ret = _msdos_pre_extender(scp, intr, rmreg, r_mask);
@@ -1258,7 +1258,7 @@ int msdos_pre_extender(struct sigcontext_struct *scp, int intr,
  * DANG_END_FUNCTION
  */
 
-static int _msdos_post_extender(struct sigcontext_struct *scp, int intr,
+static int _msdos_post_extender(struct sigcontext *scp, int intr,
 				u_short ax,
 				const struct RealModeCallStructure *rmreg)
 {
@@ -1630,7 +1630,7 @@ static int _msdos_post_extender(struct sigcontext_struct *scp, int intr,
     return update_mask;
 }
 
-int msdos_post_extender(struct sigcontext_struct *scp, int intr,
+int msdos_post_extender(struct sigcontext *scp, int intr,
 			 const struct RealModeCallStructure *rmreg)
 {
     int ret = _msdos_post_extender(scp, intr, pop_v(), rmreg);
@@ -1639,7 +1639,7 @@ int msdos_post_extender(struct sigcontext_struct *scp, int intr,
     return ret;
 }
 
-static int mouse_callback(struct sigcontext_struct *scp,
+static int mouse_callback(struct sigcontext *scp,
 		 const struct RealModeCallStructure *rmreg)
 {
     void *sp = SEL_ADR_CLNT(_ss, _esp, MSDOS_CLIENT.is_32);
@@ -1668,7 +1668,7 @@ static int mouse_callback(struct sigcontext_struct *scp,
     return 1;
 }
 
-static int ps2_mouse_callback(struct sigcontext_struct *scp,
+static int ps2_mouse_callback(struct sigcontext *scp,
 		 const struct RealModeCallStructure *rmreg)
 {
     unsigned short *rm_ssp;
@@ -1767,7 +1767,7 @@ static void rmcb_handler(struct RealModeCallStructure *rmreg)
     do_retf(rmreg, (1 << ss_INDEX) | (1 << esp_INDEX));
 }
 
-static void msdos_api_call(struct sigcontext_struct *scp)
+static void msdos_api_call(struct sigcontext *scp)
 {
     D_printf("MSDOS: extension API call: 0x%04x\n", _LWORD(eax));
     if (_LWORD(eax) == 0x0100) {
@@ -1778,9 +1778,9 @@ static void msdos_api_call(struct sigcontext_struct *scp)
     }
 }
 
-int msdos_fault(struct sigcontext_struct *scp)
+int msdos_fault(struct sigcontext *scp)
 {
-    struct sigcontext_struct new_sct;
+    struct sigcontext new_sct;
     int reg;
     unsigned int segment;
     unsigned short desc;
@@ -1946,7 +1946,7 @@ static far_t get_rm_handler(int (*handler)(struct sigcontext *,
     return ret;
 }
 
-void msdos_pm_call(struct sigcontext_struct *scp)
+void msdos_pm_call(struct sigcontext *scp)
 {
     if (_eip == 1 + DPMI_SEL_OFF(MSDOS_API_call)) {
 	msdos_api_call(scp);
@@ -1959,7 +1959,7 @@ void msdos_pm_call(struct sigcontext_struct *scp)
     }
 }
 
-int msdos_pre_pm(struct sigcontext_struct *scp,
+int msdos_pre_pm(struct sigcontext *scp,
 		 struct RealModeCallStructure *rmreg)
 {
     if (_eip == 1 + DPMI_SEL_OFF(MSDOS_XMS_call)) {
@@ -1971,7 +1971,7 @@ int msdos_pre_pm(struct sigcontext_struct *scp,
     return 1;
 }
 
-int msdos_pre_rm(struct sigcontext_struct *scp,
+int msdos_pre_rm(struct sigcontext *scp,
 		 const struct RealModeCallStructure *rmreg)
 {
     int ret = 0;

--- a/src/dosext/dpmi/msdos.h
+++ b/src/dosext/dpmi/msdos.h
@@ -36,21 +36,21 @@ extern void msdos_reset(u_short emm_s);
 extern void msdos_init(int is_32, unsigned short mseg);
 extern void msdos_done(void);
 extern int msdos_get_lowmem_size(void);
-extern int msdos_pre_extender(struct sigcontext_struct *scp, int intr,
+extern int msdos_pre_extender(struct sigcontext *scp, int intr,
 	struct RealModeCallStructure *rmreg, int *r_mask);
-extern int msdos_post_extender(struct sigcontext_struct *scp, int intr,
+extern int msdos_post_extender(struct sigcontext *scp, int intr,
 	const struct RealModeCallStructure *rmreg);
-extern int msdos_fault(struct sigcontext_struct *scp);
+extern int msdos_fault(struct sigcontext *scp);
 #ifdef DOSEMU
-extern int msdos_pre_rm(struct sigcontext_struct *scp,
+extern int msdos_pre_rm(struct sigcontext *scp,
 	const struct RealModeCallStructure *rmreg);
-extern void msdos_post_rm(struct sigcontext_struct *scp,
+extern void msdos_post_rm(struct sigcontext *scp,
 	struct RealModeCallStructure *rmreg);
-extern int msdos_pre_pm(struct sigcontext_struct *scp,
+extern int msdos_pre_pm(struct sigcontext *scp,
 	struct RealModeCallStructure *rmreg);
-extern void msdos_post_pm(struct sigcontext_struct *scp,
+extern void msdos_post_pm(struct sigcontext *scp,
 	const struct RealModeCallStructure *rmreg);
-extern void msdos_pm_call(struct sigcontext_struct *scp);
+extern void msdos_pm_call(struct sigcontext *scp);
 #endif
 
 #define MSDOS_DONE 1

--- a/src/emu-i386/cpu.c
+++ b/src/emu-i386/cpu.c
@@ -106,7 +106,7 @@ struct _fpstate vm86_fpu_state __attribute__ ((aligned(16)));
  * DANG_END_FUNCTION
  *
  */
-int cpu_trap_0f (unsigned char *csp, struct sigcontext_struct *scp)
+int cpu_trap_0f (unsigned char *csp, struct sigcontext *scp)
 {
 	int increment_ip = 0;
 	g_printf("CPU: TRAP op 0F %02x %02x\n",csp[1],csp[2]);

--- a/src/emu-i386/simx86/codegen-sim.c
+++ b/src/emu-i386/simx86/codegen-sim.c
@@ -2370,7 +2370,7 @@ void Gen_sim(int op, int mode, ...)
 		v = vga_access(DOSADDR_REL(AR2.pu), DOSADDR_REL(AR1.pu));
 		if (v) {
 		    int op;
-		    struct sigcontext_struct s, *scp = &s;
+		    struct sigcontext s, *scp = &s;
 		    _err = v;
 		    _rdi = AR1.d;
 		    _rsi = AR2.d;

--- a/src/emu-i386/simx86/codegen.h
+++ b/src/emu-i386/simx86/codegen.h
@@ -317,7 +317,7 @@ extern char OpSize[];
 
 #define OPSIZE(m) (OpSize[(m)&(DATA16|MBYTE)])
 
-int Cpatch(struct sigcontext_struct *scp);
+int Cpatch(struct sigcontext *scp);
 int UnCpatch(unsigned char *eip);
 void stub_rep(void) asm ("stub_rep__");
 void stub_stk_16(void) asm ("stub_stk_16__");

--- a/src/emu-i386/simx86/cpatch.c
+++ b/src/emu-i386/simx86/cpatch.c
@@ -439,7 +439,7 @@ asm (
 /*
  * enters here only from a fault
  */
-int Cpatch(struct sigcontext_struct *scp)
+int Cpatch(struct sigcontext *scp)
 {
     unsigned char *p;
     int w16;

--- a/src/emu-i386/simx86/emu86.h
+++ b/src/emu-i386/simx86/emu86.h
@@ -659,7 +659,7 @@ int ModGetReg1(unsigned int PC, int mode);
 //
 char *e_emu_disasm(unsigned char *org, int is32, unsigned int refseg);
 char *e_print_regs(void);
-char *e_print_scp_regs(struct sigcontext_struct *scp, int pmode);
+char *e_print_scp_regs(struct sigcontext *scp, int pmode);
 const char *e_trace_fp(void);
 void GCPrint(unsigned char *cp, unsigned char *cbase, int len);
 char *showreg(signed char r);
@@ -675,7 +675,7 @@ int e_querymprotrange(unsigned int al, unsigned int ah);
 int e_markpage(unsigned int addr, size_t len);
 int e_querymark(unsigned int addr, size_t len);
 void e_resetpagemarks(unsigned int addr, size_t len);
-int e_handle_pagefault(struct sigcontext_struct *scp);
+int e_handle_pagefault(struct sigcontext *scp);
 void mprot_init(void);
 void mprot_end(void);
 void InvalidateSegs(void);
@@ -693,7 +693,7 @@ void init_emu_npu(void);
 
 unsigned e_VgaRead(unsigned char *ptr, int mode);
 void e_VgaWrite(unsigned char *ptr, unsigned u, int mode);
-void e_VgaMovs(struct sigcontext_struct *scp, char op, int w16, int dp);
-int e_vgaemu_fault(struct sigcontext_struct *scp, unsigned page_fault);
+void e_VgaMovs(struct sigcontext *scp, char op, int w16, int dp);
+int e_vgaemu_fault(struct sigcontext *scp, unsigned page_fault);
 
 #endif // _EMU86_EMU86_H

--- a/src/emu-i386/simx86/memory.c
+++ b/src/emu-i386/simx86/memory.c
@@ -308,7 +308,7 @@ int e_check_munprotect(unsigned int addr, size_t len)
 
 
 #ifdef HOST_ARCH_X86
-int e_handle_pagefault(struct sigcontext_struct *scp)
+int e_handle_pagefault(struct sigcontext *scp)
 {
 	int codehit;
 	register int v;

--- a/src/emu-i386/simx86/sigsegv.c
+++ b/src/emu-i386/simx86/sigsegv.c
@@ -85,7 +85,7 @@ void e_VgaWrite(unsigned char *a, unsigned u, int mode)
   vga_write_word(addr+2, u>>16);
 }
 
-void e_VgaMovs(struct sigcontext_struct *scp, char op, int w16, int dp)
+void e_VgaMovs(struct sigcontext *scp, char op, int w16, int dp)
 {
   unsigned int rep = (op&2? _ecx : 1);
 
@@ -191,7 +191,7 @@ static int jitx86_instr_len(const unsigned char *rip)
   return 0;
 }
 
-int e_vgaemu_fault(struct sigcontext_struct *scp, unsigned page_fault)
+int e_vgaemu_fault(struct sigcontext *scp, unsigned page_fault)
 {
   int i, j;
   unsigned vga_page = 0, u=0;
@@ -466,7 +466,7 @@ badrw:
 
 /* ======================================================================= */
 /*
- * DANG_BEGIN_FUNCTION dosemu_fault(int, struct sigcontext_struct);
+ * DANG_BEGIN_FUNCTION dosemu_fault(int, struct sigcontext);
  *
  * All CPU exceptions (except 13=general_protection from V86 mode,
  * which is directly scanned by the kernel) are handled here.
@@ -478,7 +478,7 @@ badrw:
 					Segments[(s) >> 3].base_addr)
 
 /* this function is called from dosemu_fault */
-int e_emu_fault(struct sigcontext_struct *scp)
+int e_emu_fault(struct sigcontext *scp)
 {
 #ifdef __x86_64__
   if (_trapno == 0x0e && _cr2 > 0xffffffff)

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -55,9 +55,6 @@ extern void e_priv_iopl(int);
 #define CONFIG_CPUSIM 1
 #endif
 
-#ifndef sigcontext_struct
-#define sigcontext_struct sigcontext
-#endif
 /* ----------------------------------------------------------------------- */
 
 /* Cpuemu status register - pack as much info as possible here, so to
@@ -85,7 +82,7 @@ void avltr_destroy(void);
 /* called from dpmi.c */
 void emu_mhp_SetTypebyte (unsigned short selector, int typebyte);
 unsigned short emu_do_LAR (unsigned short selector);
-char *e_scp_disasm(struct sigcontext_struct *scp, int pmode);
+char *e_scp_disasm(struct sigcontext *scp, int pmode);
 
 /* called from mfs.c, fatfs.c and some places that memcpy */
 #ifdef X86_EMULATOR
@@ -100,16 +97,16 @@ void init_emu_cpu (void);
 void reset_emu_cpu (void);
 
 /* called/used from dpmi.c */
-int e_dpmi(struct sigcontext_struct *scp);
-void e_dpmi_b0x(int op,struct sigcontext_struct *scp);
+int e_dpmi(struct sigcontext *scp);
+void e_dpmi_b0x(int op,struct sigcontext *scp);
 extern int in_dpmi_emu;
 
 /* called from sigsegv.c */
-int e_emu_fault(struct sigcontext_struct *scp);
+int e_emu_fault(struct sigcontext *scp);
 
 /* called from signal.c */
 #ifdef X86_EMULATOR
-int e_gen_sigalrm(struct sigcontext_struct *scp);
+int e_gen_sigalrm(struct sigcontext *scp);
 #else
 #define e_gen_sigalrm(x) 1
 #endif

--- a/src/include/cpu.h
+++ b/src/include/cpu.h
@@ -22,9 +22,6 @@
 #ifdef __linux__
 #define _regs vm86s.regs
 #endif
-#ifndef sigcontext_struct
-#define sigcontext_struct sigcontext
-#endif
 
 #include "extern.h"
 
@@ -421,13 +418,13 @@ EXTERN struct vec_t *ivecs;
 #define _cr2	(scp->cr2)
 
 void dosemu_fault(int, siginfo_t *, void *);
-int _dosemu_fault(int signal, struct sigcontext_struct *scp);
+int _dosemu_fault(int signal, struct sigcontext *scp);
 #endif
 
 void show_regs(char *, int), show_ints(int, int);
 char *emu_disasm(unsigned int ip);
 
-int cpu_trap_0f (unsigned char *, struct sigcontext_struct *);
+int cpu_trap_0f (unsigned char *, struct sigcontext *);
 
 extern unsigned int read_port_w(unsigned short port);
 extern int write_port_w(unsigned int value,unsigned short port);

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -451,10 +451,10 @@ extern void sig_ctx_restore(int tid);
 extern int sigchld_register_handler(pid_t pid, void (*handler)(void));
 extern int sigchld_enable_handler(pid_t pid, int on);
 extern void addset_signals_that_queue(sigset_t *x);
-extern void registersig(int sig, void (*handler)(struct sigcontext_struct *));
-extern void init_handler(struct sigcontext_struct *scp);
+extern void registersig(int sig, void (*handler)(struct sigcontext *));
+extern void init_handler(struct sigcontext *scp);
 #ifdef __x86_64__
-extern void deinit_handler(struct sigcontext_struct *scp);
+extern void deinit_handler(struct sigcontext *scp);
 extern int check_fix_fs_gs_base(unsigned char prefix);
 #else
 #define deinit_handler(scp)

--- a/src/include/vgaemu.h
+++ b/src/include/vgaemu.h
@@ -484,7 +484,7 @@ int VGA_emulate_outw(ioport_t, Bit16u);
 Bit8u VGA_emulate_inb(ioport_t);
 Bit16u VGA_emulate_inw(ioport_t);
 #ifdef __linux__
-int vga_emu_fault(struct sigcontext_struct *, int pmode);
+int vga_emu_fault(struct sigcontext *, int pmode);
 #define VGA_EMU_FAULT(scp,code,pmode) vga_emu_fault(scp,pmode)
 #endif
 int vga_emu_pre_init(void);
@@ -648,8 +648,8 @@ unsigned char Herc_get_mode_ctrl(void);
  */
 
 unsigned instr_len(unsigned char *, int);
-int instr_emu(struct sigcontext_struct *scp, int pmode, int cnt);
-int decode_modify_segreg_insn(struct sigcontext_struct *scp, int pmode,
+int instr_emu(struct sigcontext *scp, int pmode, int cnt);
+int decode_modify_segreg_insn(struct sigcontext *scp, int pmode,
     unsigned int *new_val);
 
 /*

--- a/src/plugin/console/vc.c
+++ b/src/plugin/console/vc.c
@@ -116,7 +116,7 @@ static void SIGACQUIRE_call(void *arg)
 int dos_has_vt = 1;
 
 static void
-acquire_vt (struct sigcontext_struct *scp)
+acquire_vt (struct sigcontext *scp)
 {
   dos_has_vt = 1;
 
@@ -252,7 +252,7 @@ static void wait_for_active_vc(void)
   } while (errno == EINTR);
 }
 
-static void release_vt (struct sigcontext_struct *scp)
+static void release_vt (struct sigcontext *scp)
 {
   dos_has_vt = 0;
 

--- a/src/plugin/term/terminal.c
+++ b/src/plugin/term/terminal.c
@@ -357,7 +357,7 @@ static int term_change_config(unsigned item, void *buf)
    return 100;
 }
 
-static void sigwinch(struct sigcontext_struct *scp)
+static void sigwinch(struct sigcontext *scp)
 {
   get_screen_size();
 }


### PR DESCRIPTION
Since kernel 2.1.1 the sigcontext structure has been named sigcontext. I
don't believe Dosemu2 will be built on anything earlier.