### PR TITLE
MS-DOS 3.3 fatfs boot patches

### DIFF
--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -125,23 +125,23 @@ void fatfs_init(struct disk *dp)
   if (dp->floppy) {
     switch (dp->default_cmos) {
       case THREE_INCH_288MFLOP:
-        f->fat_id = 0xf0;
+        f->media_id = 0xf0;
         f->cluster_secs = 2;
         break;
       case THREE_INCH_FLOPPY:
-        f->fat_id = 0xf0;
+        f->media_id = 0xf0;
         f->cluster_secs = 1;
         break;
       case FIVE_INCH_FLOPPY:
-        f->fat_id = 0xf9;
+        f->media_id = 0xf9;
         f->cluster_secs = 1;
         break;
       case THREE_INCH_720KFLOP:
-        f->fat_id = 0xf9;
+        f->media_id = 0xf9;
         f->cluster_secs = 2;
         break;
       case FIVE_INCH_360KFLOP:
-        f->fat_id = 0xfd;
+        f->media_id = 0xfd;
         f->cluster_secs = 2;
         break;
     }
@@ -150,14 +150,14 @@ void fatfs_init(struct disk *dp)
     f->root_secs = 14;
   } else if (dp->part_info.type == 1) {
     fatfs_msg("Using FAT12, sectors count=%li\n", dp->part_info.num_secs);
-    f->fat_id = 0xf8;
+    f->media_id = 0xf8;
     f->cluster_secs = 8;
     f->fat_type = FAT_TYPE_FAT12;
     f->total_secs = dp->part_info.num_secs;
     f->root_secs = 32;
   } else {
     unsigned u;
-    f->fat_id = 0xf8;
+    f->media_id = 0xf8;
     f->fat_type = FAT_TYPE_FAT16;
     f->total_secs = dp->part_info.num_secs;
     f->root_secs = 32;
@@ -393,7 +393,7 @@ static void set_geometry(fatfs_t *f, unsigned char *b)
   else {
     b[0x13] = b[0x14] = 0x00;
   }
-  b[0x15] = f->fat_id;
+  b[0x15] = f->media_id;
   b[0x16] = f->fat_secs;
   b[0x17] = f->fat_secs >> 8;
   b[0x18] = f->secs_track;
@@ -1249,7 +1249,7 @@ unsigned next_cluster(fatfs_t *f, unsigned clu)
 
   if(clu < 2) {
     u = 0xffff;
-    if(clu == 0) *(unsigned char *) &u = f->fat_id;
+    if(clu == 0) *(unsigned char *) &u = f->media_id;
     return u;
   }
 
@@ -1431,7 +1431,7 @@ void build_boot_blk(fatfs_t *f, unsigned char *b)
       d0[0x05] = d_o >> 24;
       d0[0x06] = d_o;		/* bx */
       d0[0x07] = d_o >> 8;
-      d0[0x09] = f->fat_id;	/* ch */
+      d0[0x09] = f->media_id;	/* ch */
       d0[0x0a] = f->drive_num;	/* dl */
 
       fatfs_msg("made boot block suitable for MS-DOS, version < 7\n");

--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -147,22 +147,27 @@ void fatfs_init(struct disk *dp)
     }
     f->fat_type = FAT_TYPE_FAT12;
     f->total_secs = dp->tracks * dp->heads * dp->sectors;
+    f->root_secs = 14;
   } else if (dp->part_info.type == 1) {
     fatfs_msg("Using FAT12, sectors count=%li\n", dp->part_info.num_secs);
-    f->fat_id = 0xf0;
+    f->fat_id = 0xf8;
     f->cluster_secs = 8;
     f->fat_type = FAT_TYPE_FAT12;
     f->total_secs = dp->part_info.num_secs;
+    f->root_secs = 32;
   } else {
     unsigned u;
     f->fat_id = 0xf8;
     f->fat_type = FAT_TYPE_FAT16;
     f->total_secs = dp->part_info.num_secs;
+    f->root_secs = 32;
     for (u = 4; u <= 512; u <<= 1) {
       if (u * 0xfff0u > f->total_secs)
         break;
     }
     f->cluster_secs = u;
+    fatfs_msg("Using FAT16, sectors count=%i & cluster_size=%d\n",
+		    f->total_secs, f->cluster_secs);
   }
   f->serial = dp->serial;
   f->secs_track = dp->sectors;
@@ -173,10 +178,8 @@ void fatfs_init(struct disk *dp)
   f->fats = 2;
   if (f->fat_type == FAT_TYPE_FAT12) {
     f->fat_secs = ((f->total_secs / f->cluster_secs + 2) * 3 + 0x3ff) >> 10;
-    f->root_secs = 14;
   } else {
     f->fat_secs = ((f->total_secs / f->cluster_secs + 2) * 2 + 0x1ff) >> 9;
-    f->root_secs = 32;
   }
   f->root_entries = f->root_secs << 4;
   f->last_cluster = (f->total_secs - f->reserved_secs - f->fats * f->fat_secs

--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -535,6 +535,29 @@ enum { IO_IDX, MSD_IDX, DRB_IDX, DRD_IDX,
 #define NEWMSD_D (MS_D | (1 << 26))
 #define OLDMSD_D (MS_D | (1 << 27))
 
+static char *system_type(unsigned int t) {
+    switch(t) {
+    case MS_D:
+        return "Unknown MS-DOS";
+    case PC_D:
+        return "Unknown PC-DOS";
+    case DR_D:
+        return "DR-DOS";
+/*  case DRO_D:
+	return "Old DR-DOS"; // Duplicate case to PC_D at the moment
+*/
+    case REALPCD_D:
+        return "New PC-DOS (>= v4.0)";
+    case OLDPCD_D:
+        return "Old PC-DOS (< v4.0)";
+    case NEWMSD_D:
+        return "New MS-DOS (>= v4.0)";
+    case OLDMSD_D:
+        return "Old MS-DOS (< v4.0)";
+    }
+
+    return "Unknown System Type";
+}
 
 struct fs_prio sfiles[] = {
     [IO_IDX]   = { "IO.SYS",		1, 0 },
@@ -861,7 +884,8 @@ void scan_dir(fatfs_t *f, unsigned oi)
       try_add_fdos(f, oi);
     else
       f->sys_type = sys_type;
-    fatfs_msg("system type is 0x%x\n", f->sys_type);
+    fatfs_msg("system type is \"%s\" (0x%x)\n",
+              system_type(f->sys_type), f->sys_type);
   }
 
   for (i = 0; i < num; i++) {

--- a/src/base/misc/fatfs.h
+++ b/src/base/misc/fatfs.h
@@ -43,7 +43,7 @@ typedef struct {
   unsigned serial;
   char label[12];
   unsigned char fat_type;
-  unsigned char fat_id;
+  unsigned char media_id;
   unsigned fat_secs;
   unsigned fats;
   unsigned root_secs;


### PR DESCRIPTION
This series of patches [fixes #49] allow MS-DOS 3.3 to boot on both FAT12 and FAT16 filesystems generated by hdimage directory. For them to be operational the missing part is that somehow the filesystem size must be constrained to be recognisable by MS-DOS 3.3. For testing I patched disks.c
as follows:

For FAT16
```C
diff --git a/src/base/misc/disks.c b/src/base/misc/disks.c
index ef0baa2..1961b10 100644
--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -512,9 +512,9 @@ void dir_auto(struct disk *dp)
    * We emulate an entire disk with 1 partition starting at t/h/s 0/1/1.
    * You are free to change the geometry (e.g. to change the partition size).
    */
-    dp->sectors = 63;
-    dp->heads = 255;
-    dp->tracks = 255;
+    dp->sectors = 17;
+    dp->heads = 4;
+    dp->tracks = 605;
     dp->start = dp->sectors;
   }
```

For FAT12
```C
diff --git a/src/base/misc/disks.c b/src/base/misc/disks.c
index ef0baa2..1961b10 100644
--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -512,9 +512,9 @@ void dir_auto(struct disk *dp)
    * We emulate an entire disk with 1 partition starting at t/h/s 0/1/1.
    * You are free to change the geometry (e.g. to change the partition size).
    */
-    dp->sectors = 63;
-    dp->heads = 255;
-    dp->tracks = 255;
+    dp->sectors = 17;
+    dp->heads = 4;
+    dp->tracks = 306;
     dp->start = dp->sectors;
   }
```

Without the disk size constraint, MS-DOS 3.3 will not boot. A proper config option or other solution for the selection of a smaller disk for these cases should be created.

Tested with MS-DOS 3.3 | result
-------------------------- | ----
FAT12 with boot.blk | OK
FAT12 without boot.blk | OK
FAT16 with boot.blk |OK
FAT16 without boot.blk | OK

Tested with PC-DOS 3.3 | result
-------------------------- | ----
FAT12 without boot.blk | OK
FAT16 without boot.blk | OK
