### PR TITLE
Add initial support for KVM.

### DIFF
--- a/src/base/async/int.c
+++ b/src/base/async/int.c
@@ -1480,8 +1480,6 @@ int can_revector(int i)
 #endif
   case 0x28:                    /* keyboard idle interrupt */
   case 0x2f:			/* needed for XMS, redirector, and idling */
-  case DOS_HELPER_INT:		/* e6 for redirector and helper (was 0xfe) */
-  case 0xe7:			/* for mfs FCB helper */
     return REVECT;
   /* following 3 vectors must be revectored for DPMI */
   case 0x1c:			/* ROM BIOS timer tick interrupt */
@@ -2285,8 +2283,8 @@ void setup_interrupts(void) {
   if (config.ipxsup)
     interrupt_function[0x7a][NO_REVECT] = ipx_int7a;
 #endif
-  interrupt_function[DOS_HELPER_INT][REVECT] = inte6;
-  interrupt_function[0xe7][REVECT] = inte7;
+  interrupt_function[DOS_HELPER_INT][NO_REVECT] = inte6;
+  interrupt_function[0xe7][NO_REVECT] = inte7;
 
   /* set up relocated video handler (interrupt 0x42) */
   if (config.dualmon == 2) {

--- a/src/base/bios/int10.c
+++ b/src/base/bios/int10.c
@@ -57,6 +57,7 @@
 #include "bios.h"
 #include "int.h"
 #include "speaker.h"
+#include "timers.h"
 #include "utilities.h"
 #include "vgaemu.h"
 #include "vgatext.h"
@@ -254,6 +255,8 @@ void tty_char_out(unsigned char ch, int s, int attr)
   unsigned dst;
 
 /* i10_deb("tty_char_out: char 0x%02x, page %d, attr 0x%02x\n", ch, s, attr); */
+
+  reset_idle(0);
 
   if (config.cardtype == CARD_NONE) {
      if (!config.quiet) putchar (ch);

--- a/src/base/init/lexer.l.in
+++ b/src/base/init/lexer.l.in
@@ -414,6 +414,7 @@ vm86			RETURN(VM86);
 full			RETURN(FULL);
 vm86sim			RETURN(VM86SIM);
 fullsim			RETURN(FULLSIM);
+kvm			RETURN(KVM);
 
 	/* disk keywords */
 hdimage			RETURN(HDIMAGE);

--- a/src/base/init/parser.y.in
+++ b/src/base/init/parser.y.in
@@ -251,7 +251,7 @@ while (0)
 	/* speaker */
 %token EMULATED NATIVE
 	/* cpuemu */
-%token CPUEMU VM86 FULL VM86SIM FULLSIM
+%token CPUEMU VM86 FULL VM86SIM FULLSIM KVM
 	/* keyboard */
 %token RAWKEYBOARD
 %token PRESTROKE
@@ -477,6 +477,7 @@ line		: HOGTHRESH expression	{ config.hogthreshold = $2; }
 #endif
 			}
 			c_printf("CONF: %s CPUEMU set to %d for %d86\n",
+				config.cpuemu > 4 ? "KVM" : 
 				CONFIG_CPUSIM ? "simulated" : "JIT",
 				config.cpuemu, (int)vm86s.cpu_type);
 #endif
@@ -1703,6 +1704,7 @@ cpuemu		: L_OFF		{ $$ = 0; }
 		| FULL		{ $$ = 4; }
 		| VM86SIM	{ $$ = 5; }
 		| FULLSIM	{ $$ = 6; }
+		| KVM		{ $$ = 7; }
 		| STRING        { yyerror("got '%s', expected 'off', 'vm86' or 'full'", $1);
 				  free($1); }
 		| error         { yyerror("expected 'off', 'vm86' or 'full'"); }

--- a/src/base/video/text.c
+++ b/src/base/video/text.c
@@ -44,6 +44,7 @@
 #include "vgatext.h"
 #include "render_priv.h"
 #include "translate.h"
+#include "timers.h"
 
 static struct text_system * Text = NULL;
 int use_bitmap_font;
@@ -685,6 +686,7 @@ int update_text_screen(void)
                 /* ok, we've got the string now send it to the X server */
 
                 draw_string(start_x, y, charbuff, len, attr);
+                if (len > 0) reset_idle(0);
 
 		if ((prev_cursor_location >= start_off) &&
 		    (prev_cursor_location < start_off + len*2))

--- a/src/emu-i386/Makefile
+++ b/src/emu-i386/Makefile
@@ -2,7 +2,7 @@
 top_builddir=../..
 include $(top_builddir)/Makefile.conf
 
-CFILES=cpu.c ports.c do_vm86.c cputime.c
+CFILES=cpu.c ports.c do_vm86.c cputime.c kvm.c
 
 
 SFILES=

--- a/src/emu-i386/do_vm86.c
+++ b/src/emu-i386/do_vm86.c
@@ -317,6 +317,8 @@ static int true_vm86(struct vm86_struct *x)
 
 static int do_vm86(struct vm86_struct *x)
 {
+    if (config.cpuemu == 5)
+	return kvm_vm86();
 #ifdef __i386__
 #ifdef X86_EMULATOR
     if (config.cpuemu)

--- a/src/emu-i386/kvm.c
+++ b/src/emu-i386/kvm.c
@@ -1,0 +1,321 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+/*
+ *  Emulate vm86() using KVM
+ *  Started 2015, Bart Oldeman
+ *  References: http://lwn.net/Articles/658511/
+ *  plus example at http://lwn.net/Articles/658512/
+ */
+
+#include "config.h"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+#include <linux/kvm.h>
+
+#include "emu.h"
+#include "cpu.h"
+#include "dpmi.h"
+#include "port.h"
+
+static int vcpufd = -1;
+static struct kvm_run *run = NULL;
+static struct kvm_sregs sregs;
+
+/* Initialize KVM and memory mappings */
+static void kvm_init(void)
+{
+  struct kvm_userspace_memory_region region = {
+    .slot = 0,
+    .guest_phys_addr = 0x0,
+    .memory_size = LOWMEM_SIZE + HMASIZE,
+    .userspace_addr = (uint64_t)(unsigned long)mem_base,
+  };
+  int kvm, vmfd, ret, mmap_size;
+
+  kvm = open("/dev/kvm", O_RDWR | O_CLOEXEC);
+  if (kvm == -1) {
+    perror("KVM: error opening /dev/kvm");
+    leavedos(99);
+  }
+
+  vmfd = ioctl(kvm, KVM_CREATE_VM, (unsigned long)0);
+  if (vmfd == -1) {
+    perror("KVM: KVM_CREATE_VM");
+    leavedos(99);
+  }
+
+  /* Map guest memory: only conventional memory + HMA for now */
+  ret = ioctl(vmfd, KVM_SET_USER_MEMORY_REGION, &region);
+  if (ret == -1) {
+    perror("KVM: KVM_SET_USER_MEMORY_REGION");
+    leavedos(99);
+  }
+
+  vcpufd = ioctl(vmfd, KVM_CREATE_VCPU, (unsigned long)0);
+  if (vmfd == -1) {
+    perror("KVM: KVM_CREATE_VCPU");
+    leavedos(99);
+  }
+
+  mmap_size = ioctl(kvm, KVM_GET_VCPU_MMAP_SIZE, NULL);
+  if (mmap_size == -1) {
+    perror("KVM: KVM_GET_VCPU_MMAP_SIZE");
+    leavedos(99);
+  }
+  if (mmap_size < sizeof(*run)) {
+    fprintf(stderr, "KVM: KVM_GET_VCPU_MMAP_SIZE unexpectedly small\n");
+    leavedos(99);
+  }
+  run = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED, vcpufd, 0);
+  if (run == MAP_FAILED) {
+    perror("KVM: mmap vcpu");
+    leavedos(99);
+  }
+
+  ret = ioctl(vcpufd, KVM_GET_SREGS, &sregs);
+  if (ret == -1) {
+    perror("KVM: KVM_GET_SREGS");
+    leavedos(99);
+  }
+}
+
+/* Emulate vm86() using KVM
+   Note: KVM traps much less than vm86.
+   - VM86_SIGNAL comes from exiting with -1 and errno==EINTR
+     we also exit with VM86_SIGNAL with IN/OUT instructions because KVM
+     has already decoded them.
+   - VM86_UNKNOWN only happens through the HLT instruction
+   - VM86_INTx never happens: interrupts are handled using the IVT
+     Revectored ints (as in src/base/async/int.c) do not work.
+   - VM86_STI never happens; we need to use IF, not VIF;
+     and VIP is not listened too (TODO: inject IRQs into KVM)
+*/
+int kvm_vm86(void)
+{
+  static struct kvm_regs regs;
+  unsigned int newflags;
+  int ret, vm86_ret;
+
+  if (vcpufd == -1) {
+    kvm_init();
+  }
+  newflags = vm86s.regs.eflags | 0x2;
+  if (isset_IF())
+    newflags |= IF;
+  else
+    newflags &= ~IF;
+  /* avoid syscalls if DOSEMU did not modify the CPU state */
+  if (vcpufd == -1 ||
+      regs.rip != vm86s.regs.eip ||
+      regs.rax != vm86s.regs.eax ||
+      regs.rbx != vm86s.regs.ebx ||
+      regs.rcx != vm86s.regs.ecx ||
+      regs.rdx != vm86s.regs.edx ||
+      regs.rsi != vm86s.regs.esi ||
+      regs.rdi != vm86s.regs.edi ||
+      regs.rbp != vm86s.regs.ebp ||
+      regs.rsp != vm86s.regs.esp ||
+      regs.rflags != newflags) {
+    regs.rip = vm86s.regs.eip;
+    regs.rax = vm86s.regs.eax;
+    regs.rbx = vm86s.regs.ebx;
+    regs.rcx = vm86s.regs.ecx;
+    regs.rdx = vm86s.regs.edx;
+    regs.rsi = vm86s.regs.esi;
+    regs.rdi = vm86s.regs.edi;
+    regs.rbp = vm86s.regs.ebp;
+    regs.rsp = vm86s.regs.esp;
+    regs.rflags = newflags;
+    ret = ioctl(vcpufd, KVM_SET_REGS, &regs);
+    if (ret == -1) {
+      perror("KVM: KVM_SET_REGS");
+      leavedos(99);
+    }
+  }
+  if (sregs.cs.selector != vm86s.regs.cs ||
+      sregs.ds.selector != vm86s.regs.ds ||
+      sregs.es.selector != vm86s.regs.es ||
+      sregs.fs.selector != vm86s.regs.fs ||
+      sregs.gs.selector != vm86s.regs.gs ||
+      sregs.ss.selector != vm86s.regs.ss) {
+    sregs.cs.base = vm86s.regs.cs << 4;
+    sregs.cs.selector = vm86s.regs.cs;
+    sregs.ds.base = vm86s.regs.ds << 4;
+    sregs.ds.selector = vm86s.regs.ds;
+    sregs.es.base = vm86s.regs.es << 4;
+    sregs.es.selector = vm86s.regs.es;
+    sregs.fs.base = vm86s.regs.fs << 4;
+    sregs.fs.selector = vm86s.regs.fs;
+    sregs.gs.base = vm86s.regs.gs << 4;
+    sregs.gs.selector = vm86s.regs.gs;
+    sregs.ss.base = vm86s.regs.ss << 4;
+    sregs.ss.selector = vm86s.regs.ss;
+    ret = ioctl(vcpufd, KVM_SET_SREGS, &sregs);
+    if (ret == -1) {
+      perror("KVM: KVM_SET_SREGS");
+      leavedos(99);
+    }
+  }
+  ret = ioctl(vcpufd, KVM_RUN, NULL);
+  if (ret == -1 && errno != EINTR) {
+    perror("KVM: KVM_RUN");
+    leavedos(99);
+  }
+  vm86_ret = VM86_SIGNAL;
+  if (ret == 0) {
+    switch (run->exit_reason) {
+    case KVM_EXIT_HLT:
+      vm86_ret = VM86_UNKNOWN;
+      break;
+    case KVM_EXIT_IO:
+    {
+      /* handle IO here to avoid decoding in vm86_GP_fault,
+	 then return to DOSEMU using VM86_SIGNAL.
+       */
+      union data {
+	Bit8u b[sizeof(*run)];
+	Bit16u w[sizeof(*run)/2];
+	Bit32u d[sizeof(*run)/4];
+      } *data = (union data *)((Bit8u *)run + run->io.data_offset);
+      switch(run->io.direction) {
+      case KVM_EXIT_IO_IN:
+	if (run->io.count == 1) {
+	  switch(run->io.size) {
+	  case 1:
+	    data->b[0] = inb(run->io.port);
+	    break;
+	  case 2:
+	    data->w[0] = inw(run->io.port);
+	    break;
+	  case 4:
+	    data->d[0] = ind(run->io.port);
+	    break;
+	  default:
+	    goto kvm_io_error;
+	  }
+	  break;
+	}
+	switch(run->io.size) {
+	case 1:
+	  port_rep_inb(run->io.port, data->b, 1, run->io.count);
+	  break;
+	case 2:
+	  port_rep_inw(run->io.port, data->w, 1, run->io.count);
+	  break;
+	case 4:
+	  port_rep_ind(run->io.port, data->d, 1, run->io.count);
+	  break;
+	default:
+	  goto kvm_io_error;
+	}
+	break;
+      case KVM_EXIT_IO_OUT:
+	if (run->io.count == 1) {
+	  switch(run->io.size) {
+	  case 1:
+	    outb(run->io.port, data->b[0]);
+	    break;
+	  case 2:
+	    outw(run->io.port, data->w[0]);
+	    break;
+	  case 4:
+	    outd(run->io.port, data->d[0]);
+	    break;
+	  default:
+	    goto kvm_io_error;
+	  }
+	  break;
+	}
+	switch(run->io.size) {
+	case 1:
+	  port_rep_outb(run->io.port, data->b, 1, run->io.count);
+	  break;
+	case 2:
+	  port_rep_outw(run->io.port, data->w, 1, run->io.count);
+	  break;
+	case 4:
+	  port_rep_outd(run->io.port, data->d, 1, run->io.count);
+	  break;
+	default:
+	  goto kvm_io_error;
+	}
+	break;
+      default:
+      kvm_io_error:
+	fprintf(stderr, "KVM: unknown situation for KVM_EXIT_IO\n");
+	leavedos(99);
+      }
+      break;
+    }
+    case KVM_EXIT_FAIL_ENTRY:
+      fprintf(stderr,
+	      "KVM_EXIT_FAIL_ENTRY: hardware_entry_failure_reason = 0x%llx\n",
+	      (unsigned long long)run->fail_entry.hardware_entry_failure_reason);
+      leavedos(99);
+    case KVM_EXIT_INTERNAL_ERROR:
+      fprintf(stderr,
+	      "KVM_EXIT_INTERNAL_ERROR: suberror = 0x%x\n", run->internal.suberror);
+      leavedos(99);
+    case KVM_EXIT_INTR:
+      fprintf(stderr, "KVM_EXIT_INTR");
+      leavedos(99);
+    default:
+      fprintf(stderr, "KVM: exit_reason = 0x%x\n", run->exit_reason);
+      leavedos(99);
+    }
+  }
+
+  ret = ioctl(vcpufd, KVM_GET_REGS, &regs);
+  if (ret == -1) {
+    perror("KVM: KVM_GET_REGS");
+    leavedos(99);
+  }
+  vm86s.regs.eax = regs.rax;
+  vm86s.regs.ebx = regs.rbx;
+  vm86s.regs.ecx = regs.rcx;
+  vm86s.regs.edx = regs.rdx;
+  vm86s.regs.esi = regs.rsi;
+  vm86s.regs.edi = regs.rdi;
+  vm86s.regs.ebp = regs.rbp;
+  vm86s.regs.esp = regs.rsp;
+  vm86s.regs.eflags = regs.rflags;
+  if (regs.rflags & IF)
+    set_IF();
+  else
+    clear_IF();
+  vm86s.regs.eip = regs.rip;
+  /* KVM skips over the HLT instruction but vm86 stays there */
+  if (vm86_ret == VM86_UNKNOWN) vm86s.regs.eip--;
+  ret = ioctl(vcpufd, KVM_GET_SREGS, &sregs);
+  if (ret == -1) {
+    perror("KVM: KVM_GET_REGS");
+    leavedos(99);
+  }
+  vm86s.regs.cs = sregs.cs.selector;
+  vm86s.regs.ds = sregs.ds.selector;
+  vm86s.regs.es = sregs.es.selector;
+  vm86s.regs.fs = sregs.fs.selector;
+  vm86s.regs.gs = sregs.gs.selector;
+  vm86s.regs.ss = sregs.ss.selector;
+  return vm86_ret;
+}

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -46,6 +46,7 @@ struct eflags_fs_gs {
 extern struct eflags_fs_gs eflags_fs_gs;
 
 int vm86_init(void);
+int kvm_vm86(void);
 #ifdef __i386__
 #define vm86(param) syscall(SYS_vm86old, param)
 #define vm86_plus(function,param) syscall(SYS_vm86, function, param)


### PR DESCRIPTION
This is sufficient to boot DOS with $_cpu_emu=(0) and $_hogthreshold=(0),
but without redirector support. The main issue is that INTs are not
trapped so we can only have HLT and I/O traps.

I have only tested this so far in basic vm86 text mode, no DPMI or graphics,
but it's promising because the speed is comparable to vm86() syscall speed,
and vm86() seems to be on life support these days.