### PR TITLE
build system: re-enable out-of-tree builds

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+cd $(dirname $0)
 srcdir=`pwd`
 echo "Generating toplevel configure script..."
 if ! autoreconf --install --force --warnings=all ; then
@@ -27,4 +28,4 @@ for dir in `cat plugin_configure`; do
 done
 cd $srcdir
 echo
-echo "Done, now run ./default-configure"
+echo "Done, now run $(dirname $0)/default-configure"

--- a/configure.ac
+++ b/configure.ac
@@ -172,7 +172,7 @@ if test -x $srcdir/mkpluginhooks; then
     AC_MSG_NOTICE(Including plugins: $PLUGINS);
     cd src
     for i in $PLUGINSUBDIRS; do
-      if ! grep USE_DL_PLUGINS $i/Makefile >/dev/null ; then
+      if ! grep USE_DL_PLUGINS ../$srcdir/src/$i/Makefile >/dev/null ; then
         ST_PLUGINSUBDIRS="$ST_PLUGINSUBDIRS $i"
       fi
     done

--- a/mkpluginhooks
+++ b/mkpluginhooks
@@ -122,8 +122,8 @@ if [ "$PDIRS" != " " ]; then
   for d in $PDIRS; do
     # Test if this plugin is enabled
     if [ -f $DESTDIR/$d/$CONF/${PREF}enable ] && \
-	[ -f $DESTDIR/$d/Makefile ] && ([ ! -f $DESTDIR/$d/configure.ac ] || \
-	[ -f $DESTDIR/$d/configure ]); then
+	[ -f $SRCDIR/$d/Makefile ] && ([ ! -f $SRCDIR/$d/configure.ac ] || \
+	[ -f $SRCDIR/$d/configure ]); then
       enable=`cat $DESTDIR/$d/$CONF/${PREF}enable`
     else
       enable=no

--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -39,8 +39,8 @@ ifneq "$(wildcard *.d)" ""
 endif
 endif
 
-Makefile.conf: configure
-	./configure
+Makefile.conf: $(srcdir)/configure
+	$(srcdir)/configure
 configure: configure.ac
 	if [ -d m4 ]; then \
 		AC_F="-I m4 -I $(REALTOPDIR)/m4"; \

--- a/src/dosext/dpmi/Makefile
+++ b/src/dosext/dpmi/Makefile
@@ -4,7 +4,7 @@ include $(top_builddir)/Makefile.conf
 
 CFILES = dpmi.c memory.c emu-ldt.c msdoshlp.c vxd.c
 SFILES = dpmisel.S
-ALL_CPPFLAGS += -Imsdos
+ALL_CPPFLAGS += -I$(srcdir)/msdos
 
 all:  lib
 

--- a/src/dosext/dpmi/msdos/Makefile
+++ b/src/dosext/dpmi/msdos/Makefile
@@ -3,7 +3,7 @@ top_builddir=../../../..
 include $(top_builddir)/Makefile.conf
 
 CFILES = msdos.c segreg.c msdos_ldt.c
-ALL_CPPFLAGS += -DDOSEMU -I..
+ALL_CPPFLAGS += -DDOSEMU -I$(srcdir)/..
 
 all:  lib
 

--- a/src/plugin/X/Makefile
+++ b/src/plugin/X/Makefile
@@ -8,7 +8,7 @@ top_builddir=../../..
 include $(top_builddir)/Makefile.conf
 include Makefile.conf
 
-ALL_CFLAGS+=$(DL_CFLAGS) -Iinclude $(X_CFLAGS)
+ALL_CFLAGS+=$(DL_CFLAGS) -I. -I$(srcdir)/include $(X_CFLAGS)
 CFILES = X.c screen.c keyb_X.c keyb_X_keycode.c X_keysyms.c X_keymaps.c \
 	X_speaker.c X_font.c
 


### PR DESCRIPTION
For dosemu1 I had one out-of-tree build for i386 and one for x86_64 and that is not working any more.
This fixes it.