### PR TITLE
Builtins - old DOS get program name from the env

### DIFF
--- a/src/plugin/commands/builtins.c
+++ b/src/plugin/commands/builtins.c
@@ -414,11 +414,24 @@ int commands_plugin_inte6(void)
 	args[0] = strdup(com_getarg0());
 	strupperDOS(args[0]);
 	argc = com_argparse((char *)&psp->cmdline_len, &args[1], MAX_ARGS - 1) + 1;
+
+	/* DOS 4 and up */
 	strncpy(builtin_name, mcb->name, sizeof(builtin_name) - 1);
 	builtin_name[sizeof(builtin_name) - 1] = 0;
 	strupperDOS(builtin_name);
-
 	com = find_com_program(builtin_name);
+
+	/* DOS 3.0->3.31 construct the program name from the environment */
+	if(!com) {
+		char *p = strrchr(args[0],'\\');
+		strncpy(builtin_name, p+1, sizeof(builtin_name) - 1);
+		builtin_name[sizeof(builtin_name) - 1] = 0;
+		p = strchr(builtin_name, '.');
+		if(p)
+			*p = '\0';
+		com = find_com_program(builtin_name);
+	}
+
 	if (com) {
 		int err = com->program(argc, args);
 		if (!err) {


### PR DESCRIPTION
Older DOS version (3.0 -> 3.31) don't have a name field in MCB. The info
is available immediately following the environment strings. So if we
don't find the program using mcb->name then try again by constructing
one from argv[0] which was derived from the environment block. This allows
the Dosemu builtins to function on older DOSes. Potentially something
similar could be used to update the window title in X.