### PR TITLE
disks: Allow the user to force disk type at runtime

### DIFF
--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -76,6 +76,15 @@
 # If the name begins with '/dev/', then wholedisk or partition access is
 # done instead of a virtual hdimage such as "/dev/hda", "/dev/hda1" or
 # "/dev/hda1:ro" for readonly
+#
+# For older versions of MS-DOS and PC-DOS you may want to limit the size of
+# any directory mode virtual disks that are presented as if they are too large
+# or have non-standard geometry the OS may fail to recognise them.
+# This option is useful for forcing FAT12 or FAT16 as opposed to Dosemu's
+# normal FAT16B formatting.
+# /path/to/dir:hdtype1 - creates 10mb IBM type1 disk with C/H/S of 306/4/17
+# /path/to/dir:hdtype2 - creates 21mb IBM type2 disk with C/H/S of 615/4/17
+#
 # Currently mounted devices and swap are refused. Hdimages and devices may
 # be mixed such as "hdimage_c /dev/hda1 /dev/hda3:ro". Default: "drives/*"
 

--- a/etc/global.conf
+++ b/etc/global.conf
@@ -633,8 +633,12 @@ else
         $yyy = $yyy, " }";
         $$yyy;
       else
-        $yyy = strdel($xxx, strstr($xxx, ":ro"), 999);
+        $yyy2 = strdel($xxx, strstr($xxx, ":ro"), 999);
+        $yyy1 = strdel($yyy2, strstr($xxx, ":hdtype1"), 999);
+        $yyy = strdel($yyy1, strstr($xxx, ":hdtype2"), 999);
         $zzz = strsplit($xxx, strstr($xxx, ":ro"), 999);
+        $uuu = strsplit($xxx, strstr($xxx, ":hdtype1"), 999);
+        $vvv = strsplit($xxx, strstr($xxx, ":hdtype2"), 999);
         if (strchr($yyy, "/") != 0)
           $yyyy = $HOME, "/.dosemu/", $yyy
           shell("test -e '", $yyyy, "'")
@@ -651,9 +655,13 @@ else
         if (!$DOSEMU_SHELL_RETURN)
           if (strlen($zzz))
             disk { directory $yyy readonly };
+          else if (strlen($uuu))
+            disk { directory $yyy hdtype1 };
+          else if (strlen($vvv))
+            disk { directory $yyy hdtype2 };
           else
             disk { directory $yyy };
-          endif
+          endif endif endif
         else
           disk { image $yyy }
         endif

--- a/src/base/init/lexer.l.in
+++ b/src/base/init/lexer.l.in
@@ -438,6 +438,8 @@ offset			RETURN(OFFSET);
 floppy			RETURN(L_FLOPPY);
 cdrom			RETURN(CDROM);
 diskcyl4096		RETURN(DISKCYL4096);
+hdtype1			RETURN(HDTYPE1);
+hdtype2			RETURN(HDTYPE2);
 
 	/* keyboard */
 

--- a/src/base/init/parser.y.in
+++ b/src/base/init/parser.y.in
@@ -291,7 +291,7 @@ while (0)
 %token LPT COMMAND TIMEOUT L_FILE
 	/* disk */
 %token L_PARTITION BOOTFILE WHOLEDISK THREEINCH THREEINCH_720 THREEINCH_2880 FIVEINCH FIVEINCH_360 ATAPI READONLY LAYOUT
-%token SECTORS CYLINDERS TRACKS HEADS OFFSET HDIMAGE DISKCYL4096
+%token SECTORS CYLINDERS TRACKS HEADS OFFSET HDIMAGE HDTYPE1 HDTYPE2 DISKCYL4096
 	/* ports/io */
 %token RDONLY WRONLY RDWR ORMASK ANDMASK RANGE FAST SLOW
 	/* Silly interrupts */
@@ -1428,12 +1428,14 @@ disk_flags	: disk_flag
 		;
 disk_flag	: READONLY		{ dptr->wantrdonly = 1; }
 		| THREEINCH	{ dptr->default_cmos = THREE_INCH_FLOPPY; }
-		| THREEINCH_2880	{ dptr->default_cmos = THREE_INCH_288MFLOP; }		
-		| THREEINCH_720	{ dptr->default_cmos = THREE_INCH_720KFLOP; }		
+		| THREEINCH_2880	{ dptr->default_cmos = THREE_INCH_288MFLOP; }
+		| THREEINCH_720	{ dptr->default_cmos = THREE_INCH_720KFLOP; }
 		| ATAPI		{ dptr->default_cmos = ATAPI_FLOPPY; }
 		| FIVEINCH	{ dptr->default_cmos = FIVE_INCH_FLOPPY; }
 		| FIVEINCH_360	{ dptr->default_cmos = FIVE_INCH_360KFLOP; }
 		| DISKCYL4096	{ dptr->diskcyl4096 = 1; }
+		| HDTYPE1	{ dptr->hdtype = 1; }
+		| HDTYPE2	{ dptr->hdtype = 2; }
 		| SECTORS expression	{ dptr->sectors = $2; }
 		| CYLINDERS expression	{ dptr->tracks = $2; }
 		| TRACKS expression	{ dptr->tracks = $2; }
@@ -1971,9 +1973,9 @@ static void start_bootdisk(void)
 {
   if (config.bootdisk)           /* Already a bootdisk configured ? */
     yyerror("There is already a bootdisk configured");
-      
+
   dptr = &bootdisk;              /* set pointer do bootdisk-struct */
-      
+
   dptr->diskcyl4096 = 0;
   dptr->sectors = 0;             /* setup default-values           */
   dptr->heads   = 0;
@@ -2018,11 +2020,12 @@ static void start_disk(void)
     }
   else
     dptr = &hdisktab[c_hdisks];
-      
+
   dptr->type    =  NODISK;
   dptr->sectors = -1;
   dptr->heads   = -1;
   dptr->tracks  = -1;
+  dptr->hdtype = 0;
   dptr->timeout = 0;
   dptr->dev_name = NULL;              /* default-values */
   dptr->boot_name = NULL;
@@ -2046,7 +2049,7 @@ static void start_vnet(char *mode) {
   else {
     error("Unknown vnet mode \"%s\"\n", mode);
     config.exitearly = 1;
-  } 
+  }
 }
 
 static void do_part(char *dev)
@@ -2058,9 +2061,9 @@ static void do_part(char *dev)
 #ifdef __linux__
   dptr->part_info.number = atoi(dptr->dev_name+8);
 #endif
-  if (dptr->part_info.number == 0) 
+  if (dptr->part_info.number == 0)
     yyerror("%s must be a PARTITION, can't find number suffix!\n",
-   	    dptr->dev_name);
+	    dptr->dev_name);
 }
 
 static void stop_disk(int token)

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -512,9 +512,29 @@ void dir_auto(struct disk *dp)
    * We emulate an entire disk with 1 partition starting at t/h/s 0/1/1.
    * You are free to change the geometry (e.g. to change the partition size).
    */
-    dp->sectors = 63;
-    dp->heads = 255;
-    dp->tracks = 255;
+    switch (dp->hdtype) {
+      case 0:
+        dp->tracks = 255;
+        dp->heads = 255;
+        dp->sectors = 63;
+        break;
+      case 1:
+        dp->tracks = 306;
+        dp->heads = 4;
+        dp->sectors = 17;
+        d_printf("DISK: Forcing IBM disk type 1\n");
+        break;
+      case 2:
+        dp->tracks = 615;
+        dp->heads = 4;
+        dp->sectors = 17;
+        d_printf("DISK: Forcing IBM disk type 2\n");
+        break;
+      default:
+        d_printf("DISK: Invalid disk type (%d)\n", dp->hdtype);
+        config.exitearly = 1;
+        break;
+    }
     dp->start = dp->sectors;
   }
 

--- a/src/include/disks.h
+++ b/src/include/disks.h
@@ -54,6 +54,7 @@ struct disk {
   int sectors, heads, tracks;	/* geometry */
   unsigned long start;		/* geometry */
   unsigned long long num_secs;	/* total sectors on disk */
+  int hdtype;			/* 0 none, 1 IBM type1, 2 IBM type2 */
   int default_cmos;		/* default CMOS floppy type */
   int drive_num;
   unsigned long serial;		/* serial number */


### PR DESCRIPTION
This patch adds a config option that allows the user to choose a predetermined
disk type at runtime for hdimage that create a fatfs filesystem from a
directory. This is useful with older versions of DOS e.g. those before v4.0
that did not support large disks or FAT16B filesystems. The disk geometry
chosen is that used by the early IBM BIOS. This page details the types
available:
http://webpages.charter.net/danrollins/techhelp/0054.HTM

A new dosemu.conf variable '$_hdtype' is added with the default being
the current behaviour with keyword of "none", and the following types are
supported from that list
$_hdtype = "type1" # creates 10mb IBM type1 disks with C/H/S of 306/4/17
$_hdtype = "type2" # creates 21mb IBM type2 disks with C/H/S of 615/4/17