### PR TITLE
Test support 01

### DIFF
--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -84,6 +84,7 @@
 # normal FAT16B formatting.
 # /path/to/dir:hdtype1 - creates 10mb IBM type1 disk with C/H/S of 306/4/17
 # /path/to/dir:hdtype2 - creates 21mb IBM type2 disk with C/H/S of 615/4/17
+# /path/to/dir:hdtype9 - creates 117mb IBM type9 disk with C/H/S of 900/15/17
 #
 # Currently mounted devices and swap are refused. Hdimages and devices may
 # be mixed such as "hdimage_c /dev/hda1 /dev/hda3:ro". Default: "drives/*"

--- a/etc/global.conf
+++ b/etc/global.conf
@@ -632,12 +632,14 @@ else
         $yyy = $yyy, " }";
         $$yyy;
       else
-        $yyy2 = strdel($xxx, strstr($xxx, ":ro"), 999);
-        $yyy1 = strdel($yyy2, strstr($xxx, ":hdtype1"), 999);
-        $yyy = strdel($yyy1, strstr($xxx, ":hdtype2"), 999);
+        $yyy3 = strdel($xxx, strstr($xxx, ":ro"), 999);
+        $yyy2 = strdel($yyy3, strstr($xxx, ":hdtype1"), 999);
+        $yyy1 = strdel($yyy2, strstr($xxx, ":hdtype2"), 999);
+        $yyy = strdel($yyy1, strstr($xxx, ":hdtype9"), 999);
         $zzz = strsplit($xxx, strstr($xxx, ":ro"), 999);
         $uuu = strsplit($xxx, strstr($xxx, ":hdtype1"), 999);
         $vvv = strsplit($xxx, strstr($xxx, ":hdtype2"), 999);
+        $www = strsplit($xxx, strstr($xxx, ":hdtype9"), 999);
         if (strchr($yyy, "/") != 0)
           $yyyy = $HOME, "/.dosemu/", $yyy
           shell("test -e '", $yyyy, "'")
@@ -654,9 +656,11 @@ else
             disk { directory $yyy hdtype1 };
           else if (strlen($vvv))
             disk { directory $yyy hdtype2 };
+          else if (strlen($www))
+            disk { directory $yyy hdtype9 };
           else
             disk { directory $yyy };
-          endif endif endif
+          endif endif endif endif
         else
          shell("test -f '", $yyy, "'")
          if (!$DOSEMU_SHELL_RETURN)

--- a/man/mkfatimage16.1
+++ b/man/mkfatimage16.1
@@ -8,7 +8,8 @@ mkfatimage16 \- generate a virtual drive image suitable for DOSEMU
 .B \-b bsectfile
 ]
 [{
-.B \-t tracks
+.B [\-t tracks]
+.B [\-h heads]
 |
 .B \-k Kbytes
 }]
@@ -43,11 +44,13 @@ The file created by mkfatimage16 then can be used as a virtual drive, when defin
 .I /etc/dosemu.conf.
 As long as
 .B \-k
-is not given, the number of heads is always 4 and you have 17 sectors per head
+is not given, the number of heads defaults to 4 and you have 17 sectors per track
 else it is adjusted accordingly.
 To vary the size, you may either use the
 .B \-t
-option or specify the total amount of Kbytes via
+/
+.B \-h
+options or specify the total amount of Kbytes via
 .B \-k
 option.
 
@@ -76,13 +79,18 @@ into the bootsector of the partition.
 .I \-t num
 Make the virtual disk have
 .I num
-tracks. This is the one way to define the size of the disk.
+tracks.
+.TP
+.I \-h num
+Make the virtual disk have
+.I num
+heads. Using tracks and heads is one way to define the size of the disk.
 .TP
 .I \-k Kbytes
 Make the virtual disk be
 .I Kbytes
 in size. Using
-.I \-t
+.I \-t|\-h
 and
 .I \-k
 are mutual exclusive.
@@ -100,7 +108,7 @@ instead of
 .TP
 .I \-p
 Pad the hdimage with zero up to the total size given by
-.I \-t
+.I \-t|\-h
 or
 .I \-k
 (only in conjunction with

--- a/src/base/init/lexer.l.in
+++ b/src/base/init/lexer.l.in
@@ -441,6 +441,7 @@ cdrom			RETURN(CDROM);
 diskcyl4096		RETURN(DISKCYL4096);
 hdtype1			RETURN(HDTYPE1);
 hdtype2			RETURN(HDTYPE2);
+hdtype9			RETURN(HDTYPE9);
 
 	/* keyboard */
 

--- a/src/base/init/parser.y.in
+++ b/src/base/init/parser.y.in
@@ -290,7 +290,7 @@ while (0)
 %token LPT COMMAND TIMEOUT L_FILE
 	/* disk */
 %token L_PARTITION BOOTFILE WHOLEDISK THREEINCH THREEINCH_720 THREEINCH_2880 FIVEINCH FIVEINCH_360 ATAPI READONLY LAYOUT
-%token SECTORS CYLINDERS TRACKS HEADS OFFSET HDIMAGE HDTYPE1 HDTYPE2 DISKCYL4096
+%token SECTORS CYLINDERS TRACKS HEADS OFFSET HDIMAGE HDTYPE1 HDTYPE2 HDTYPE9 DISKCYL4096
 	/* ports/io */
 %token RDONLY WRONLY RDWR ORMASK ANDMASK RANGE FAST SLOW
 	/* Silly interrupts */
@@ -1449,6 +1449,7 @@ disk_flag	: READONLY		{ dptr->wantrdonly = 1; }
 		| DISKCYL4096	{ dptr->diskcyl4096 = 1; }
 		| HDTYPE1	{ dptr->hdtype = 1; }
 		| HDTYPE2	{ dptr->hdtype = 2; }
+		| HDTYPE9	{ dptr->hdtype = 9; }
 		| SECTORS expression	{ dptr->sectors = $2; }
 		| CYLINDERS expression	{ dptr->tracks = $2; }
 		| TRACKS expression	{ dptr->tracks = $2; }

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -520,6 +520,12 @@ void dir_auto(struct disk *dp)
         dp->sectors = 17;
         d_printf("DISK: Forcing IBM disk type 2\n");
         break;
+      case 9:
+        dp->tracks = 900;
+        dp->heads = 15;
+        dp->sectors = 17;
+        d_printf("DISK: Forcing IBM disk type 9\n");
+        break;
       default:
         d_printf("DISK: Invalid disk type (%d)\n", dp->hdtype);
         config.exitearly = 1;

--- a/src/include/disks.h
+++ b/src/include/disks.h
@@ -56,7 +56,7 @@ struct disk {
   int sectors, heads, tracks;	/* geometry */
   unsigned long start;		/* geometry */
   unsigned long long num_secs;	/* total sectors on disk */
-  int hdtype;			/* 0 none, 1 IBM type1, 2 IBM type2 */
+  int hdtype;			/* 0 none, IBM Types 1, 2 and 9 */
   int default_cmos;		/* default CMOS floppy type */
   int drive_num;
   unsigned long serial;		/* serial number */

--- a/src/tools/periph/Makefile
+++ b/src/tools/periph/Makefile
@@ -11,7 +11,7 @@ CFILES=hdinfo.c mkhdimage.c putrom.c mkfatimage16.c \
 SFILES=bootsect.S
 SRC=$(CFILES) $(SFILES)
 OBJ1=hdinfo mkhdimage putrom dexeconfig scsicheck dosctrl vbioscheck
-OBJ=$(OBJ1) $(BINPATH)/bin/mkfatimage16
+OBJ=$(OBJ1) $(BINPATH)/bin/mkfatimage16 $(BINPATH)/bin/mkhdimage
 SCRIPT=getrom
 
 ALL_CPPFLAGS += -I.
@@ -20,6 +20,9 @@ all: $(OBJ)
 
 $(BINPATH)/bin/mkfatimage16: mkfatimage16.o bootsect.o
 	$(LD) $(ALL_LDFLAGS) $^ -o $@
+
+$(BINPATH)/bin/mkhdimage: mkhdimage.o
+	$(LD) $(ALL_LDFLAGS) $< -o $@
 
 $(OBJ1): %: %.o
 	$(LD) $(ALL_LDFLAGS) $< -o $@
@@ -33,7 +36,7 @@ install:
 	install -m 0755 $(SCRIPT) $(IDEST)/dosemu
 
 clean::
-	rm -f $(OBJ) *.o mkfatimage16
+	rm -f $(OBJ) *.o mkfatimage16 mkhdimage
 	rm -f *.out
 
 realclean:: clean

--- a/src/tools/periph/mkfatimage16.c
+++ b/src/tools/periph/mkfatimage16.c
@@ -250,7 +250,7 @@ static void usage(void)
 {
   fprintf(stderr,
     "Usage:\n"
-    "  mkfatimage [-b bsectfile] [{-t tracks | -k Kbytes}]\n"
+    "  mkfatimage [-b bsectfile] [{[-t tracks] [-h heads] | -k Kbytes}]\n"
     "             [-l volume-label] [-f outfile] [-p ] [file...]\n");
   close_exit(1);
 }
@@ -270,7 +270,7 @@ int main(int argc, char *argv[])
   {
     usage();
   }
-  while ((n = getopt(argc, argv, "b:l:t:k:f:p")) != EOF)
+  while ((n = getopt(argc, argv, "b:l:t:h:k:f:p")) != EOF)
   {
     switch (n)
     {
@@ -285,20 +285,37 @@ int main(int argc, char *argv[])
         volume_label[11] = '\0';
       break;
     case 't':
-      if (kbytes >= 0) usage();
-      kbytes =0;
+      if (kbytes > 0)
+        usage();
+      kbytes = 0;
       tracks = atoi(optarg);
       if (tracks <= 0) {
-	fprintf(stderr, "Error: %ld tracks specified - must be positive \n", tracks);
-	close_exit(1);
+        fprintf(stderr, "Error: %ld tracks specified - must be positive\n", tracks);
+        close_exit(1);
       }
       if (tracks > 1024) {
-	fprintf(stderr, "Error: %ld tracks specified - must <= 1024 \n", tracks);
-	close_exit(1);
+        fprintf(stderr, "Error: %ld tracks specified - must <= 1024\n", tracks);
+        close_exit(1);
       }
       break;
+    case 'h':
+      if (kbytes > 0)
+        usage();
+      kbytes = 0;
+      heads = atoi(optarg);
+      if (heads <= 0) {
+        fprintf(stderr, "Error: %ld heads specified - must be positive\n", heads);
+        close_exit(1);
+      }
+      if (heads > 15) {
+        fprintf(stderr, "Error: %ld heads specified - must <= 15\n", heads);
+        close_exit(1);
+      }
+      p_ending_head = heads - 1;
+      break;
     case 'k':
-      if (kbytes != -1) usage();
+      if (kbytes != -1)
+        usage();
       kbytes = strtol(optarg, 0,0) *2;  /* needed total number of sectors */
       if (kbytes < (SECTORS_PER_TRACK * HEADS *2)) {
         fprintf(stderr, "Error: %d Kbyte specified, must be a reasonable size\n", kbytes);

--- a/src/tools/periph/mkhdimage.c
+++ b/src/tools/periph/mkhdimage.c
@@ -13,31 +13,52 @@
 #endif
 #include <errno.h>
 #include <string.h>
+#include <assert.h>
 
-int sectors = 17, heads = 4, cylinders = 40, header_size = 128;
+#include "disks.h"
+
 
 static void usage(void)
 {
-  fprintf(stderr, "mkhdimage [-h <heads>] [-s <sectors>] [-c|-t <cylinders>]\n");
+  fprintf(stderr, "mkhdimage [-h <heads>] [-s <sectors>] [-c|-t <cylinders> -f <outfile>]\n");
 }
 
 int
 main(int argc, char **argv)
 {
   int c;
-  int pos = 0;
+  int ret = 0;
+  int fdout = STDOUT_FILENO;
+  struct image_header *hdr;
 
-  while ((c = getopt(argc, argv, "h:s:t:c:s:")) != EOF) {
+  hdr = malloc(HEADER_SIZE);
+  assert(hdr != NULL);
+  memset(hdr, 0, HEADER_SIZE);
+
+  strncpy(hdr->sig, "DOSEMU", sizeof(hdr->sig));
+  hdr->cylinders = 40;
+  hdr->heads = 4;
+  hdr->sectors = 17;
+  hdr->header_end = HEADER_SIZE;
+
+  while ((c = getopt(argc, argv, "h:s:t:c:s:f:")) != EOF) {
     switch (c) {
     case 'h':
-      heads = atoi(optarg);
+      hdr->heads = atoi(optarg);
       break;
     case 's':
-      sectors = atoi(optarg);
+      hdr->sectors = atoi(optarg);
       break;
     case 'c':			/* cylinders */
     case 't':			/* tracks */
-      cylinders = atoi(optarg);
+      hdr->cylinders = atoi(optarg);
+      break;
+    case 'f':
+      fdout = open(optarg, O_CREAT|O_WRONLY|O_TRUNC, 0644);
+      if(fdout < 0) {
+        fprintf(stderr, "Could not open file '%s' for writing\n", optarg);
+        exit(1);
+      }
       break;
     default:
       fprintf(stderr, "Unknown option '%c'\n", c);
@@ -46,27 +67,24 @@ main(int argc, char **argv)
     }
   }
 
-#define WRITE(fd, ptr, size) ({ int w_tmp=0; \
-do { w_tmp=write(fd,ptr,size); } while ((w_tmp == -1) && (errno == EINTR)); \
-if (w_tmp == -1) \
-  fprintf(stderr, "WRITE ERROR: %d, *%s* in file %s, line %d\n", \
-	  errno, strerror(errno), __FILE__, __LINE__); \
-w_tmp; })
-
-  pos += WRITE(STDOUT_FILENO, "DOSEMU", 7);
-  pos += WRITE(STDOUT_FILENO, &heads, 4);
-  pos += WRITE(STDOUT_FILENO, &sectors, 4);
-  pos += WRITE(STDOUT_FILENO, &cylinders, 4);
-  pos += WRITE(STDOUT_FILENO, &header_size, 4);
-
-  {
-    char tmp[256];
-
-    memset(tmp, 0, 256);
-
-    pos += WRITE(STDOUT_FILENO, tmp, header_size - pos);
-    fprintf(stderr, "Pos now is %d\n", pos);
+  ret = write(fdout, hdr, HEADER_SIZE);
+  if (ret != HEADER_SIZE) {
+    fprintf(stderr, "Failed to write header\n");
+    exit(1);
   }
+
+  if(fdout != STDOUT_FILENO) {
+    /* Write hole */
+    lseek(fdout, (hdr->cylinders*hdr->heads*hdr->sectors*512) - 1, SEEK_CUR);
+    ret = write(fdout, "", 1);
+    if (ret != 1) {
+      fprintf(stderr, "Failed to write disk blocks\n");
+      exit(2);
+    }
+    close(fdout);
+  }
+
+  free(hdr);
 
   return 0;
 }


### PR DESCRIPTION
A couple of tweaks to peripheral programs to allow specific geometry hdimages to be created. A further change to disks.c allow the virtual hd disk created from a directory to be presented with known geometry that requires FAT16B filesystem. An IBM type 9 disk having CHS of 900/15/17 geometry was chosen. This enables easy comparison of hdimage and vfs directory boot logs, by ensuring the filesystem geometry is identical.