### PR TITLE
mapping: allocate contiguous memory for low + dpmi when possible.

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -222,8 +222,6 @@ void *alias_mapping(int cap, unsigned targ, size_t mapsize, int protect, void *s
   addr = mappingdriver->alias(cap, target, mapsize, protect, source);
   if (addr == MAP_FAILED)
     return addr;
-  if (cap & MAPPING_INIT_LOWRAM)
-    mem_base = addr;
   update_aliasmap(addr, mapsize, (cap & MAPPING_VGAEMU) ? target : source);
   if (config.cpu_vm == CPUVM_KVM)
     mprotect_kvm(addr, mapsize, protect);
@@ -280,7 +278,7 @@ void *mmap_mapping(int cap, void *target, size_t mapsize, int protect, off_t sou
     }
     if (target == (void *)-1) target = NULL;
 #ifdef __x86_64__
-    if (flags == 0 && (cap & (MAPPING_DPMI|MAPPING_VGAEMU)))
+    if (flags == 0 && (cap & (MAPPING_DPMI|MAPPING_VGAEMU|MAPPING_INIT_LOWRAM)))
       flags = MAP_32BIT;
 #endif
     addr = mmap(target, mapsize, protect,

--- a/src/dosext/dpmi/dmemory.h
+++ b/src/dosext/dpmi/dmemory.h
@@ -40,4 +40,6 @@ int DPMI_GetPageAttributes(dpmi_pm_block_root *root, unsigned long handle, int o
 /* to align the pointer to the (next) page boundary */
 #define PAGE_ALIGN(addr)	(((addr)+PAGE_SIZE-1)&PAGE_MASK)
 
+unsigned long dpmi_mem_size(void);
+
 #endif


### PR DESCRIPTION
The only time this is not possible is when using vm86() on i386,
of if $_dpmi is explicitly set by the user.

Making the space contiguous avoids looking for VMAs under 1G and
simplifies the KVM-DPMI patch.