### PR TITLE
build system: link DOS binaries indirectly with GCC

### DIFF
--- a/src/commands/Makefile
+++ b/src/commands/Makefile
@@ -41,10 +41,10 @@ PD=precompiled
 all: $(COM2) $(SYS)
 
 %.sys.elf: %.o
-	ld --section-start=.text=0 -e _start16 -o $@ $<
+	$(LD) $(ALL_LDFLAGS) -Wl,--section-start=.text=0,-e,_start16 -nostdlib -o $@ $<
 
 %.com.elf: %.o
-	ld --section-start=.text=0x100 -e _start16 -o $@ $<
+	$(LD) $(ALL_LDFLAGS) -Wl,--section-start=.text=0x100,-e,_start16 -nostdlib -o $@ $<
 
 $(D)/%: %.elf
 	objcopy -j .text -O binary $< $@

--- a/src/plugin/commands/Makefile
+++ b/src/plugin/commands/Makefile
@@ -35,7 +35,7 @@ $(STUBSYMLINK): $(D)/generic.com
 	ln -sf $(<F) $@
 
 %.com.elf: %.o
-	ld --section-start=.text=0x100 -e _start16 -o $@ $<
+	$(LD) $(ALL_LDFLAGS) -Wl,--section-start=.text=0x100,-e,_start16 -nostdlib -o $@ $<
 
 $(D)/%: %.elf
 	objcopy -j .text -O binary $< $@


### PR DESCRIPTION
This partly reverts 0a5f8922ace6e. The problem with using ld
directly is that it breaks "target_bits 64" when (cross-)compiling
with i386 userspace, as the "-m64" is lost.

Of course this is not the only way to fix this issue, one can also add "-m elf_i386" or "-m elf_x86_64" to the ld command line but that needs a bit more setup.