### PR TITLE
In CPU tests use the same selectors (0xf/0x17) for DJGPP as for Linux.

### DIFF
--- a/src/tests/test-i386-code16.S
+++ b/src/tests/test-i386-code16.S
@@ -2,11 +2,7 @@
         .globl code16_start
         .globl code16_end
 
-#ifdef __DJGPP__
-CS_SEG = 0x10f
-#else
 CS_SEG = 0xf
-#endif
 
 code16_start:
 

--- a/src/tests/test-i386.c
+++ b/src/tests/test-i386.c
@@ -1261,8 +1261,6 @@ static inline int modify_ldt(int func, void * ptr, unsigned long bytecount)
 #define user_desc modify_ldt_ldt_s
 #endif
 
-#define MK_SEL(n) (((n) << 3) | 7)
-
 #endif
 
 #ifdef __DJGPP__
@@ -1270,9 +1268,9 @@ static inline int modify_ldt(int func, void * ptr, unsigned long bytecount)
 #include <dpmi.h>
 #include <sys/segments.h>
 
-#define MK_SEL(n) (((n+0x20) << 3) | 7)
-
 #endif
+
+#define MK_SEL(n) (((n) << 3) | 7)
 
 uint8_t seg_data1[4096];
 uint8_t seg_data2[4096];


### PR DESCRIPTION
This is possible because the first 16 selector entries are reserved
for the "Allocate Specific LDT Descriptor" DPMI function.
The old way of using selectors 0x10f/0x117 no longer works because
DOSEMU now uses more selectors itself.