### PR TITLE
 Dpmi use pool mem only

### DIFF
--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -3147,10 +3147,16 @@ void dpmi_setup(void)
 		    DPMI_SEL_OFF(DPMI_sel_code_end)-1, 1,
                   MODIFY_LDT_CONTENTS_CODE, 0, 0, 0, 0)) goto err;
 
-    if (SetSelector(dpmi_data_sel16, DOSADDR_REL(DPMI_sel_data_start),
+    block = DPMI_malloc(host_pm_block_root,
+			PAGE_ALIGN(DPMI_sel_data_end-DPMI_sel_data_start));
+    if (block == NULL) {
+      error("DPMI: can't allocate memory for DPMI host helper data\n");
+      goto err2;
+    }
+    if (SetSelector(dpmi_data_sel16, block->base,
 		    DPMI_DATA_OFF(DPMI_sel_data_end)-1, 0,
                   MODIFY_LDT_CONTENTS_DATA, 0, 0, 0, 0)) goto err;
-    if (SetSelector(dpmi_data_sel32, DOSADDR_REL(DPMI_sel_data_start),
+    if (SetSelector(dpmi_data_sel32, block->base,
 		    DPMI_DATA_OFF(DPMI_sel_data_end)-1, 1,
                   MODIFY_LDT_CONTENTS_DATA, 0, 0, 0, 0)) goto err;
 

--- a/src/dosext/dpmi/dpmi.h
+++ b/src/dosext/dpmi/dpmi.h
@@ -111,7 +111,7 @@ struct DPMIclient_struct {
   dpmi_pm_block_root *pm_block_root;
   unsigned short private_data_segment;
   int in_dpmi_rm_stack;
-  unsigned char *pm_stack;
+  dpmi_pm_block *pm_stack;
   int in_dpmi_pm_stack;
   /* for real mode call back, DPMI function 0x303 0x304 */
   RealModeCallBack realModeCallBack[0x10];

--- a/src/dosext/dpmi/memory.c
+++ b/src/dosext/dpmi/memory.c
@@ -142,7 +142,8 @@ int dpmi_alloc_pool(void)
     num_pages = (config.dpmi >> 2) +
       ((DPMI_pm_stack_size * DPMI_MAX_CLIENTS) >> PAGE_SHIFT) +
       (PAGE_ALIGN(LDT_ENTRIES*LDT_ENTRY_SIZE) >> PAGE_SHIFT) +
-      (PAGE_ALIGN(DPMI_sel_code_end-DPMI_sel_code_start) >> PAGE_SHIFT);
+      (PAGE_ALIGN(DPMI_sel_code_end-DPMI_sel_code_start) >> PAGE_SHIFT) +
+      (PAGE_ALIGN(DPMI_sel_data_end-DPMI_sel_data_start) >> PAGE_SHIFT);
     mpool_numpages = num_pages + 5;  /* 5 extra pages */
     memsize = mpool_numpages << PAGE_SHIFT;
 

--- a/src/dosext/dpmi/memory.c
+++ b/src/dosext/dpmi/memory.c
@@ -33,6 +33,7 @@
 #include "smalloc.h"
 #include "dmemory.h"
 #include "dpmi.h"
+#include "dpmisel.h"
 
 #ifndef PAGE_SHIFT
 #define PAGE_SHIFT		12
@@ -140,7 +141,8 @@ int dpmi_alloc_pool(void)
     /* Create DPMI pool */
     num_pages = (config.dpmi >> 2) +
       ((DPMI_pm_stack_size * DPMI_MAX_CLIENTS) >> PAGE_SHIFT) +
-      (PAGE_ALIGN(LDT_ENTRIES*LDT_ENTRY_SIZE) >> PAGE_SHIFT);
+      (PAGE_ALIGN(LDT_ENTRIES*LDT_ENTRY_SIZE) >> PAGE_SHIFT) +
+      (PAGE_ALIGN(DPMI_sel_code_end-DPMI_sel_code_start) >> PAGE_SHIFT);
     mpool_numpages = num_pages + 5;  /* 5 extra pages */
     memsize = mpool_numpages << PAGE_SHIFT;
 

--- a/src/dosext/dpmi/memory.c
+++ b/src/dosext/dpmi/memory.c
@@ -32,6 +32,7 @@
 #include "mapping.h"
 #include "smalloc.h"
 #include "dmemory.h"
+#include "dpmi.h"
 
 #ifndef PAGE_SHIFT
 #define PAGE_SHIFT		12
@@ -137,7 +138,8 @@ int dpmi_alloc_pool(void)
     void *dpmi_base;
 
     /* Create DPMI pool */
-    num_pages = config.dpmi >> 2;
+    num_pages = (config.dpmi >> 2) +
+      ((DPMI_pm_stack_size * DPMI_MAX_CLIENTS) >> PAGE_SHIFT);
     mpool_numpages = num_pages + 5;  /* 5 extra pages */
     memsize = mpool_numpages << PAGE_SHIFT;
 

--- a/src/dosext/dpmi/memory.c
+++ b/src/dosext/dpmi/memory.c
@@ -139,7 +139,8 @@ int dpmi_alloc_pool(void)
 
     /* Create DPMI pool */
     num_pages = (config.dpmi >> 2) +
-      ((DPMI_pm_stack_size * DPMI_MAX_CLIENTS) >> PAGE_SHIFT);
+      ((DPMI_pm_stack_size * DPMI_MAX_CLIENTS) >> PAGE_SHIFT) +
+      (PAGE_ALIGN(LDT_ENTRIES*LDT_ENTRY_SIZE) >> PAGE_SHIFT);
     mpool_numpages = num_pages + 5;  /* 5 extra pages */
     memsize = mpool_numpages << PAGE_SHIFT;
 


### PR DESCRIPTION
When working on the KVM DPMI patch I found it annoying to have so many DPMI mappings. Sometimes the locked pm stack would be below mem_base, sometimes above, etc.

I found it easiest to just combine everything into the pool memory. This way all DPMI memory is in a single block which also makes debugging easier.

To keep the handle number the same for DPMI clients, there is a private host_pm_block_root for the pmstacks, data & code helpers and LDT alias memory.
