### PR TITLE
Dosdebug: allow tc command to respect breakpoints

### DIFF
--- a/src/tools/debugger/mhpdbg.c
+++ b/src/tools/debugger/mhpdbg.c
@@ -473,7 +473,13 @@ unsigned int mhp_debug(enum dosdebug_event code, unsigned int parm1, unsigned in
 			  mhpdbgc.stopped = 1;
 			  break;
 		  }
+
+		  if (traceloop && mhp_bpchk(mhp_getcsip_value())) {
+			  traceloop = 0;
+			  loopbuf[0] = '\0';
+		  }
 	  }
+
 	  if (DBG_ARG(mhpdbgc.currcode) == 3) { /* int3 (0xCC) */
 		  int ok=0;
 		  unsigned int csip=mhp_getcsip_value() - 1;


### PR DESCRIPTION
This patch allows a tc command to be halted if a breakpoint is
encountered. This is useful for logging the actions of a function or
interrupt call. See the following transcript:

Note: the indentation is awfully inconsistent in the file src/tools/debugger/mhpdbg.c.

~~~
system state: stopped
AX=0000  BX=037c  CX=0586  DX=0112  SI=0023  DI=0300  SP=0a80  BP=0000
DS=0112  ES=0112  FS=0000  GS=0000  FL=000a3346
CS:IP=002c:8264       SS:SP=0112:0a80

002c:8264 E8DBBE           call 4142 ($-4125)
u

002c:8267 07               pop  es
002c:8268 9C               pushf
002c:8269 36A08300         mov  al,ss:[0083]
002c:826d 98               cbw
002c:826e 40               inc  ax
002c:826f 750A             jne  827B ($+a)
002c:8271 48               dec  ax
002c:8272 7507             jne  827B ($+7)
002c:8274 36FE068300       inc  byte ss:[0083]
002c:8279 9D               popf
002c:827a C3               ret
002c:827b 36A1BC03         mov  ax,ss:[03BC]
002c:827f 9D               popf
002c:8280 C3               ret
002c:8281 8AE1             mov  ah,cl
002c:8283 E8FD0B           call 8E83 ($+bfd)
002c:8286 3C01             cmp  al,01

bp 002c:8267
tc
AX=0000  BX=037c  CX=0586  DX=0112  SI=0023  DI=0300  SP=0a7e  BP=0000
DS=0112  ES=0112  FS=0000  GS=0000  FL=000a3346
CS:IP=002c:4142       SS:SP=0112:0a7e

002c:4142 2E8E06673D       mov  es,cs:[3D67]
AX=0000  BX=037c  CX=0586  DX=0112  SI=0023  DI=0300  SP=0a7e  BP=0000
DS=0112  ES=0112  FS=0000  GS=0000  FL=000a3346
CS:IP=002c:4147       SS:SP=0112:0a7e

002c:4147 268F06EE05       pop  word es:[05EE]
AX=0000  BX=037c  CX=0586  DX=0112  SI=0023  DI=0300  SP=0a80  BP=0000
DS=0112  ES=0112  FS=0000  GS=0000  FL=000a3346
CS:IP=002c:414c       SS:SP=0112:0a80

002c:414c 58               pop  ax
AX=0100  BX=037c  CX=0586  DX=0112  SI=0023  DI=0300  SP=0a82  BP=0000
DS=0112  ES=0112  FS=0000  GS=0000  FL=000a3346
CS:IP=002c:414d       SS:SP=0112:0a82

002c:414d 5B               pop  bx
AX=0100  BX=0000  CX=0586  DX=0112  SI=0023  DI=0300  SP=0a84  BP=0000
DS=0112  ES=0112  FS=0000  GS=0000  FL=000a3346
CS:IP=002c:414e       SS:SP=0112:0a84

002c:414e 59               pop  cx
AX=0100  BX=0000  CX=00f9  DX=0112  SI=0023  DI=0300  SP=0a86  BP=0000
DS=0112  ES=0112  FS=0000  GS=0000  FL=000a3346
CS:IP=002c:414f       SS:SP=0112:0a86

002c:414f 5A               pop  dx
AX=0100  BX=0000  CX=00f9  DX=007f  SI=0023  DI=0300  SP=0a88  BP=0000
DS=0112  ES=0112  FS=0000  GS=0000  FL=000a3346
CS:IP=002c:4150       SS:SP=0112:0a88

002c:4150 5E               pop  si
AX=0100  BX=0000  CX=00f9  DX=007f  SI=010d  DI=0300  SP=0a8a  BP=0000
DS=0112  ES=0112  FS=0000  GS=0000  FL=000a3346
CS:IP=002c:4151       SS:SP=0112:0a8a

002c:4151 5F               pop  di
AX=0100  BX=0000  CX=00f9  DX=007f  SI=010d  DI=01fb  SP=0a8c  BP=0000
DS=0112  ES=0112  FS=0000  GS=0000  FL=000a3346
CS:IP=002c:4152       SS:SP=0112:0a8c

002c:4152 5D               pop  bp
AX=0100  BX=0000  CX=00f9  DX=007f  SI=010d  DI=01fb  SP=0a8e  BP=0000
DS=0112  ES=0112  FS=0000  GS=0000  FL=000a3346
CS:IP=002c:4153       SS:SP=0112:0a8e

002c:4153 1F               pop  ds
AX=0100  BX=0000  CX=00f9  DX=007f  SI=010d  DI=01fb  SP=0a90  BP=0000
DS=0112  ES=0112  FS=0000  GS=0000  FL=000a3346
CS:IP=002c:4154       SS:SP=0112:0a90

002c:4154 26FF26EE05       jmp  near word es:[05EE]
system state: stopped
AX=0100  BX=0000  CX=00f9  DX=007f  SI=010d  DI=01fb  SP=0a90  BP=0000
DS=0112  ES=0112  FS=0000  GS=0000  FL=000a3346
CS:IP=002c:8267       SS:SP=0112:0a90

002c:8267 07               pop  es
~~~
