### PR TITLE
use POSIX compliant `find` in mkpluginhooks

### DIFF
--- a/mkpluginhooks
+++ b/mkpluginhooks
@@ -15,7 +15,7 @@ PINC=plugin_incdirs
 PCONF=plugin_configure
 PARSDIR=src/base/init
 
-PDIRS=`cd $SRCDIR; find ./ -maxdepth 1 ! -name include -type d -printf ' %f'`
+PDIRS="$(cd $SRCDIR; find . -maxdepth 1 ! -name include ! -path . -type d -exec basename {} \;)"
 
 function gendummy {
   for i in $HEADERS; do


### PR DESCRIPTION
I'm trying to build dosemu2 in an alpine linux based docker container (for some good fun!). Alpine is a musl based distribution with base BusyBox binaries. The `find` command doesn't have the -printf option, so I've made a patch to handle this. Will keep you posted re: other build issues on this platform. Thanks!