### PR TITLE
Kvm vm86

### DIFF
--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -40,6 +40,14 @@
 
 # $_cpu_emu = "off"
 
+# Select cpu virtualization mode.
+# "vm86" - use v86 mode via vm86() syscall. Only available on x86-32.
+# "kvm" - use KVM, hardware-assisted in-kernel virtual machine.
+# "emulated" - use CPU emulator
+# "auto" - select whatever works
+
+# $_cpu_vm = "auto"
+
 # if possible use Pentium cycle counter for timing. Default: off
 
 # $_rdtsc = (off)

--- a/etc/global.conf
+++ b/etc/global.conf
@@ -149,7 +149,7 @@ else
     checkuservar $_debug, $_trace_ports,
       $_features, $_mapping, $_hogthreshold, $_cli_timeout,
       $_timemode,
-      $_mathco, $_cpu, $_cpu_emu, $_rdtsc, $_cpuspeed, $_xms, $_ems,
+      $_mathco, $_cpu, $_cpu_vm, $_cpu_emu, $_rdtsc, $_cpuspeed, $_xms, $_ems,
       $_ems_frame, $_ems_uma_pages, $_ems_conv_pages,
       $_ext_mem, $_dpmi, $_dpmi_base, $_ignore_djgpp_null_derefs, $_emusys,
       $_emuini, $_dosmem, $_full_file_locks, $_lfn_support
@@ -219,6 +219,8 @@ else
   else
     cpuemu off
   endif
+  $xxx = "cpu_vm ", $_cpu_vm;
+  $$xxx
   $_pm_dos_api = $_ems;		# disabling EMS disables also the translator
   if ($_ems || ($_dpmi && $_pm_dos_api))
     ems {

--- a/src/arch/linux/async/signal.c
+++ b/src/arch/linux/async/signal.c
@@ -174,6 +174,7 @@ static void __init_handler(struct sigcontext *scp, int async)
 	  fprintf(stderr, "for unknown reasons.\nPlease contact linux-msdos@vger.kernel.org.\n");
 	fprintf(stderr, "Set $_cpu_emu=\"full\" or \"fullsim\" to avoid this message.\n");
       }
+      config.cpu_vm = CPUVM_EMU;
       config.cpuemu = 4;
       _cs = getsegment(cs);
   }
@@ -182,7 +183,7 @@ static void __init_handler(struct sigcontext *scp, int async)
   if (in_vm86) {
 #ifdef __i386__
 #ifdef X86_EMULATOR
-    if (!config.cpuemu)
+    if (config.cpu_vm != CPUVM_EMU)
 #endif
       {
 	if (getsegment(fs) != eflags_fs_gs.fs)

--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -224,6 +224,8 @@ void *alias_mapping(int cap, unsigned targ, size_t mapsize, int protect, void *s
   if (cap & MAPPING_INIT_LOWRAM)
     mem_base = addr;
   update_aliasmap(addr, mapsize, (cap & MAPPING_VGAEMU) ? target : source);
+  if (config.cpu_vm == CPUVM_KVM)
+    mprotect_kvm(addr, mapsize, protect);
   Q__printf("MAPPING: %s alias created at %p\n", cap, addr);
   return addr;
 }
@@ -295,6 +297,8 @@ void *mmap_mapping(int cap, void *target, size_t mapsize, int protect, off_t sou
     return MAP_FAILED;
   }
   Q__printf("MAPPING: map success, cap=%s, addr=%p\n", cap, addr);
+  if (config.cpu_vm == CPUVM_KVM)
+    mprotect_kvm(addr, mapsize, protect);
   return addr;
 }
 
@@ -315,6 +319,8 @@ int mprotect_mapping(int cap, void *addr, size_t mapsize, int protect)
   Q__printf("MAPPING: mprotect, cap=%s, addr=%p, size=%zx, protect=%x\n",
 	cap, addr, mapsize, protect);
   ret = mprotect(addr, mapsize, protect);
+  if (config.cpu_vm == CPUVM_KVM)
+    mprotect_kvm(addr, mapsize, protect);
   if (ret)
     error("mprotect() failed: %s\n", strerror(errno));
   return ret;

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -546,6 +546,15 @@ static void read_cpu_info(void)
 
 static void config_post_process(void)
 {
+    if (config.cpu_vm == -1) {
+#ifdef __x86_64__
+      config.cpu_vm = CPUVM_EMU;	// for now
+#else
+      config.cpu_vm = config.cpuemu ? CPUVM_EMU : CPUVM_VM86;
+#endif
+    }
+    if (config.cpu_vm != CPUVM_EMU)
+      config.cpuemu = 0;
     config.realcpu = CPU_386;
     if (vm86s.cpu_type > config.realcpu || config.rdtsc || config.mathco)
 	read_cpu_info();

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -546,6 +546,13 @@ static void read_cpu_info(void)
 
 static void config_post_process(void)
 {
+    config.realcpu = CPU_386;
+    if (vm86s.cpu_type > config.realcpu || config.rdtsc || config.mathco)
+	read_cpu_info();
+    if (vm86s.cpu_type > config.realcpu) {
+	vm86s.cpu_type = config.realcpu;
+	fprintf(stderr, "CONF: emulated CPU forced down to real CPU: %d86\n",(int)vm86s.cpu_type);
+    }
     if (config.cpu_vm == -1) {
 #ifdef __x86_64__
       config.cpu_vm = CPUVM_EMU;	// for now
@@ -553,14 +560,12 @@ static void config_post_process(void)
       config.cpu_vm = config.cpuemu ? CPUVM_EMU : CPUVM_VM86;
 #endif
     }
-    if (config.cpu_vm != CPUVM_EMU)
+    if (config.cpu_vm != CPUVM_EMU) {
       config.cpuemu = 0;
-    config.realcpu = CPU_386;
-    if (vm86s.cpu_type > config.realcpu || config.rdtsc || config.mathco)
-	read_cpu_info();
-    if (vm86s.cpu_type > config.realcpu) {
-    	vm86s.cpu_type = config.realcpu;
-    	fprintf(stderr, "CONF: emulated CPU forced down to real CPU: %d86\n",(int)vm86s.cpu_type);
+    } else if (config.cpuemu == 0) {
+	config.cpuemu = 3;
+	init_emu_cpu();
+	c_printf("CONF: JIT CPUEMU set to 3 for %d86\n", (int)vm86s.cpu_type);
     }
     if (config.rdtsc) {
 	if (config.smp) {

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -273,9 +273,10 @@ void low_mem_init(void)
 	      );
     exit(EXIT_FAILURE);
 #else
-    if (config.cpuemu < 3)
+    if (config.cpu_vm == CPUVM_VM86)
     {
       /* switch on vm86-only JIT CPU emulation to with non-zero base */
+      config.cpu_vm = CPUVM_EMU;
       config.cpuemu = 3;
       init_emu_cpu();
       c_printf("CONF: JIT CPUEMU set to 3 for %d86\n", (int)vm86s.cpu_type);
@@ -299,12 +300,6 @@ void low_mem_init(void)
 #endif
   result = alias_mapping(MAPPING_INIT_LOWRAM, -1, LOWMEM_SIZE + HMASIZE,
 			   PROT_READ | PROT_WRITE | PROT_EXEC, lowmem);
-  if (config.cpuemu < 3) {
-    /* switch on vm86-only JIT CPU emulation to with non-zero base */
-    config.cpuemu = 3;
-    init_emu_cpu();
-    c_printf("CONF: JIT CPUEMU set to 3 for %d86\n", (int)vm86s.cpu_type);
-  }
 #endif
 
   if (result == MAP_FAILED) {

--- a/src/base/init/lexer.l.in
+++ b/src/base/init/lexer.l.in
@@ -415,6 +415,9 @@ full			RETURN(FULL);
 vm86sim			RETURN(VM86SIM);
 fullsim			RETURN(FULLSIM);
 
+cpu_vm			RETURN(CPU_VM);
+kvm			RETURN(KVM);
+
 	/* disk keywords */
 hdimage			RETURN(HDIMAGE);
 image			RETURN(HDIMAGE);

--- a/src/base/init/parser.y.in
+++ b/src/base/init/parser.y.in
@@ -251,7 +251,7 @@ while (0)
 	/* speaker */
 %token EMULATED NATIVE
 	/* cpuemu */
-%token CPUEMU VM86 FULL VM86SIM FULLSIM
+%token CPUEMU CPU_VM VM86 FULL VM86SIM FULLSIM KVM
 	/* keyboard */
 %token RAWKEYBOARD
 %token PRESTROKE
@@ -318,6 +318,7 @@ while (0)
 	/* %expect 1 */
 
 %type <i_value> int_bool irq_bool bool speaker floppy_bool cpuemu
+%type <i_value> cpu_vm
 
 %%
 
@@ -465,6 +466,11 @@ line		: HOGTHRESH expression	{ config.hogthreshold = $2; }
 			c_printf("CONF: CPUEMU set to %d for %d86\n",
 				config.cpuemu, (int)vm86s.cpu_type);
 #endif
+			}
+		| CPU_VM cpu_vm
+			{
+			config.cpu_vm = $2;
+			c_printf("CONF: CPU VM set to %d\n", config.cpu_vm);
 			}
 		| CPUEMU cpuemu
 			{
@@ -1704,6 +1710,15 @@ cpuemu		: L_OFF		{ $$ = 0; }
 		| STRING        { yyerror("got '%s', expected 'off', 'vm86' or 'full'", $1);
 				  free($1); }
 		| error         { yyerror("expected 'off', 'vm86' or 'full'"); }
+		;
+
+cpu_vm		: L_AUTO	{ $$ = -1; }
+		| VM86		{ $$ = CPUVM_VM86; }
+		| KVM		{ $$ = CPUVM_KVM; }
+		| EMULATED	{ $$ = CPUVM_EMU; }
+		| STRING        { yyerror("got '%s' for cpu_vm", $1);
+				  free($1); }
+		| error         { yyerror("bad value for cpu_vm"); }
 		;
 
 %%

--- a/src/base/misc/dump.c
+++ b/src/base/misc/dump.c
@@ -186,7 +186,7 @@ char *DPMI_show_state(struct sigcontext *scp)
      * area, we fall into another fault which likely terminates dosemu.
      */
 #ifdef X86_EMULATOR
-    if (!config.cpuemu || (_trapno!=0x0b && _trapno!=0x0c))
+    if (config.cpu_vm != CPUVM_EMU || (_trapno!=0x0b && _trapno!=0x0c))
 #endif
     {
       int i;

--- a/src/base/misc/priv.c
+++ b/src/base/misc/priv.c
@@ -144,7 +144,7 @@ int priv_iopl(int pl)
   }
   else ret = iopl(pl);
 #ifdef X86_EMULATOR
-  if (config.cpuemu) e_priv_iopl(pl);
+  if (config.cpu_vm == CPUVM_EMU) e_priv_iopl(pl);
 #endif
   if (ret == 0)
     current_iopl = pl;

--- a/src/emu-i386/Makefile
+++ b/src/emu-i386/Makefile
@@ -2,13 +2,13 @@
 top_builddir=../..
 include $(top_builddir)/Makefile.conf
 
-CFILES=cpu.c ports.c do_vm86.c cputime.c
+CFILES=cpu.c ports.c do_vm86.c cputime.c kvm.c
 
 
-SFILES=
+SFILES=kvmmon.S
 ALL=$(CFILES) $(SFILES)
 
-OBJS=$(CFILES:.c=.o)
+OBJS=$(CFILES:.c=.o) $(SFILES:.S=.o)
 #OOBJS=bios.o
 DEPENDS=$(CFILES:.c=.d)
 

--- a/src/emu-i386/cpu.c
+++ b/src/emu-i386/cpu.c
@@ -309,7 +309,7 @@ void cpu_setup(void)
   fpu_reset();
 
 #ifdef X86_EMULATOR
-  if (config.cpuemu) {
+  if (config.cpu_vm == CPUVM_EMU) {
     init_emu_cpu();
   }
 #endif

--- a/src/emu-i386/do_vm86.c
+++ b/src/emu-i386/do_vm86.c
@@ -317,9 +317,11 @@ static int true_vm86(struct vm86_struct *x)
 
 static int do_vm86(struct vm86_struct *x)
 {
+    if (config.cpu_vm == CPUVM_KVM)
+	return kvm_vm86(x);
 #ifdef __i386__
 #ifdef X86_EMULATOR
-    if (config.cpuemu)
+    if (config.cpu_vm == CPUVM_EMU)
 	return e_vm86();
 #endif
     return true_vm86(x);
@@ -562,9 +564,11 @@ void do_int_call_back(int intno)
 static void vm86plus_init(void)
 {
 #ifdef X86_EMULATOR
-    if (config.cpuemu >= 3)
+    if (config.cpu_vm == CPUVM_EMU && config.cpuemu >= 3)
 	return;
 #endif
+    if (config.cpu_vm == CPUVM_KVM)
+	return;
 #ifdef __i386__
 //    if (!vm86_plus(VM86_PLUS_INSTALL_CHECK,0)) return;
     if (syscall(SYS_vm86old, (void *)VM86_PLUS_INSTALL_CHECK) == -1 &&
@@ -576,7 +580,8 @@ static void vm86plus_init(void)
     error("vm86 service not available in your kernel, %s\n", strerror(errno));
     error("using CPU emulation for vm86()\n");
 #endif
-    if (config.cpuemu < 3) {
+    if (config.cpu_vm == CPUVM_VM86 && config.cpuemu < 3) {
+	config.cpu_vm = CPUVM_EMU;
 	config.cpuemu = 3;
 	init_emu_cpu();
     }

--- a/src/emu-i386/kvm.c
+++ b/src/emu-i386/kvm.c
@@ -1,0 +1,508 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+/*
+ *  Emulate vm86() using KVM
+ *  Started 2015, Bart Oldeman
+ *  References: http://lwn.net/Articles/658511/
+ *  plus example at http://lwn.net/Articles/658512/
+ */
+
+#include "config.h"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+#include <linux/kvm.h>
+
+#include "emu.h"
+#include "emu-ldt.h"
+
+#define SAFE_MASK (X86_EFLAGS_CF|X86_EFLAGS_PF| \
+                   X86_EFLAGS_AF|X86_EFLAGS_ZF|X86_EFLAGS_SF| \
+                   X86_EFLAGS_TF|X86_EFLAGS_DF|X86_EFLAGS_OF| \
+                   X86_EFLAGS_NT|X86_EFLAGS_AC|X86_EFLAGS_ID) // 0x244dd5
+#define RETURN_MASK (SAFE_MASK | 0x28 | X86_EFLAGS_FIXED) // 0x244dff
+
+extern char kvm_mon_start[];
+extern char kvm_mon_hlt[];
+extern char kvm_mon_end[];
+
+/* V86 monitor structure to run code in V86 mode with VME enabled inside KVM
+   This contains:
+   1. a TSS with
+     a. ss0:esp0 set to a stack at the top of the monitor structure
+        This stack contains a copy of the vm86_regs struct.
+     b. An interrupt redirect bitmap copied from info->int_revectored
+     c. I/O bitmap, for now set to trap all ints. Todo: sync with ioperm()
+   2. A GDT with 3 entries
+     a. 0 entry
+     b. selector 8: flat CS
+     c. selector 0x10: flat SS
+   3. An IDT with 33 (0x21) entries:
+     a. 0x20 entries for all CPU exceptions
+     b. a special entry at index 0x20 to interrupt the VM
+   4. The stack (from 1a) above
+   5. The code pointed to by the IDT entries, from kvmmon.S, on a new page
+      This just pushes the exception number, error code, and all registers
+      to the stack and executes the HLT instruction which is then trapped
+      by KVM.
+ */
+
+#define TSS_IOPB_SIZE (65536 / 8)
+#define GDT_ENTRIES 3
+#undef IDT_ENTRIES
+#define IDT_ENTRIES 0x21
+#define CODE_PAGE_SIZE 0x1000
+
+struct monitor {
+    Task tss;                                /* 0000 */
+    /* tss.esp0                                 0004 */
+    /* tss.ss0                                  0008 */
+    /* tss.IOmapbaseT (word)                    0066 */
+    struct revectored_struct int_revectored; /* 0068 */
+    unsigned char io_bitmap[TSS_IOPB_SIZE+1];/* 0088 */
+    /* TSS last byte (limit)                    2088 */
+    unsigned char padding0[0x2100-sizeof(Task)
+		-sizeof(struct revectored_struct)
+		-(TSS_IOPB_SIZE+1)];
+    Descriptor gdt[GDT_ENTRIES];             /* 2100 */
+    unsigned char padding1[0x2200-0x2100
+	-GDT_ENTRIES*sizeof(Descriptor)];    /* 2118 */
+    Gatedesc idt[IDT_ENTRIES];               /* 2200 */
+    unsigned char padding2[0x3000-0x2200
+	-IDT_ENTRIES*sizeof(Gatedesc)
+	-sizeof(struct vm86_regs)];          /* 2308 */
+    struct vm86_regs regs;    /* Fault stack at 2FAC */
+    unsigned char code[CODE_PAGE_SIZE];      /* 3000 */
+    /* 3000 IDT exception 0 code start
+       300A IDT exception 1 code start
+       .... ....
+       3140 IDT exception 0x21 code start
+       314A IDT common code start
+       315F IDT common code end
+    */
+};
+
+/* switches KVM virtual machine to vm86 mode */
+static struct monitor *enter_vm86(int vmfd, int vcpufd)
+{
+  int ret, i;
+  struct kvm_regs regs;
+  struct kvm_sregs sregs;
+  struct monitor *monitor;
+
+  /* create monitor structure in memory */
+  monitor = mmap(NULL, sizeof(*monitor), PROT_READ | PROT_WRITE,
+		 MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+  struct kvm_userspace_memory_region tss_region = {
+    .slot = 1,
+    .guest_phys_addr = LOWMEM_SIZE + HMASIZE,
+    .memory_size = sizeof(*monitor),
+    .userspace_addr = (uint64_t)(unsigned long)monitor,
+  };
+
+  /* Map guest memory: TSS */
+  ret = ioctl(vmfd, KVM_SET_USER_MEMORY_REGION, &tss_region);
+  if (ret == -1) {
+    perror("KVM: KVM_SET_USER_MEMORY_REGION");
+    leavedos(99);
+  }
+
+  memset(monitor, 0, sizeof(*monitor));
+  /* trap all I/O instructions with GPF */
+  memset(monitor->io_bitmap, 0xff, TSS_IOPB_SIZE+1);
+
+  ret = ioctl(vcpufd, KVM_GET_SREGS, &sregs);
+  if (ret == -1) {
+    perror("KVM: KVM_GET_SREGS");
+    leavedos(99);
+  }
+
+  sregs.tr.base = LOWMEM_SIZE + HMASIZE;
+  sregs.tr.limit = offsetof(struct monitor, io_bitmap) + TSS_IOPB_SIZE;
+  sregs.tr.unusable = 0;
+  sregs.tr.type = 0xb;
+  sregs.tr.s = 0;
+  sregs.tr.dpl = 0;
+  sregs.tr.present = 1;
+  sregs.tr.avl = 0;
+  sregs.tr.l = 0;
+  sregs.tr.db = 0;
+  sregs.tr.g = 0;
+
+  monitor->tss.esp0 = sregs.tr.base + offsetof(struct monitor, regs) +
+    sizeof(monitor->regs);
+  monitor->tss.ss0 = 0x10;
+  monitor->tss.IOmapbase = offsetof(struct monitor, io_bitmap);
+
+  // setup GDT
+  sregs.gdt.base = sregs.tr.base + offsetof(struct monitor, gdt);
+  sregs.gdt.limit = GDT_ENTRIES * sizeof(Descriptor) - 1;
+  for (i=1; i<GDT_ENTRIES; i++) {
+    monitor->gdt[i].limit_lo = 0xffff;
+    monitor->gdt[i].type = 0xa;
+    monitor->gdt[i].S = 1;
+    monitor->gdt[i].present = 1;
+    monitor->gdt[i].limit_hi = 0xf;
+    monitor->gdt[i].DB = 1;
+    monitor->gdt[i].gran = 1;
+  }
+  // flat data selector (0x10)
+  monitor->gdt[GDT_ENTRIES-1].type = 2;
+
+  sregs.idt.base = sregs.tr.base + offsetof(struct monitor, idt);
+  sregs.idt.limit = IDT_ENTRIES * sizeof(Gatedesc)-1;
+  // setup IDT
+  for (i=0; i<IDT_ENTRIES; i++) {
+    unsigned int offs = sregs.tr.base + offsetof(struct monitor, code) + i * 10;
+    monitor->idt[i].offs_lo = offs & 0xffff;
+    monitor->idt[i].offs_hi = offs >> 16;
+    monitor->idt[i].seg = 0x8; // FLAT_CODE_SEL
+    monitor->idt[i].type = 0xe;
+    monitor->idt[i].DPL = 3;
+    monitor->idt[i].present = 1;
+  }
+  memcpy(monitor->code, kvm_mon_start, kvm_mon_end - kvm_mon_start);
+
+  sregs.cr0 |= X86_CR0_PE;
+  sregs.cr4 |= X86_CR4_VME;
+
+  /* setup registers to point to VM86 monitor */
+  sregs.cs.base = 0;
+  sregs.cs.limit = 0xffffffff;
+  sregs.cs.selector = 0x8;
+  sregs.cs.db = 1;
+  sregs.cs.g = 1;
+
+  sregs.ss.base = 0;
+  sregs.ss.limit = 0xffffffff;
+  sregs.ss.selector = 0x10;
+  sregs.ss.db = 1;
+  sregs.ss.g = 1;
+
+  ret = ioctl(vcpufd, KVM_SET_SREGS, &sregs);
+  if (ret == -1) {
+    perror("KVM: KVM_SET_SREGS");
+    leavedos(99);
+  }
+
+  /* just after the HLT */
+  regs.rip = sregs.tr.base + offsetof(struct monitor, code) +
+    (kvm_mon_hlt - kvm_mon_start) + 1;
+  regs.rsp = sregs.tr.base + offsetof(struct monitor, regs);
+  regs.rflags = X86_EFLAGS_FIXED;
+  ret = ioctl(vcpufd, KVM_SET_REGS, &regs);
+  if (ret == -1) {
+    perror("KVM: KVM_SET_REGS");
+    leavedos(99);
+  }
+
+  return monitor;
+}
+
+/* Initialize KVM and memory mappings */
+static int kvm_init(struct kvm_run **prun, struct monitor **pmonitor)
+{
+  struct kvm_userspace_memory_region region = {
+    .slot = 0,
+    .guest_phys_addr = 0x0,
+    .memory_size = LOWMEM_SIZE + HMASIZE,
+    .userspace_addr = (uint64_t)(unsigned long)mem_base,
+  };
+  struct kvm_cpuid *cpuid;
+  struct kvm_run *run;
+  int kvm, vmfd, vcpufd, ret, mmap_size;
+
+  kvm = open("/dev/kvm", O_RDWR | O_CLOEXEC);
+  if (kvm == -1) {
+    perror("KVM: error opening /dev/kvm");
+    leavedos(99);
+  }
+
+  vmfd = ioctl(kvm, KVM_CREATE_VM, (unsigned long)0);
+  if (vmfd == -1) {
+    perror("KVM: KVM_CREATE_VM");
+    leavedos(99);
+  }
+
+  /* Map guest memory: only conventional memory + HMA for now */
+  ret = ioctl(vmfd, KVM_SET_USER_MEMORY_REGION, &region);
+  if (ret == -1) {
+    perror("KVM: KVM_SET_USER_MEMORY_REGION");
+    leavedos(99);
+  }
+
+  /* this call is only there to shut up the kernel saying
+     "KVM_SET_TSS_ADDR need to be called before entering vcpu"
+     this is only really needed if the vcpu is started in real mode and
+     the kernel needs to emulate that using V86 mode, as is necessary
+     on Nehalem and earlier Intel CPUs */
+  ret = ioctl(vmfd, KVM_SET_TSS_ADDR,
+	      (unsigned long)(LOWMEM_SIZE + HMASIZE + sizeof(struct monitor)));
+  if (ret == -1) {
+    perror("KVM: KVM_SET_TSS_ADDR");
+    leavedos(99);
+  }
+
+  vcpufd = ioctl(vmfd, KVM_CREATE_VCPU, (unsigned long)0);
+  if (vmfd == -1) {
+    perror("KVM: KVM_CREATE_VCPU");
+    leavedos(99);
+  }
+
+  cpuid = malloc(sizeof(*cpuid) + 2*sizeof(cpuid->entries[0]));
+  cpuid->nent = 2;
+  // Use the same values as in emu-i386/simx86/interp.c
+  // (Pentium 133-200MHz, "GenuineIntel")
+  cpuid->entries[0] = (struct kvm_cpuid_entry) { .function = 0,
+    .eax = 1, .ebx = 0x756e6547, .ecx = 0x6c65746e, .edx = 0x49656e69 };
+  // family 5, model 2, stepping 12, fpu vme de pse tsc msr mce cx8
+  cpuid->entries[1] = (struct kvm_cpuid_entry) { .function = 1,
+    .eax = 0x052c, .ebx = 0, .ecx = 0, .edx = 0x1bf };
+  ret = ioctl(vcpufd, KVM_SET_CPUID, cpuid);
+  free(cpuid);
+  if (ret == -1) {
+    perror("KVM: KVM_SET_CPUID");
+    leavedos(99);
+  }
+
+  mmap_size = ioctl(kvm, KVM_GET_VCPU_MMAP_SIZE, NULL);
+  if (mmap_size == -1) {
+    perror("KVM: KVM_GET_VCPU_MMAP_SIZE");
+    leavedos(99);
+  }
+  if (mmap_size < sizeof(*run)) {
+    fprintf(stderr, "KVM: KVM_GET_VCPU_MMAP_SIZE unexpectedly small\n");
+    leavedos(99);
+  }
+  run = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED, vcpufd, 0);
+  if (run == MAP_FAILED) {
+    perror("KVM: mmap vcpu");
+    leavedos(99);
+  }
+
+  *prun = run;
+  *pmonitor = enter_vm86(vmfd, vcpufd);
+  return vcpufd;
+}
+
+/* This function works like handle_vm86_fault in the Linux kernel,
+   except:
+   * since we use VME we only need to handle
+     PUSHFD, POPFD, IRETD always
+     POPF, IRET only if it sets TF or IF with VIP set
+     STI only if VIP is set and VIF was not set
+     INT only if it is revectored
+   * The Linux kernel splits the CPU flags into on-CPU flags and
+     flags (VFLAGS) IOPL, NT, AC, and ID that are kept on the stack.
+     Here all those flags are merged into on-CPU flags, with the
+     exception of IOPL. IOPL is always set to 0 on the CPU,
+     and to 3 on the stack with PUSHF
+*/
+static int kvm_handle_vm86_fault(struct vm86_regs *regs, unsigned int cpu_type)
+{
+  unsigned char opcode;
+  int data32 = 0, pref_done = 0;
+  unsigned int csp = regs->cs << 4;
+  unsigned int ssp = regs->ss << 4;
+  unsigned short ip = regs->eip & 0xffff;
+  unsigned short sp = regs->esp & 0xffff;
+  unsigned int orig_flags = regs->eflags;
+  int ret = -1;
+
+  do {
+    switch (opcode = popb(csp, ip)) {
+    case 0x66:      /* 32-bit data */     data32 = 1; break;
+    case 0x67:      /* 32-bit address */  break;
+    case 0x2e:      /* CS */              break;
+    case 0x3e:      /* DS */              break;
+    case 0x26:      /* ES */              break;
+    case 0x36:      /* SS */              break;
+    case 0x65:      /* GS */              break;
+    case 0x64:      /* FS */              break;
+    case 0xf2:      /* repnz */           break;
+    case 0xf3:      /* rep */             break;
+    default: pref_done = 1;
+    }
+  } while (!pref_done);
+
+  switch (opcode) {
+
+  case 0x9c: { /* only pushfd faults with VME */
+    unsigned int flags = regs->eflags & RETURN_MASK;
+    if (regs->eflags & X86_EFLAGS_VIF)
+      flags |= X86_EFLAGS_IF;
+    flags |= X86_EFLAGS_IOPL;
+    pushl(ssp, sp, flags);
+    break;
+  }
+
+  case 0xcd: { /* int xx */
+    int intno = popb(csp, ip);
+    ret = VM86_INTx + (intno << 8);
+    break;
+  }
+
+  case 0xcf: /* iret */
+    if (data32) {
+      ip = popl(ssp, sp);
+      regs->cs = popl(ssp, sp);
+    } else {
+      ip = popw(ssp, sp);
+      regs->cs = popw(ssp, sp);
+    }
+    /* fall through into popf */
+  case 0x9d: { /* popf */
+    unsigned int newflags;
+    if (data32) {
+      newflags = popl(ssp, sp);
+      if (cpu_type >= CPU_286 && cpu_type <= CPU_486) {
+	newflags &= ~X86_EFLAGS_ID;
+	if (cpu_type < CPU_486)
+	  newflags &= ~X86_EFLAGS_AC;
+      }
+      regs->eflags &= ~SAFE_MASK;
+    } else {
+      /* must have VIP or TF set in VME, otherwise does not trap */
+      newflags = popw(ssp, sp);
+      regs->eflags &= ~(SAFE_MASK & 0xffff);
+    }
+    regs->eflags |= newflags & SAFE_MASK;
+    if (newflags & X86_EFLAGS_IF) {
+      regs->eflags |= X86_EFLAGS_VIF;
+      if (orig_flags & X86_EFLAGS_VIP) ret = VM86_STI;
+    } else {
+      regs->eflags &= ~X86_EFLAGS_VIF;
+    }
+    break;
+  }
+
+  case 0xfb: /* STI */
+    /* must have VIP set in VME, otherwise does not trap */
+    regs->eflags |= X86_EFLAGS_VIF;
+    ret = VM86_STI;
+    break;
+
+  default:
+    return VM86_UNKNOWN;
+  }
+
+  regs->esp = (regs->esp & 0xffff0000) | sp;
+  regs->eip = (regs->eip & 0xffff0000) | ip;
+  if (ret != -1)
+    return ret;
+  if (orig_flags & X86_EFLAGS_TF)
+    return VM86_TRAP + (1 << 8);
+  return ret;
+}
+
+/* Emulate vm86() using KVM */
+int kvm_vm86(struct vm86_struct *info)
+{
+  struct vm86_regs *regs;
+  int ret, vm86_ret;
+  unsigned int exit_reason;
+  static int vcpufd = -1;
+  static struct kvm_run *run;
+  static struct monitor *monitor;
+
+  if (vcpufd == -1) {
+    vcpufd = kvm_init(&run, &monitor);
+    warn("Using V86 mode inside KVM\n");
+  }
+
+  regs = &monitor->regs;
+  *regs = info->regs;
+  monitor->int_revectored = info->int_revectored;
+
+  regs->eflags &= (SAFE_MASK | X86_EFLAGS_VIF | X86_EFLAGS_VIP);
+  regs->eflags |= X86_EFLAGS_FIXED | X86_EFLAGS_VM | X86_EFLAGS_IF;
+
+  do {
+    vm86_ret = -1;
+    ret = ioctl(vcpufd, KVM_RUN, NULL);
+
+    /* KVM should only exit for three reasons:
+       1. KVM_EXIT_HLT: at the hlt in kvmmon.S.
+       2. KVM_EXIT_INTR: (with ret==-1) after a signal. In this case we
+          re-enter KVM with int 0x20 injected (if possible) so it will fault
+          with KMV_EXIT_HLT.
+       3. KVM_EXIT_IRQ_WINDOW_OPEN: if it is not possible to inject interrupts
+          KVM is re-entered asking it to exit when interrupt injection is
+          possible, then it exits with this code. This only happens if a signal
+          occurs during execution of the monitor code in kvmmon.S.
+    */
+    exit_reason = run->exit_reason;
+    if (ret == -1 && errno == EINTR) {
+      exit_reason = KVM_EXIT_INTR;
+    } else if (ret != 0) {
+      perror("KVM: KVM_RUN");
+      leavedos(99);
+    }
+
+    switch (exit_reason) {
+    case KVM_EXIT_HLT: {
+      /* __null_gs = exception number */
+      /* orig_eax = error code */
+      unsigned int trapno = regs->__null_gs;
+      vm86_ret = VM86_SIGNAL;
+      if (trapno == 1 || trapno == 3)
+	vm86_ret = VM86_TRAP | (trapno << 8);
+      else if (trapno == 0xd)
+	vm86_ret = kvm_handle_vm86_fault(regs, info->cpu_type);
+      else if (trapno != 0x20) {
+	fprintf(stderr, "KVM: unhandled exception 0x%x\n", trapno); //TODO
+	leavedos(99);
+      }
+      break;
+    }
+    case KVM_EXIT_IRQ_WINDOW_OPEN:
+    case KVM_EXIT_INTR:
+      run->request_interrupt_window = !run->ready_for_interrupt_injection;
+      if (run->ready_for_interrupt_injection) {
+	struct kvm_interrupt interrupt = (struct kvm_interrupt){.irq = 0x20};
+	ret = ioctl(vcpufd, KVM_INTERRUPT, &interrupt);
+	if (ret == -1) {
+	  perror("KVM: KVM_INTERRUPT");
+	  leavedos(99);
+	}
+      }
+      break;
+    case KVM_EXIT_FAIL_ENTRY:
+      fprintf(stderr,
+	      "KVM_EXIT_FAIL_ENTRY: hardware_entry_failure_reason = 0x%llx f=0x%lx\n",
+	      (unsigned long long)run->fail_entry.hardware_entry_failure_reason,
+	      regs->eflags);
+      leavedos(99);
+    case KVM_EXIT_INTERNAL_ERROR:
+      fprintf(stderr,
+	      "KVM_EXIT_INTERNAL_ERROR: suberror = 0x%x\n", run->internal.suberror);
+      leavedos(99);
+    default:
+      fprintf(stderr, "KVM: exit_reason = 0x%x\n", exit_reason);
+      leavedos(99);
+    }
+
+  } while (vm86_ret == -1);
+
+  info->regs = *regs;
+  return vm86_ret;
+}

--- a/src/emu-i386/kvm.c
+++ b/src/emu-i386/kvm.c
@@ -488,9 +488,8 @@ int kvm_vm86(struct vm86_struct *info)
       break;
     case KVM_EXIT_FAIL_ENTRY:
       fprintf(stderr,
-	      "KVM_EXIT_FAIL_ENTRY: hardware_entry_failure_reason = 0x%llx f=0x%lx\n",
-	      (unsigned long long)run->fail_entry.hardware_entry_failure_reason,
-	      regs->eflags);
+	      "KVM_EXIT_FAIL_ENTRY: hardware_entry_failure_reason = 0x%llx\n",
+	      (unsigned long long)run->fail_entry.hardware_entry_failure_reason);
       leavedos(99);
     case KVM_EXIT_INTERNAL_ERROR:
       fprintf(stderr,

--- a/src/emu-i386/kvmmon.S
+++ b/src/emu-i386/kvmmon.S
@@ -51,9 +51,12 @@ kvm_mon_main:
         push %edx
         push %ecx
         push %ebx
+        mov %cr2,%eax
+        push %eax
 	.globl kvm_mon_hlt
 kvm_mon_hlt:
         hlt
+        pop %eax
         pop %ebx
         pop %ecx
         pop %edx

--- a/src/emu-i386/kvmmon.S
+++ b/src/emu-i386/kvmmon.S
@@ -1,0 +1,71 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+/*
+ *  IDT handlers for the V86 monitor using KVM
+ *  These just push the exception number and state, and then execute
+ *  a common HLT which is trapped by KVM.
+ */
+
+	.section .text
+
+	.globl kvm_mon_start
+kvm_mon_start:
+
+        i = 0
+        .rept 0x21
+        .if i == 8 || (i >= 0xa && i <= 0xe) || i == 0x11 || i == 0x1e
+        /* these exceptions already pushed an error code */
+        nop
+        nop
+        .else
+        /* push fake error code for consistent stack */
+        pushl $0
+        .endif
+        pushl $i
+        jmp kvm_mon_main
+        i = i + 1
+        .fill kvm_mon_start+10*i-., 1, 0x90
+        .endr
+
+kvm_mon_main:
+        sub $0xc,%esp
+        push %eax
+        push %ebp
+        push %edi
+        push %esi
+        push %edx
+        push %ecx
+        push %ebx
+	.globl kvm_mon_hlt
+kvm_mon_hlt:
+        hlt
+        pop %ebx
+        pop %ecx
+        pop %edx
+        pop %esi
+        pop %edi
+        pop %ebp
+        pop %eax
+        add $0x14,%esp
+        iret
+
+	.globl kvm_mon_end
+kvm_mon_end:
+
+#ifdef __ELF__
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/src/emu-i386/kvmmon.S
+++ b/src/emu-i386/kvmmon.S
@@ -21,6 +21,7 @@
  */
 
 	.section .text
+	.code32
 
 	.globl kvm_mon_start
 kvm_mon_start:

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -46,6 +46,7 @@ struct eflags_fs_gs {
 extern struct eflags_fs_gs eflags_fs_gs;
 
 int vm86_init(void);
+int kvm_vm86(struct vm86_struct *info);
 #ifdef __i386__
 #define vm86(param) syscall(SYS_vm86old, param)
 #define vm86_plus(function,param) syscall(SYS_vm86, function, param)

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -176,6 +176,7 @@ typedef struct config_info {
        int cpuemu;
        boolean cpusim;
 #endif
+       int cpu_vm;
        int CPUSpeedInMhz;
        /* for video */
        int console_video;
@@ -349,9 +350,8 @@ typedef struct config_info {
 } config_t;
 
 
-#define SPKR_OFF	0
-#define SPKR_NATIVE	1
-#define SPKR_EMULATED	2
+enum { SPKR_OFF, SPKR_NATIVE, SPKR_EMULATED };
+enum { CPUVM_VM86, CPUVM_KVM, CPUVM_EMU };
 
 /*
  * Right now, dosemu only supports two serial ports.

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -78,6 +78,7 @@ typedef int munmap_mapping_type(int cap, void *addr, size_t mapsize);
 int munmap_mapping (int cap, void *addr, size_t mapsize);
 
 int mprotect_mapping(int cap, void *addr, size_t mapsize, int protect);
+void mprotect_kvm(void *addr, size_t mapsize, int protect);
 
 void *extended_mremap(void *addr, size_t old_len, size_t new_len,
        int flags, void * new_addr);

--- a/src/include/vm86_compat.h
+++ b/src/include/vm86_compat.h
@@ -4,6 +4,7 @@
 #ifdef __i386__
 #include <asm/vm86.h>
 #else
+#include <asm/processor-flags.h>
 
 /*
  * I'm guessing at the VIF/VIP flag usage, but hope that this is how
@@ -15,25 +16,6 @@
  *
  * Linus
  */
-
-#define X86_EFLAGS_CF	0x00000001 /* Carry Flag */
-#define X86_EFLAGS_BIT1	0x00000002 /* Bit 1 - always on */
-#define X86_EFLAGS_PF	0x00000004 /* Parity Flag */
-#define X86_EFLAGS_AF	0x00000010 /* Auxiliary carry Flag */
-#define X86_EFLAGS_ZF	0x00000040 /* Zero Flag */
-#define X86_EFLAGS_SF	0x00000080 /* Sign Flag */
-#define X86_EFLAGS_TF	0x00000100 /* Trap Flag */
-#define X86_EFLAGS_IF	0x00000200 /* Interrupt Flag */
-#define X86_EFLAGS_DF	0x00000400 /* Direction Flag */
-#define X86_EFLAGS_OF	0x00000800 /* Overflow Flag */
-#define X86_EFLAGS_IOPL	0x00003000 /* IOPL mask */
-#define X86_EFLAGS_NT	0x00004000 /* Nested Task */
-#define X86_EFLAGS_RF	0x00010000 /* Resume Flag */
-#define X86_EFLAGS_VM	0x00020000 /* Virtual Mode */
-#define X86_EFLAGS_AC	0x00040000 /* Alignment Check */
-#define X86_EFLAGS_VIF	0x00080000 /* Virtual Interrupt Flag */
-#define X86_EFLAGS_VIP	0x00100000 /* Virtual Interrupt Pending */
-#define X86_EFLAGS_ID	0x00200000 /* CPUID detection flag */
 
 #define BIOSSEG		0x0f000
 


### PR DESCRIPTION
Here is my implementation of KVM using V86 mode. It just needs a few details worked out such as SIGILL calling int6, but otherwise it is pretty much a plug-in replacement for the vm86 syscall so I based it back on devel because the revectoring changes are no longer necessary.

I split the PR into two commits, the KVM part authored by me, and the $_cpu_vm API changes by Stas.

This should also work with older Intel CPUs (Core2/Nehalem) without unrestricted guest.