### PR TITLE
KVM: if KVM fails with EFAULT, retry. Fixes #116 (Micro Machines).

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -317,9 +317,21 @@ int mprotect_mapping(int cap, void *addr, size_t mapsize, int protect)
   int ret;
   Q__printf("MAPPING: mprotect, cap=%s, addr=%p, size=%zx, protect=%x\n",
 	cap, addr, mapsize, protect);
-  ret = mprotect(addr, mapsize, protect);
+  /* it is important to r/o protect the KVM guest page tables BEFORE
+     calling mprotect as this function is called by parallel threads
+     (vgaemu.c:_vga_emu_update).
+     Otherwise the page can be r/w in the guest but r/o on the host which
+     causes KVM to exit with EFAULT when the guest writes there.
+     We do not need to worry about caching/TLBs because the kernel will
+     walk the guest page tables (see kernel:
+     Documentation/virtual/kvm/mmu.txt:
+     - if needed, walk the guest page tables to determine the guest translation
+       (gva->gpa or ngpa->gpa)
+       - if permissions are insufficient, reflect the fault back to the guest)
+  */
   if (config.cpu_vm == CPUVM_KVM)
     mprotect_kvm(addr, mapsize, protect);
+  ret = mprotect(addr, mapsize, protect);
   if (ret)
     error("mprotect() failed: %s\n", strerror(errno));
   return ret;


### PR DESCRIPTION
The cause for the EFAULT is that the threaded vgaemu code makes
pages r/o while KVM is running. The page tables (+caches/TLB)
can then be temporarily out-of-sync. Simply retrying KVM_RUN
fixes the issue, because by then everything is synced again.