### PR TITLE
Auto-detect KVM, and fall back to CPUEMU if not available.

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -23,6 +23,7 @@
 #include "utilities.h"
 #include "Linux/mman.h"
 #include "mapping.h"
+#include "kvm.h"
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -553,23 +553,10 @@ static void config_post_process(void)
 	vm86s.cpu_type = config.realcpu;
 	fprintf(stderr, "CONF: emulated CPU forced down to real CPU: %d86\n",(int)vm86s.cpu_type);
     }
-    if (config.cpu_vm == -1) {
-      if (config.cpuemu)
-        config.cpu_vm = CPUVM_EMU;
-      else
-        config.cpu_vm =
-#ifdef __x86_64__
-          CPUVM_KVM
-#else
-          CPUVM_VM86
-#endif
-          ;
-    }
     if (config.cpu_vm != CPUVM_EMU) {
       config.cpuemu = 0;
     } else if (config.cpuemu == 0) {
 	config.cpuemu = 3;
-	init_emu_cpu();
 	c_printf("CONF: JIT CPUEMU set to 3 for %d86\n", (int)vm86s.cpu_type);
     }
     if (config.rdtsc) {

--- a/src/emu-i386/cpu.c
+++ b/src/emu-i386/cpu.c
@@ -31,6 +31,7 @@
 #include "int.h"
 #include "dpmi.h"
 #include "priv.h"
+#include "kvm.h"
 
 #ifdef X86_EMULATOR
 #include "simx86/syncpu.h"
@@ -289,6 +290,7 @@ static void fpu_io_write(ioport_t port, Bit8u val)
 void cpu_setup(void)
 {
   emu_iodev_t io_dev;
+  int orig_cpu_vm = config.cpu_vm;
   io_dev.read_portb = fpu_io_read;
   io_dev.write_portb = fpu_io_write;
   io_dev.read_portw = NULL;
@@ -308,8 +310,54 @@ void cpu_setup(void)
   savefpstate(vm86_fpu_state);
   fpu_reset();
 
+  if (config.cpu_vm == -1) {
+    if (config.cpuemu)
+      config.cpu_vm = CPUVM_EMU;
+    else
+      config.cpu_vm =
+#ifdef __x86_64__
+	CPUVM_KVM
+#else
+	CPUVM_VM86
+#endif
+	;
+  }
+
+  if (config.cpu_vm == CPUVM_KVM && !init_kvm_cpu()) {
+    if (orig_cpu_vm == -1) {
+      warn("KVM not available: %s\n", strerror(errno));
+    } else {
+      error("KVM not available: %s\n", strerror(errno));
+    }
+    config.cpu_vm = CPUVM_EMU;
+  }
+
+#ifdef __i386__
+  if (config.cpu_vm == CPUVM_VM86) {
+//    if (!vm86_plus(VM86_PLUS_INSTALL_CHECK,0)) return;
+    if (syscall(SYS_vm86old, (void *)VM86_PLUS_INSTALL_CHECK) != -1 ||
+		errno != EFAULT) {
+      if (orig_cpu_vm == CPUVM_VM86) {
+        error("vm86 service not available in your kernel, %s\n", strerror(errno));
+      }
+#ifdef X86_EMULATOR
+      config.cpu_vm = CPUVM_EMU;
+#else
+      exit(1);
+#endif
+    }
+  }
+#endif
+
 #ifdef X86_EMULATOR
   if (config.cpu_vm == CPUVM_EMU) {
+    if (orig_cpu_vm != CPUVM_EMU) {
+      config.cpuemu = 3;
+      if (orig_cpu_vm == -1)
+	warn("using CPU emulation for vm86()\n");
+      else
+	error("using CPU emulation for vm86()\n");
+    }
     init_emu_cpu();
   }
 #endif

--- a/src/emu-i386/do_vm86.c
+++ b/src/emu-i386/do_vm86.c
@@ -49,6 +49,7 @@
 #ifdef X86_EMULATOR
 #include "cpu-emu.h"
 #endif
+#include "kvm.h"
 
 #include "video.h"
 
@@ -561,42 +562,11 @@ void do_int_call_back(int intno)
     __do_call_back(ISEG(intno), IOFF(intno), 1);
 }
 
-static void vm86plus_init(void)
-{
-#ifdef X86_EMULATOR
-    if (config.cpu_vm == CPUVM_EMU && config.cpuemu >= 3)
-	return;
-#endif
-    if (config.cpu_vm == CPUVM_KVM)
-	return;
-#ifdef __i386__
-//    if (!vm86_plus(VM86_PLUS_INSTALL_CHECK,0)) return;
-    if (syscall(SYS_vm86old, (void *)VM86_PLUS_INSTALL_CHECK) == -1 &&
-		errno == EFAULT)
-	return;
-#endif
-#ifdef X86_EMULATOR
-#ifdef __i386__
-    error("vm86 service not available in your kernel, %s\n", strerror(errno));
-    error("using CPU emulation for vm86()\n");
-#endif
-    if (config.cpu_vm == CPUVM_VM86 && config.cpuemu < 3) {
-	config.cpu_vm = CPUVM_EMU;
-	config.cpuemu = 3;
-	init_emu_cpu();
-    }
-    return;
-#endif
-    fprintf(stderr, "vm86plus service not available in your kernel\n\r");
-    exit(1);
-}
-
 int vm86_init(void)
 {
     emu_hlt_t hlt_hdlr = HLT_INITIALIZER;
     hlt_hdlr.name = "do_call_back";
     hlt_hdlr.func = callback_return;
     CBACK_OFF = hlt_register_handler(hlt_hdlr);
-    vm86plus_init();
     return 0;
 }

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -46,7 +46,6 @@ struct eflags_fs_gs {
 extern struct eflags_fs_gs eflags_fs_gs;
 
 int vm86_init(void);
-int kvm_vm86(struct vm86_struct *info);
 #ifdef __i386__
 #define vm86(param) syscall(SYS_vm86old, param)
 #define vm86_plus(function,param) syscall(SYS_vm86, function, param)

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -1,0 +1,27 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#ifndef KVM_H
+#define KVM_H
+
+#include "emu.h"
+
+/* kvm functions */
+int init_kvm_cpu(void);
+int kvm_vm86(struct vm86_struct *info);
+void mprotect_kvm(void *addr, size_t mapsize, int protect);
+
+#endif

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -78,7 +78,6 @@ typedef int munmap_mapping_type(int cap, void *addr, size_t mapsize);
 int munmap_mapping (int cap, void *addr, size_t mapsize);
 
 int mprotect_mapping(int cap, void *addr, size_t mapsize, int protect);
-void mprotect_kvm(void *addr, size_t mapsize, int protect);
 
 void *extended_mremap(void *addr, size_t old_len, size_t new_len,
        int flags, void * new_addr);


### PR DESCRIPTION
This fixes cpu_vm="auto" if KVM is not available (because of kernel
CPU, or BIOS). The fallback code has been mostly consolidated into
cpu.c, and KVM functions are defined in a new header kvm.h.