### PR TITLE
simx86: fix _rip in scas/cmps handler for JIT accesses to vgaemu mem.

### DIFF
--- a/src/emu-i386/simx86/sigsegv.c
+++ b/src/emu-i386/simx86/sigsegv.c
@@ -317,6 +317,7 @@ int e_vgaemu_fault(struct sigcontext *scp, unsigned page_fault)
 		_edi = AR1.d;
 		_esi = AR2.d;
 		_eflags = (_eflags & ~EFLAGS_CC) | (EFLAGS & EFLAGS_CC);
+		_rip = (long)(p+1);
 		break;
 /*aa*/	case STOSb: {
 		int d = (_eflags & EFLAGS_DF? -1:1);
@@ -361,6 +362,7 @@ int e_vgaemu_fault(struct sigcontext *scp, unsigned page_fault)
 		FlagSync_All();
 		_edi = AR1.d;
 		_eflags = (_eflags & ~EFLAGS_CC) | (EFLAGS & EFLAGS_CC);
+		_rip = (long)(p+1);
 		break;
 /*f2*/	case REPNE:
 /*f3*/	case REP: {


### PR DESCRIPTION
This helps Prehistorik 2 a little bit (bug #104).