### PR TITLE
KVM: map directly into non-aliased memory.

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -319,18 +319,6 @@ int mprotect_mapping(int cap, void *addr, size_t mapsize, int protect)
   int ret;
   Q__printf("MAPPING: mprotect, cap=%s, addr=%p, size=%zx, protect=%x\n",
 	cap, addr, mapsize, protect);
-  /* it is important to r/o protect the KVM guest page tables BEFORE
-     calling mprotect as this function is called by parallel threads
-     (vgaemu.c:_vga_emu_update).
-     Otherwise the page can be r/w in the guest but r/o on the host which
-     causes KVM to exit with EFAULT when the guest writes there.
-     We do not need to worry about caching/TLBs because the kernel will
-     walk the guest page tables (see kernel:
-     Documentation/virtual/kvm/mmu.txt:
-     - if needed, walk the guest page tables to determine the guest translation
-       (gva->gpa or ngpa->gpa)
-       - if permissions are insufficient, reflect the fault back to the guest)
-  */
   if (config.cpu_vm == CPUVM_KVM)
     mprotect_kvm(addr, mapsize, protect);
   ret = mprotect(addr, mapsize, protect);

--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -223,8 +223,10 @@ void *alias_mapping(int cap, unsigned targ, size_t mapsize, int protect, void *s
   if (addr == MAP_FAILED)
     return addr;
   update_aliasmap(addr, mapsize, (cap & MAPPING_VGAEMU) ? target : source);
-  if (config.cpu_vm == CPUVM_KVM)
+  if (config.cpu_vm == CPUVM_KVM && !(cap & MAPPING_OTHER)) {
+    mmap_kvm(DOSADDR_REL(addr), source, mapsize);
     mprotect_kvm(addr, mapsize, protect);
+  }
   Q__printf("MAPPING: %s alias created at %p\n", cap, addr);
   return addr;
 }

--- a/src/emu-i386/kvm.c
+++ b/src/emu-i386/kvm.c
@@ -131,9 +131,6 @@ void init_kvm_monitor(void)
   struct kvm_regs regs;
   struct kvm_sregs sregs;
 
-  /* Map guest memory: only conventional memory + HMA for now */
-  mmap_kvm(0, mem_base, LOWMEM_SIZE + HMASIZE);
-
   /* create monitor structure in memory */
   monitor = mmap(NULL, sizeof(*monitor), PROT_READ | PROT_WRITE,
 		 MAP_SHARED | MAP_ANONYMOUS, -1, 0);

--- a/src/emu-i386/kvm.c
+++ b/src/emu-i386/kvm.c
@@ -119,7 +119,6 @@ static struct monitor {
 
 static struct kvm_run *run;
 static int vmfd, vcpufd;
-static volatile int mprotected_kvm = 0;
 
 #define MAXSLOT 40
 static struct kvm_userspace_memory_region maps[MAXSLOT];
@@ -393,8 +392,6 @@ void mprotect_kvm(void *addr, size_t mapsize, int protect)
     else if (protect & PROT_READ)
       monitor->pte[page] |= PG_PRESENT | PG_USER;
   }
-
-  mprotected_kvm = 1;
 }
 
 /* This function works like handle_vm86_fault in the Linux kernel,
@@ -534,17 +531,7 @@ int kvm_vm86(struct vm86_struct *info)
           KVM is re-entered asking it to exit when interrupt injection is
           possible, then it exits with this code. This only happens if a signal
           occurs during execution of the monitor code in kvmmon.S.
-       4. ret==-1 and errno == EFAULT: this can happen if code in vgaemu.c
-          calls mprotect in parallel and the TLB is out of sync with the
-          actual page tables; if this happen we retry and it should not happen
-          again since the KVM exit/entry makes everything sync'ed.
     */
-    if (mprotected_kvm) { // case 4
-      mprotected_kvm = 0;
-      if (ret == -1 && errno == EFAULT)
-	ret = ioctl(vcpufd, KVM_RUN, NULL);
-    }
-
     exit_reason = run->exit_reason;
     if (ret == -1 && errno == EINTR) {
       exit_reason = KVM_EXIT_INTR;

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -24,5 +24,6 @@ int init_kvm_cpu(void);
 void init_kvm_monitor(void);
 int kvm_vm86(struct vm86_struct *info);
 void mprotect_kvm(void *addr, size_t mapsize, int protect);
+void mmap_kvm(unsigned targ, void *addr, size_t mapsize);
 
 #endif


### PR DESCRIPTION
This now fixes the race by mapping directly into non-aliased memory.

This will also help the KVM + DPMI patch -- I had to put in some funny logic to allow some maps and not others.