### PR TITLE
Auto-detect KVM, and fall back to CPUEMU if not available + allow to run DPMI code via KVM

### DIFF
--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -48,6 +48,14 @@
 
 # $_cpu_vm = "auto"
 
+# Select cpu virtualization mode for DPMI.
+# "native" - use native LDT via modify_ldt() syscall.
+# "kvm" - use KVM, hardware-assisted in-kernel virtual machine.
+# "emulated" - use CPU emulator
+# "auto" - select whatever works
+
+# $_cpu_vm_dpmi = "auto"
+
 # if possible use Pentium cycle counter for timing. Default: off
 
 # $_rdtsc = (off)

--- a/etc/global.conf
+++ b/etc/global.conf
@@ -149,8 +149,8 @@ else
     checkuservar $_debug, $_trace_ports,
       $_features, $_mapping, $_hogthreshold, $_cli_timeout,
       $_timemode,
-      $_mathco, $_cpu, $_cpu_vm, $_cpu_emu, $_rdtsc, $_cpuspeed, $_xms, $_ems,
-      $_ems_frame, $_ems_uma_pages, $_ems_conv_pages,
+      $_mathco, $_cpu, $_cpu_vm, $_cpu_vm_dpmi, $_cpu_emu, $_rdtsc, $_cpuspeed,
+      $_xms, $_ems, $_ems_frame, $_ems_uma_pages, $_ems_conv_pages,
       $_ext_mem, $_dpmi, $_dpmi_base, $_ignore_djgpp_null_derefs, $_emusys,
       $_emuini, $_dosmem, $_full_file_locks, $_lfn_support
     checkuservar
@@ -220,6 +220,8 @@ else
     cpuemu off
   endif
   $xxx = "cpu_vm ", $_cpu_vm;
+  $$xxx
+  $xxx = "cpu_vm_dpmi ", $_cpu_vm_dpmi;
   $$xxx
   $_pm_dos_api = $_ems;		# disabling EMS disables also the translator
   if ($_ems || ($_dpmi && $_pm_dos_api))

--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -226,7 +226,7 @@ void *alias_mapping(int cap, unsigned targ, size_t mapsize, int protect, void *s
     mem_base = addr;
   update_aliasmap(addr, mapsize, (cap & MAPPING_VGAEMU) ? target : source);
   if (config.cpu_vm == CPUVM_KVM)
-    mprotect_kvm(addr, mapsize, protect);
+    mmap_kvm(cap, addr, mapsize, protect);
   Q__printf("MAPPING: %s alias created at %p\n", cap, addr);
   return addr;
 }
@@ -299,7 +299,7 @@ void *mmap_mapping(int cap, void *target, size_t mapsize, int protect, off_t sou
   }
   Q__printf("MAPPING: map success, cap=%s, addr=%p\n", cap, addr);
   if (config.cpu_vm == CPUVM_KVM)
-    mprotect_kvm(addr, mapsize, protect);
+    mmap_kvm(cap, addr, mapsize, protect);
   return addr;
 }
 
@@ -321,7 +321,7 @@ int mprotect_mapping(int cap, void *addr, size_t mapsize, int protect)
 	cap, addr, mapsize, protect);
   ret = mprotect(addr, mapsize, protect);
   if (config.cpu_vm == CPUVM_KVM)
-    mprotect_kvm(addr, mapsize, protect);
+    mprotect_kvm(cap, addr, mapsize, protect);
   if (ret)
     error("mprotect() failed: %s\n", strerror(errno));
   return ret;

--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -23,6 +23,7 @@
 #include "utilities.h"
 #include "Linux/mman.h"
 #include "mapping.h"
+#include "kvm.h"
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>

--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -493,6 +493,9 @@ int munmap_mapping(int cap, void *addr, size_t mapsize)
       return 0;
     }
 
+    if (config.cpu_vm == CPUVM_KVM)
+      munmap_kvm(cap, addr);
+
   return mappingdriver->munmap(cap, addr, mapsize);
 }
 

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -559,6 +559,12 @@ static void config_post_process(void)
 	config.cpuemu = 3;
 	c_printf("CONF: JIT CPUEMU set to 3 for %d86\n", (int)vm86s.cpu_type);
     }
+    if (config.cpu_vm_dpmi != CPUVM_EMU) {
+      if (config.cpuemu > 3 && config.cpu_vm_dpmi != -1) config.cpuemu = 3;
+    } else if (config.cpuemu < 4) {
+	config.cpuemu = 4;
+	c_printf("CONF: JIT CPUEMU set to 4 for %d86\n", (int)vm86s.cpu_type);
+    }
     if (config.rdtsc) {
 	if (config.smp) {
 		c_printf("CONF: Denying use of pentium timer on SMP machine\n");

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -553,23 +553,10 @@ static void config_post_process(void)
 	vm86s.cpu_type = config.realcpu;
 	fprintf(stderr, "CONF: emulated CPU forced down to real CPU: %d86\n",(int)vm86s.cpu_type);
     }
-    if (config.cpu_vm == -1) {
-      if (config.cpuemu)
-        config.cpu_vm = CPUVM_EMU;
-      else
-        config.cpu_vm =
-#ifdef __x86_64__
-          CPUVM_KVM
-#else
-          CPUVM_VM86
-#endif
-          ;
-    }
     if (config.cpu_vm != CPUVM_EMU) {
       config.cpuemu = 0;
     } else if (config.cpuemu == 0) {
 	config.cpuemu = 3;
-	init_emu_cpu();
 	c_printf("CONF: JIT CPUEMU set to 3 for %d86\n", (int)vm86s.cpu_type);
     }
     if (config.rdtsc) {

--- a/src/base/init/lexer.l.in
+++ b/src/base/init/lexer.l.in
@@ -416,6 +416,7 @@ vm86sim			RETURN(VM86SIM);
 fullsim			RETURN(FULLSIM);
 
 cpu_vm			RETURN(CPU_VM);
+cpu_vm_dpmi		RETURN(CPU_VM_DPMI);
 kvm			RETURN(KVM);
 
 	/* disk keywords */

--- a/src/base/init/parser.y.in
+++ b/src/base/init/parser.y.in
@@ -251,7 +251,7 @@ while (0)
 	/* speaker */
 %token EMULATED NATIVE
 	/* cpuemu */
-%token CPUEMU CPU_VM VM86 FULL VM86SIM FULLSIM KVM
+%token CPUEMU CPU_VM CPU_VM_DPMI VM86 FULL VM86SIM FULLSIM KVM
 	/* keyboard */
 %token RAWKEYBOARD
 %token PRESTROKE
@@ -318,7 +318,7 @@ while (0)
 	/* %expect 1 */
 
 %type <i_value> int_bool irq_bool bool speaker floppy_bool cpuemu
-%type <i_value> cpu_vm
+%type <i_value> cpu_vm cpu_vm_dpmi
 
 %%
 
@@ -471,6 +471,12 @@ line		: HOGTHRESH expression	{ config.hogthreshold = $2; }
 			{
 			config.cpu_vm = $2;
 			c_printf("CONF: CPU VM set to %d\n", config.cpu_vm);
+			}
+		| CPU_VM_DPMI cpu_vm_dpmi
+			{
+			config.cpu_vm_dpmi = $2;
+			c_printf("CONF: CPU VM set to %d for DPMI\n",
+				 config.cpu_vm_dpmi);
 			}
 		| CPUEMU cpuemu
 			{
@@ -1719,6 +1725,15 @@ cpu_vm		: L_AUTO	{ $$ = -1; }
 		| STRING        { yyerror("got '%s' for cpu_vm", $1);
 				  free($1); }
 		| error         { yyerror("bad value for cpu_vm"); }
+		;
+
+cpu_vm_dpmi	: L_AUTO	{ $$ = -1; }
+		| NATIVE	{ $$ = CPUVM_NATIVE; }
+		| KVM		{ $$ = CPUVM_KVM; }
+		| EMULATED	{ $$ = CPUVM_EMU; }
+		| STRING        { yyerror("got '%s' for cpu_vm_dpmi", $1);
+				  free($1); }
+		| error         { yyerror("bad value for cpu_vm_dpmi"); }
 		;
 
 %%

--- a/src/emu-i386/cpu.c
+++ b/src/emu-i386/cpu.c
@@ -323,6 +323,13 @@ void cpu_setup(void)
 	;
   }
 
+  if (config.cpu_vm_dpmi == -1) {
+    if (config.cpuemu > 3)
+      config.cpu_vm_dpmi = CPUVM_EMU;
+    else
+      config.cpu_vm_dpmi = CPUVM_NATIVE;
+  }
+
   if (config.cpu_vm == CPUVM_KVM && !init_kvm_cpu()) {
     if (orig_cpu_vm == -1) {
       warn("KVM not available: %s\n", strerror(errno));

--- a/src/emu-i386/cpu.c
+++ b/src/emu-i386/cpu.c
@@ -31,6 +31,7 @@
 #include "int.h"
 #include "dpmi.h"
 #include "priv.h"
+#include "kvm.h"
 
 #ifdef X86_EMULATOR
 #include "simx86/syncpu.h"
@@ -289,6 +290,7 @@ static void fpu_io_write(ioport_t port, Bit8u val)
 void cpu_setup(void)
 {
   emu_iodev_t io_dev;
+  int orig_cpu_vm = config.cpu_vm;
   io_dev.read_portb = fpu_io_read;
   io_dev.write_portb = fpu_io_write;
   io_dev.read_portw = NULL;
@@ -308,8 +310,54 @@ void cpu_setup(void)
   savefpstate(vm86_fpu_state);
   fpu_reset();
 
+  if (config.cpu_vm == -1) {
+    if (config.cpuemu)
+      config.cpu_vm = CPUVM_EMU;
+    else
+      config.cpu_vm =
+#ifdef __x86_64__
+	CPUVM_KVM
+#else
+	CPUVM_VM86
+#endif
+	;
+  }
+
+  if (config.cpu_vm == CPUVM_KVM && !init_kvm_cpu()) {
+    if (orig_cpu_vm == -1) {
+      warn("KVM not available: %s\n", strerror(errno));
+    } else {
+      error("KVM not available: %s\n", strerror(errno));
+    }
+    config.cpu_vm = CPUVM_EMU;
+  }
+
+#ifdef __i386__
+  if (config.cpu_vm == CPUVM_VM86) {
+//    if (!vm86_plus(VM86_PLUS_INSTALL_CHECK,0)) return;
+    if (syscall(SYS_vm86old, (void *)VM86_PLUS_INSTALL_CHECK) != -1 ||
+		errno != EFAULT) {
+      if (orig_cpu_vm == CPUVM_VM86) {
+        error("vm86 service not available in your kernel, %s\n", strerror(errno));
+      }
+#ifdef X86_EMULATOR
+      config.cpu_vm = CPUVM_EMU;
+#else
+      exit(1);
+#endif
+    }
+  }
+#endif
+
 #ifdef X86_EMULATOR
   if (config.cpu_vm == CPUVM_EMU) {
+    if (orig_cpu_vm != CPUVM_EMU) {
+      config.cpuemu = 3;
+      if (orig_cpu_vm == -1)
+	warn("using CPU emulation for vm86()\n");
+      else
+	error("using CPU emulation for vm86()\n");
+    }
     init_emu_cpu();
   }
 #endif

--- a/src/emu-i386/do_vm86.c
+++ b/src/emu-i386/do_vm86.c
@@ -561,42 +561,11 @@ void do_int_call_back(int intno)
     __do_call_back(ISEG(intno), IOFF(intno), 1);
 }
 
-static void vm86plus_init(void)
-{
-#ifdef X86_EMULATOR
-    if (config.cpu_vm == CPUVM_EMU && config.cpuemu >= 3)
-	return;
-#endif
-    if (config.cpu_vm == CPUVM_KVM)
-	return;
-#ifdef __i386__
-//    if (!vm86_plus(VM86_PLUS_INSTALL_CHECK,0)) return;
-    if (syscall(SYS_vm86old, (void *)VM86_PLUS_INSTALL_CHECK) == -1 &&
-		errno == EFAULT)
-	return;
-#endif
-#ifdef X86_EMULATOR
-#ifdef __i386__
-    error("vm86 service not available in your kernel, %s\n", strerror(errno));
-    error("using CPU emulation for vm86()\n");
-#endif
-    if (config.cpu_vm == CPUVM_VM86 && config.cpuemu < 3) {
-	config.cpu_vm = CPUVM_EMU;
-	config.cpuemu = 3;
-	init_emu_cpu();
-    }
-    return;
-#endif
-    fprintf(stderr, "vm86plus service not available in your kernel\n\r");
-    exit(1);
-}
-
 int vm86_init(void)
 {
     emu_hlt_t hlt_hdlr = HLT_INITIALIZER;
     hlt_hdlr.name = "do_call_back";
     hlt_hdlr.func = callback_return;
     CBACK_OFF = hlt_register_handler(hlt_hdlr);
-    vm86plus_init();
     return 0;
 }

--- a/src/emu-i386/do_vm86.c
+++ b/src/emu-i386/do_vm86.c
@@ -49,6 +49,7 @@
 #ifdef X86_EMULATOR
 #include "cpu-emu.h"
 #endif
+#include "kvm.h"
 
 #include "video.h"
 

--- a/src/emu-i386/kvm.c
+++ b/src/emu-i386/kvm.c
@@ -172,7 +172,7 @@ static void enter_vm86(int vmfd, int vcpufd)
   sregs.idt.limit = IDT_ENTRIES * sizeof(Gatedesc)-1;
   // setup IDT
   for (i=0; i<IDT_ENTRIES; i++) {
-    unsigned int offs = sregs.tr.base + offsetof(struct monitor, code) + i * 10;
+    unsigned int offs = sregs.tr.base + offsetof(struct monitor, code) + i * 16;
     monitor->idt[i].offs_lo = offs & 0xffff;
     monitor->idt[i].offs_hi = offs >> 16;
     monitor->idt[i].seg = 0x8; // FLAT_CODE_SEL
@@ -574,9 +574,9 @@ int kvm_vm86(struct vm86_struct *info)
   do {
     kvm_run(regs);
 
-    /* __null_gs = exception number */
-    /* orig_eax = error code */
-    trapno = regs->__null_gs;
+    /* high word(orig_eax) = exception number */
+    /* low word(orig_eax) = error code */
+    trapno = regs->orig_eax >> 16;
     vm86_ret = VM86_SIGNAL;
     if (trapno == 1 || trapno == 3)
       vm86_ret = VM86_TRAP | (trapno << 8);
@@ -585,12 +585,12 @@ int kvm_vm86(struct vm86_struct *info)
   } while (vm86_ret == -1);
 
   info->regs = *regs;
-  trapno = regs->__null_gs;
+  trapno = regs->orig_eax >> 16;
   if (vm86_ret == VM86_SIGNAL && trapno != 0x20) {
     struct sigcontext sc, *scp = &sc;
     _cr2 = (uintptr_t)MEM_BASE32(monitor->cr2);
     _trapno = trapno;
-    _err = regs->orig_eax;
+    _err = regs->orig_eax & 0xffff;
     _dosemu_fault(SIGSEGV, scp);
   }
   return vm86_ret;

--- a/src/emu-i386/kvm.c
+++ b/src/emu-i386/kvm.c
@@ -456,28 +456,13 @@ static int kvm_handle_vm86_fault(struct vm86_regs *regs, unsigned int cpu_type)
   return ret;
 }
 
-/* Emulate vm86() using KVM */
-int kvm_vm86(struct vm86_struct *info)
+/* Inner loop for KVM, runs until HLT */
+static void kvm_run(struct vm86_regs *regs)
 {
-  struct vm86_regs *regs;
-  int ret, vm86_ret;
-  unsigned int exit_reason, trapno;
-
-  if (!monitor) {
-    monitor = enter_vm86(vmfd, vcpufd);
-    warn("Using V86 mode inside KVM\n");
-  }
-
-  regs = &monitor->regs;
-  *regs = info->regs;
-  monitor->int_revectored = info->int_revectored;
-
-  regs->eflags &= (SAFE_MASK | X86_EFLAGS_VIF | X86_EFLAGS_VIP);
-  regs->eflags |= X86_EFLAGS_FIXED | X86_EFLAGS_VM | X86_EFLAGS_IF;
+  unsigned int exit_reason;
 
   do {
-    vm86_ret = -1;
-    ret = ioctl(vcpufd, KVM_RUN, NULL);
+    int ret = ioctl(vcpufd, KVM_RUN, NULL);
 
     /* KVM should only exit for three reasons:
        1. KVM_EXIT_HLT: at the hlt in kvmmon.S.
@@ -498,17 +483,8 @@ int kvm_vm86(struct vm86_struct *info)
     }
 
     switch (exit_reason) {
-    case KVM_EXIT_HLT: {
-      /* __null_gs = exception number */
-      /* orig_eax = error code */
-      trapno = regs->__null_gs;
-      vm86_ret = VM86_SIGNAL;
-      if (trapno == 1 || trapno == 3)
-	vm86_ret = VM86_TRAP | (trapno << 8);
-      else if (trapno == 0xd)
-	vm86_ret = kvm_handle_vm86_fault(regs, info->cpu_type);
+    case KVM_EXIT_HLT:
       break;
-    }
     case KVM_EXIT_IRQ_WINDOW_OPEN:
     case KVM_EXIT_INTR:
       run->request_interrupt_window = !run->ready_for_interrupt_injection;
@@ -534,7 +510,39 @@ int kvm_vm86(struct vm86_struct *info)
       fprintf(stderr, "KVM: exit_reason = 0x%x\n", exit_reason);
       leavedos(99);
     }
+  } while (exit_reason != KVM_EXIT_HLT);
+}
 
+/* Emulate vm86() using KVM */
+int kvm_vm86(struct vm86_struct *info)
+{
+  struct vm86_regs *regs;
+  int vm86_ret;
+  unsigned int trapno;
+
+  if (!monitor) {
+    monitor = enter_vm86(vmfd, vcpufd);
+    warn("Using V86 mode inside KVM\n");
+  }
+
+  regs = &monitor->regs;
+  *regs = info->regs;
+  monitor->int_revectored = info->int_revectored;
+
+  regs->eflags &= (SAFE_MASK | X86_EFLAGS_VIF | X86_EFLAGS_VIP);
+  regs->eflags |= X86_EFLAGS_FIXED | X86_EFLAGS_VM | X86_EFLAGS_IF;
+
+  do {
+    kvm_run(regs);
+
+    /* __null_gs = exception number */
+    /* orig_eax = error code */
+    trapno = regs->__null_gs;
+    vm86_ret = VM86_SIGNAL;
+    if (trapno == 1 || trapno == 3)
+      vm86_ret = VM86_TRAP | (trapno << 8);
+    else if (trapno == 0xd)
+      vm86_ret = kvm_handle_vm86_fault(regs, info->cpu_type);
   } while (vm86_ret == -1);
 
   info->regs = *regs;

--- a/src/emu-i386/kvm.c
+++ b/src/emu-i386/kvm.c
@@ -112,35 +112,18 @@ static struct monitor {
 } *monitor;
 
 static struct kvm_run *run;
-static int vmfd, vcpufd;
+static int vmfd, vcpufd, kvm_map_slot;
 
 /* switches KVM virtual machine to vm86 mode */
-static struct monitor *enter_vm86(int vmfd, int vcpufd)
+static void enter_vm86(int vmfd, int vcpufd)
 {
-  int ret, i, j;
+  int ret, i;
+  unsigned int page;
   struct kvm_regs regs;
   struct kvm_sregs sregs;
-  struct monitor *monitor;
 
-  struct kvm_userspace_memory_region region = {
-    .slot = 0,
-    .guest_phys_addr = 0x0,
-    .memory_size = LOWMEM_SIZE + HMASIZE,
-    .userspace_addr = (uint64_t)(unsigned long)mem_base,
-  };
-
-  /* Map guest memory: only conventional memory + HMA for now */
-  ret = ioctl(vmfd, KVM_SET_USER_MEMORY_REGION, &region);
-  if (ret == -1) {
-    perror("KVM: KVM_SET_USER_MEMORY_REGION");
-    leavedos(99);
-  }
-
-  /* create monitor structure in memory */
-  monitor = mmap(NULL, sizeof(*monitor), PROT_READ | PROT_WRITE,
-		 MAP_SHARED | MAP_ANONYMOUS, -1, 0);
   struct kvm_userspace_memory_region tss_region = {
-    .slot = 1,
+    .slot = kvm_map_slot++,
     .guest_phys_addr = LOWMEM_SIZE + HMASIZE,
     .memory_size = sizeof(*monitor),
     .userspace_addr = (uint64_t)(unsigned long)monitor,
@@ -153,7 +136,6 @@ static struct monitor *enter_vm86(int vmfd, int vcpufd)
     leavedos(99);
   }
 
-  memset(monitor, 0, sizeof(*monitor));
   /* trap all I/O instructions with GPF */
   memset(monitor->io_bitmap, 0xff, TSS_IOPB_SIZE+1);
 
@@ -214,11 +196,11 @@ static struct monitor *enter_vm86(int vmfd, int vcpufd)
   /* we need one page directory entry */
   monitor->pde[0] = (sregs.tr.base + offsetof(struct monitor, pte))
     | (PG_PRESENT | PG_RW | PG_USER);
-  for (i = 0; i < (LOWMEM_SIZE + HMASIZE) / PAGE_SIZE; i++)
-    monitor->pte[i] = i * PAGE_SIZE | (PG_PRESENT | PG_RW | PG_USER);
-  for (j = 0; j < offsetof(struct monitor, code) / PAGE_SIZE; j++)
-    monitor->pte[i+j] = (i+j) * PAGE_SIZE | PG_PRESENT | PG_RW;
-  monitor->pte[i+j] = ((i+j) * PAGE_SIZE) | PG_PRESENT;
+  for (page = sregs.tr.base / PAGE_SIZE;
+       page < (sregs.tr.base + offsetof(struct monitor, code)) / PAGE_SIZE;
+       page++)
+    monitor->pte[page] = page * PAGE_SIZE | PG_PRESENT | PG_RW;
+  monitor->pte[page] = (page * PAGE_SIZE) | PG_PRESENT;
 
   sregs.cr0 |= X86_CR0_PE | X86_CR0_PG;
   sregs.cr4 |= X86_CR4_VME;
@@ -252,8 +234,6 @@ static struct monitor *enter_vm86(int vmfd, int vcpufd)
     perror("KVM: KVM_SET_REGS");
     leavedos(99);
   }
-
-  return monitor;
 }
 
 /* Initialize KVM and memory mappings */
@@ -323,26 +303,83 @@ int init_kvm_cpu(void)
     return 0;
   }
 
+  /* create monitor structure in memory */
+  monitor = mmap(NULL, sizeof(*monitor), PROT_READ | PROT_WRITE,
+		 MAP_SHARED | MAP_ANONYMOUS, -1, 0);
   return 1;
 }
 
-void mprotect_kvm(void *addr, size_t mapsize, int protect)
+void mmap_kvm(int cap, void *addr, size_t mapsize, int protect)
 {
-  size_t pagesize = sysconf(_SC_PAGESIZE);
-  unsigned int start = DOSADDR_REL(addr) / pagesize;
-  unsigned int end = start + mapsize / pagesize;
-  unsigned int limit = (LOWMEM_SIZE + HMASIZE) / pagesize;
+  int ret;
   unsigned int page;
+  size_t pagesize = sysconf(_SC_PAGESIZE);
+  uintptr_t alignaddr = (uintptr_t)addr & ~(pagesize-1);
+  uintptr_t alignend = ((uintptr_t)addr + mapsize + pagesize-1) & ~(pagesize-1);
+  unsigned int start = DOSADDR_REL((unsigned char *)alignaddr) / pagesize;
+  unsigned int end = DOSADDR_REL((unsigned char *)alignend) / pagesize;
+  unsigned int limit = (LOWMEM_SIZE + HMASIZE) / pagesize;
+  struct kvm_userspace_memory_region region = {
+    .slot = kvm_map_slot++,
+    .guest_phys_addr = start * pagesize,
+    .memory_size = alignend - alignaddr,
+    .userspace_addr = alignaddr,
+  };
 
   if (start >= limit || monitor == NULL) return;
   if (end > limit) end = limit;
 
+  if (!(cap & (MAPPING_INIT_LOWRAM|MAPPING_LOWMEM|MAPPING_EMS|MAPPING_HMA|
+	       MAPPING_VGAEMU)))
+    return;
+
+  if (monitor->pte[start]) {
+    mprotect_kvm(cap, addr, mapsize, protect);
+    return;
+  }
+
+  Q_printf("KVM: mapping %p:%zx to %llx for slot %d with prot %x\n", addr,
+	   mapsize, region.guest_phys_addr, region.slot, protect);
+
+  ret = ioctl(vmfd, KVM_SET_USER_MEMORY_REGION, &region);
+  if (ret == -1) {
+    perror("KVM: KVM_SET_USER_MEMORY_REGION");
+    leavedos(99);
+  }
+
+  /* adjust paging structures in VM */
+  for (page = start; page < end; page++)
+    monitor->pte[page] = (page * pagesize) | PG_USER;
+  if (cap & MAPPING_INIT_LOWRAM)
+    cap |= MAPPING_LOWMEM;
+  mprotect_kvm(cap, addr, mapsize, protect);
+}
+
+void mprotect_kvm(int cap, void *addr, size_t mapsize, int protect)
+{
+  unsigned int page;
+  size_t pagesize = sysconf(_SC_PAGESIZE);
+  uintptr_t alignaddr = (uintptr_t)addr & ~(pagesize-1);
+  uintptr_t alignend = ((uintptr_t)addr + mapsize + pagesize-1) & ~(pagesize-1);
+  unsigned int start = DOSADDR_REL((unsigned char *)alignaddr) / pagesize;
+  unsigned int end = DOSADDR_REL((unsigned char *)alignend) / pagesize;
+  unsigned int limit = (LOWMEM_SIZE + HMASIZE) / pagesize;
+
+  if (start >= limit || monitor == NULL) return;
+  if (end > limit) end = limit;
+
+  if (!(cap & (MAPPING_LOWMEM|MAPPING_EMS|MAPPING_HMA|MAPPING_VGAEMU)))
+    return;
+
+  Q_printf("KVM: protecting %p:%zx to %zx with prot %x\n", addr,
+	   mapsize, start * pagesize, protect);
+
   for (page = start; page < end; page++) {
-    monitor->pte[page] &= ~(PG_PRESENT | PG_RW | PG_USER);
+    monitor->pte[page] &= ~(PG_PRESENT | PG_RW);
     if (protect & PROT_WRITE)
-      monitor->pte[page] |= PG_PRESENT | PG_RW | PG_USER;
+      monitor->pte[page] |= PG_PRESENT | PG_RW;
     else if (protect & PROT_READ)
-      monitor->pte[page] |= PG_PRESENT | PG_USER;
+      monitor->pte[page] |= PG_PRESENT;
   }
 }
 
@@ -519,10 +556,12 @@ int kvm_vm86(struct vm86_struct *info)
   struct vm86_regs *regs;
   int vm86_ret;
   unsigned int trapno;
+  static int first = 1;
 
-  if (!monitor) {
-    monitor = enter_vm86(vmfd, vcpufd);
+  if (first) {
+    enter_vm86(vmfd, vcpufd);
     warn("Using V86 mode inside KVM\n");
+    first = 0;
   }
 
   regs = &monitor->regs;

--- a/src/emu-i386/kvmmon.S
+++ b/src/emu-i386/kvmmon.S
@@ -43,7 +43,10 @@ kvm_mon_start:
         .endr
 
 kvm_mon_main:
-        sub $0x10,%esp
+        push %gs
+        push %fs
+        push %es
+        push %ds
         push %eax
         push %ebp
         push %edi
@@ -64,7 +67,11 @@ kvm_mon_hlt:
         pop %edi
         pop %ebp
         pop %eax
-        add $0x14,%esp
+        pop %ds
+        pop %es
+        pop %fs
+        pop %gs
+        add $0x4,%esp
         iret
 
 	.globl kvm_mon_end

--- a/src/emu-i386/kvmmon.S
+++ b/src/emu-i386/kvmmon.S
@@ -36,14 +36,14 @@ kvm_mon_start:
         /* push fake error code for consistent stack */
         pushl $0
         .endif
-        pushl $i
+        movw $i,2(%esp)
         jmp kvm_mon_main
         i = i + 1
-        .fill kvm_mon_start+10*i-., 1, 0x90
+        .fill kvm_mon_start+16*i-., 1, 0x90
         .endr
 
 kvm_mon_main:
-        sub $0xc,%esp
+        sub $0x10,%esp
         push %eax
         push %ebp
         push %edi

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -176,6 +176,7 @@ typedef struct config_info {
        boolean cpusim;
 #endif
        int cpu_vm;
+       int cpu_vm_dpmi;
        int CPUSpeedInMhz;
        /* for video */
        int console_video;
@@ -350,7 +351,7 @@ typedef struct config_info {
 
 
 enum { SPKR_OFF, SPKR_NATIVE, SPKR_EMULATED };
-enum { CPUVM_VM86, CPUVM_KVM, CPUVM_EMU };
+enum { CPUVM_VM86, CPUVM_KVM, CPUVM_EMU, CPUVM_NATIVE };
 
 /*
  * Right now, dosemu only supports two serial ports.

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -46,7 +46,6 @@ struct eflags_fs_gs {
 extern struct eflags_fs_gs eflags_fs_gs;
 
 int vm86_init(void);
-int kvm_vm86(struct vm86_struct *info);
 #ifdef __i386__
 #define vm86(param) syscall(SYS_vm86old, param)
 #define vm86_plus(function,param) syscall(SYS_vm86, function, param)

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -1,0 +1,27 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#ifndef KVM_H
+#define KVM_H
+
+#include "emu.h"
+
+/* kvm functions */
+int init_kvm_cpu(void);
+int kvm_vm86(struct vm86_struct *info);
+void mprotect_kvm(void *addr, size_t mapsize, int protect);
+
+#endif

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -24,6 +24,7 @@ int init_kvm_cpu(void);
 int kvm_vm86(struct vm86_struct *info);
 int kvm_dpmi(struct sigcontext *scp);
 void mmap_kvm(int cap, void *addr, size_t mapsize, int protect);
+void munmap_kvm(int cap, void *addr);
 void mprotect_kvm(int cap, void *addr, size_t mapsize, int protect);
 
 #endif

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -22,6 +22,7 @@
 /* kvm functions */
 int init_kvm_cpu(void);
 int kvm_vm86(struct vm86_struct *info);
+int kvm_dpmi(struct sigcontext *scp);
 void mmap_kvm(int cap, void *addr, size_t mapsize, int protect);
 void mprotect_kvm(int cap, void *addr, size_t mapsize, int protect);
 

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -22,6 +22,7 @@
 /* kvm functions */
 int init_kvm_cpu(void);
 int kvm_vm86(struct vm86_struct *info);
-void mprotect_kvm(void *addr, size_t mapsize, int protect);
+void mmap_kvm(int cap, void *addr, size_t mapsize, int protect);
+void mprotect_kvm(int cap, void *addr, size_t mapsize, int protect);
 
 #endif

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -78,7 +78,6 @@ typedef int munmap_mapping_type(int cap, void *addr, size_t mapsize);
 int munmap_mapping (int cap, void *addr, size_t mapsize);
 
 int mprotect_mapping(int cap, void *addr, size_t mapsize, int protect);
-void mprotect_kvm(void *addr, size_t mapsize, int protect);
 
 void *extended_mremap(void *addr, size_t old_len, size_t new_len,
        int flags, void * new_addr);


### PR DESCRIPTION
This fixes cpu_vm="auto" if KVM is not available (because of kernel
CPU, or BIOS). The fallback code has been mostly consolidated into
cpu.c, and KVM functions are defined in a new header kvm.h.