### PR TITLE
Jazz jackrabbit fixes

### DIFF
--- a/src/include/cpu.h
+++ b/src/include/cpu.h
@@ -312,8 +312,9 @@ static __inline__ void reset_revectored(int nr, struct revectored_struct * bitma
 #define isset_VIP()   ((_EFLAGS & VIP) != 0)
 
 #define set_EFLAGS(flgs, new_flgs) ({ \
-  int __nflgs = (new_flgs) & ~(VIP | VIF); \
-  (flgs) = (__nflgs) | IF | IOPL_MASK | ((__nflgs & IF) ? VIF : 0); \
+  int __nflgs = (new_flgs); \
+  (flgs)=(__nflgs) | IF | IOPL_MASK; \
+  ((__nflgs & IF) ? set_IF() : clear_IF()); \
 })
 #define set_FLAGS(flags) set_EFLAGS(_FLAGS, flags)
 #define get_EFLAGS(flags) ({ \


### PR DESCRIPTION
While working on PR #114 I decided to test with Jazz Jackrabbit which did not work so I went on to fix that first.

Perhaps we should have a SEL_DOS_ADR_CLNT in dpmi.c to avoid needing to do DOSADDR_REL(MEM_BASE32(p))?

In the end I think dosaddr_t is the correct type for most things in msdos.c so a bigger cleanup would be to have SEL_ADR_CLNT return a dosaddr_t everywhere. It just means we can't use snprintf any more.

For now this is just the minimum to fix the rabbit game.