### PR TITLE
Dosdebug 01

### DIFF
--- a/src/tools/debugger/dosdebug.c
+++ b/src/tools/debugger/dosdebug.c
@@ -28,8 +28,11 @@
 #include <sys/vt.h>
 #include <sys/ioctl.h>
 
-#define    TMPFILE_VAR		"/var/run/dosemu."
-#define    TMPFILE_HOME		".dosemu/run/dosemu."
+#define    TMPFILE_VAR		"/var/run"
+#define    TMPFILE_HOME		".dosemu/run"
+
+#define DBGFNIN "dosemu.dbgin."
+#define DBGFNOUT "dosemu.dbgout."
 
 #define MHP_BUFFERSIZE 8192
 
@@ -43,67 +46,6 @@ int kill_timeout=FOREVER;
 static  char *pipename_in, *pipename_out;
 int fdout, fdin;
 
-static int check_pid(int pid);
-
-static int find_dosemu_pid(char *tmpfile, int local)
-{
-  DIR *dir;
-  struct dirent *p;
-  char *dn, *id;
-  int i,j,pid=-1;
-  static int once =1;
-
-  dn = strdup(tmpfile);
-  j=i=strlen(dn);
-  while (dn[i--] != '/');  /* remove 'dosemu.dbgin' */
-  i++;
-  dn[i++]=0;
-  id=dn+i;
-  j-=i;
-
-  dir = opendir(dn);
-  if (!dir) {
-    if (local) {
-      free(dn);
-      return -1;
-    }
-    fprintf(stderr, "can't open directory %s\n",dn);
-    free(dn);
-    exit(1);
-  }
-  i = 0;
-  while((p = readdir(dir))) {
-
-    if(!strncmp(id,p->d_name,j) && p->d_name[j] >= '0' && p->d_name[j] <= '9') {
-      pid = strtol(p->d_name + j, 0, 0);
-      if(check_pid(pid)) {
-        if(once && i++ == 1) {
-          fprintf(stderr,
-            "Multiple dosemu processes running or stalled files in %s\n"
-            "restart dosdebug with one of the following pids as first arg:\n"
-            "%d", dn, pid
-          );
-          once = 0;
-        }
-      }
-      if (i > 1) fprintf(stderr, " %d", pid);
-    }
-  }
-  free(dn);
-  closedir(dir);
-  if (i > 1) {
-    fprintf(stderr, "\n");
-    if (local) return -1;
-    exit(1);
-  }
-  if (!i) {
-    if (local) return -1;
-    fprintf(stderr, "No dosemu process running, giving up.\n");
-    exit(1);
-  }
-
-  return pid;
-}
 
 static int check_pid(int pid)
 {
@@ -119,6 +61,60 @@ static int check_pid(int pid)
   }
   close(fd);
   return strstr(buf,"dos") ? 1 : 0;
+}
+
+static int filter_dosemu_zombies(const struct dirent *entry) {
+	char *dot;
+	int pid;
+
+	if(strncmp(entry->d_name, DBGFNIN, strlen(DBGFNIN)) != 0) {
+		return 0;
+	}
+
+	dot = strrchr(entry->d_name, '.');
+	if(!dot)
+		return 0;
+
+	pid = atoi(dot+1);
+	if(!pid)
+		return 0;
+
+	return check_pid(pid);
+}
+
+static int find_dosemu_pid(char *dir) {
+	struct dirent **namelist;
+	char *dot;
+	int i, n, pid = 0;
+
+	n = scandir(dir, &namelist, &filter_dosemu_zombies, alphasort);
+	if (n < 0) {
+		fprintf(stderr, "find_dosemu_pid: scandir error\n");
+	} else if (n == 0) {
+		fprintf(stderr, "find_dosemu_pid: no dosemu process found\n");
+	} else {
+		/* hook up to the first found */
+		dot = strrchr(namelist[0]->d_name, '.');
+		pid = atoi(dot+1);
+
+		if (n>1) {
+			fprintf(stderr,
+"Multiple dosemu processes running. Using the first process found or you can\n"
+"restart dosdebug with one of the following pids as the first arg:");
+			for(i=0; i<n ; i++) {
+				dot = strrchr(namelist[i]->d_name, '.');
+				fprintf(stderr, " %s", dot+1);
+			}
+			fprintf(stderr, "\n");
+		}
+		/* free the structure */
+		while (n--) {
+			free(namelist[n]);
+		}
+		free(namelist);
+	}
+
+	return pid;
 }
 
 static int switch_console(char new_console)
@@ -204,42 +200,41 @@ static void handle_dbg_input(void)
 
 int main (int argc, char **argv)
 {
-  int numfds, dospid, ret;
+  int numfds, ret, dospid = 0;
   char *home_p;
 
   FD_ZERO(&readfds);
 
   home_p = getenv("HOME");
 
-  if (!argv[1]) {
-    dospid = -1;
-    if (home_p) {
-      char *dosemu_tmpfile_pat;
-
-      ret = asprintf(&dosemu_tmpfile_pat, "%s/" TMPFILE_HOME "dbgin.", home_p);
-      assert(ret != -1);
-
-      dospid=find_dosemu_pid(dosemu_tmpfile_pat, 1);
-      free(dosemu_tmpfile_pat);
-    }
-    if (dospid == -1) {
-      dospid=find_dosemu_pid(TMPFILE_VAR "dbgin.", 0);
+  if ((argc > 1) && argv[1]) {
+    dospid=strtol(argv[1], 0, 0);
+    if (!check_pid(dospid)) {
+      fprintf(stderr, "no dosemu running on pid %d\n", dospid);
+      exit(1);
     }
   }
-  else dospid=strtol(argv[1], 0, 0);
 
-  if (!check_pid(dospid)) {
-    fprintf(stderr, "no dosemu running on pid %d\n", dospid);
-    exit(1);
+  if (home_p) {
+    char *dosemu_tmpfile_pat;
+
+    ret = asprintf(&dosemu_tmpfile_pat, "%s/" TMPFILE_HOME, home_p);
+    assert(ret != -1);
+
+    dospid=find_dosemu_pid(dosemu_tmpfile_pat);
+    free(dosemu_tmpfile_pat);
+  }
+  if (dospid < 1) {
+    dospid=find_dosemu_pid(TMPFILE_VAR);
   }
 
   /* NOTE: need to open read/write else O_NONBLOCK would fail to open */
   fdout = -1;
   if (home_p) {
-    ret = asprintf(&pipename_in, "%s/%sdbgin.%d", home_p, TMPFILE_HOME, dospid);
+    ret = asprintf(&pipename_in, "%s/%s/%s%d", home_p, TMPFILE_HOME, DBGFNIN, dospid);
     assert(ret != -1);
 
-    ret = asprintf(&pipename_out, "%s/%sdbgout.%d", home_p, TMPFILE_HOME, dospid);
+    ret = asprintf(&pipename_out, "%s/%s/%s%d", home_p, TMPFILE_HOME, DBGFNOUT, dospid);
     assert(ret != -1);
 
     fdout = open(pipename_in, O_RDWR | O_NONBLOCK);
@@ -251,10 +246,10 @@ int main (int argc, char **argv)
   if (fdout == -1) {
     /* if we cannot open pipe and we were trying $HOME/.dosemu/run directory,
        try with /var/run/dosemu directory */
-    ret = asprintf(&pipename_in, TMPFILE_VAR "dbgin.%d", dospid);
+    ret = asprintf(&pipename_in, "%s/%s%d", TMPFILE_VAR, DBGFNIN, dospid);
     assert(ret != -1);
 
-    ret = asprintf(&pipename_out, TMPFILE_VAR "dbgout.%d", dospid);
+    ret = asprintf(&pipename_out, "%s/%s%d", TMPFILE_VAR, DBGFNOUT, dospid);
     assert(ret != -1);
 
     fdout = open(pipename_in, O_RDWR | O_NONBLOCK);

--- a/src/tools/debugger/mhpdbg.c
+++ b/src/tools/debugger/mhpdbg.c
@@ -83,12 +83,15 @@ void mhp_putc(char c1)
 
 void mhp_send(void)
 {
+   int ret;
    if ((mhpdbg.sendptr) && (mhpdbg.fdout == -1)) {
       mhpdbg.sendptr = 0;
       return;
    }
    if ((mhpdbg.sendptr) && (mhpdbg.fdout != -1)) {
-      write (mhpdbg.fdout, mhpdbg.sendbuf, mhpdbg.sendptr);
+      ret = write (mhpdbg.fdout, mhpdbg.sendbuf, mhpdbg.sendptr);
+      if (ret < 0)
+         perror("write to mhpdbg.fdout failed");
       mhpdbg.sendptr = 0;
    }
 }

--- a/src/tools/debugger/mhpdbg.c
+++ b/src/tools/debugger/mhpdbg.c
@@ -156,8 +156,8 @@ static void mhp_init(void)
     if (!retval) {
       mhpdbg.fdin = open(pipename_in, O_RDONLY | O_NONBLOCK);
       if (mhpdbg.fdin != -1) {
-        /* NOTE: need to open read/write else O_NONBLOCK would fail to open */
-        mhpdbg.fdout = open(pipename_out, O_RDWR | O_NONBLOCK);
+        /* NOTE: Allow to block else we drop output on 'tc' when pipe fills */
+        mhpdbg.fdout = open(pipename_out, O_RDWR);
         if (mhpdbg.fdout != -1) {
           add_to_io_select(mhpdbg.fdin, mhp_input_async, NULL);
         }


### PR DESCRIPTION
This branch has dosdebug commits for:
1/ easing the dosemu process selection for dosdebug when there are stale debugger pipes lying around. Previously the user would need to either delete those pipes or obtain the dosemu pid manually and use it as an argument to dosdebug. Any stale pipes are now ignored.
2/ a trivial patch to quieten gcc over some unchecked write return values
3/ a minor patch to allow the output pipe to block during large outputs of text as can be seen when using the 'tc' command. Without it output is lost when the pipe fills.
 