### PR TITLE
Fix direct VGA regression (#222)

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -624,7 +624,6 @@ int unmap_hardware_ram(char type, int cap)
     }
     g_printf("unmapped hardware ram at 0x%08zx .. 0x%08zx at %#x\n",
 	     hw->base, hw->base+hw->size-1, hw->vbase);
-    hw->vbase = -1;
   }
   return 0;
 }

--- a/src/base/video/video.c
+++ b/src/base/video/video.c
@@ -403,8 +403,10 @@ void video_post_init(void)
     }
   }
 
-  vga_emu_pre_init();
-  render_init();
+  if (!config.vga) {
+    vga_emu_pre_init();
+    render_init();
+  }
 
   if (Video && Video->init)
     Video->init();

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -38,7 +38,7 @@ extern void e_priv_iopl(int);
  * untrapped port will be allowed to compile. This is not 100% safe
  * since DX can dynamically change.
  */
-#if 1
+#if 0
 #define CPUEMU_DIRECT_IO
 #endif
 


### PR DESCRIPTION
Console graphics was broken in commits 619a60d0fb2 (cpuemu only),
c43732e99, 4354909, and 43453825.

This is a minimal patch to fix those regressions.
* only initialize vgaemu if !config.vga (no console graphics).
* don't set vbase to -1 when graphics are unmapped. When switching
  otherwise it is lost forever.
* the io bitmap change for cpuemu (619a60d0fb2) activated some code
  controlled by CPUEMU_DIRECT_IO which does not work properly here
  (because the same i/o instruction writes to port 0 and VGA ports).