### PR TITLE
remap: fix performance regression from commit 263bed9b

### DIFF
--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1418,6 +1418,7 @@ static RemapFuncDesc *find_best_remap_func(unsigned flags, int src_mode, int dst
  */
 static void install_remap_funcs(RemapObject *ro, int remap_features)
 {
+  remap_features &= ~RFF_BITMAP_FONT; /* ignore this to select scalers! */
   if (remap_features & RFF_BILIN_FILT)
     remap_features &= ~RFF_LIN_FILT;
   ro->func_all = find_best_remap_func(remap_features | RFF_SCALE_ALL, ro->src_mode, ro->dst_mode, remap_list);


### PR DESCRIPTION
That commit introduced RFF_BITMAP_FONT but this field should
be ignored when choosing a scaler. If it is not ignore the slow
*_all remappers are always used instead of the fast *_1 remappers,
even if no scaling is necessary.