### PR TITLE
dosdebug: Remove outdated artifact

### DIFF
--- a/src/include/mhpdbg.h
+++ b/src/include/mhpdbg.h
@@ -13,10 +13,6 @@
 
 #include <stdarg.h>
 
-#if 0  /* now defined in include/vm86plus */
-#define VM86_TRAP 4	  /* (vm86 return) TRAP */
-#endif
-
 // There is also an argument field shifted 8 bits left
 enum dosdebug_event {
    DBG_INIT = 0,


### PR DESCRIPTION
This ineffective define has been around at least since sourceforge svn
import in 2003. We don't need it and the value, if it ever was correct,
is now wrong.