### PR TITLE
Printf types 01

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -224,17 +224,17 @@ static void *mmap_mapping_kmem(int cap, dosaddr_t targ, size_t mapsize,
   int i;
   void *target;
 
-  Q__printf("MAPPING: map kmem, cap=%s, target=%x, size=%zx, source=%#zx\n",
-	cap, targ, mapsize, source);
+  Q__printf("MAPPING: map kmem, cap=%s, target=%x, size=%zx, source=%#jx\n",
+	cap, targ, mapsize, (intmax_t)source);
 
   i = map_find_idx(kmem_map, kmem_mappings, source);
   if (i == -1) {
-	error("KMEM mapping for %#llx was not allocated!\n", (long long)source);
+	error("KMEM mapping for %#jx was not allocated!\n", (intmax_t)source);
 	return MAP_FAILED;
   }
   if (kmem_map[i].len != mapsize) {
-	error("KMEM mapping for %#zx allocated for size %#x, but %#zx requested\n",
-	      source, kmem_map[i].len, mapsize);
+	error("KMEM mapping for %#jx allocated for size %#x, but %#zx requested\n",
+	      (intmax_t)source, kmem_map[i].len, mapsize);
 	return MAP_FAILED;
   }
   if (cap & MAPPING_COPYBACK) {
@@ -441,13 +441,14 @@ static void *alloc_mapping_kmem(size_t mapsize, off_t source)
 {
     void *addr, *addr2;
 
-    Q_printf("MAPPING: alloc kmem, source=%#zx size=%#zx\n", source, mapsize);
+    Q_printf("MAPPING: alloc kmem, source=%#jx size=%#zx\n",
+             (intmax_t)source, mapsize);
     if (source == -1) {
       error("KMEM mapping without source\n");
       leavedos(64);
     }
     if (map_find_idx(kmem_map, kmem_mappings, source) != -1) {
-      error("KMEM mapping for %#zx allocated twice!\n", source);
+      error("KMEM mapping for %#jx allocated twice!\n", (intmax_t)source);
       return MAP_FAILED;
     }
     open_kmem();

--- a/src/plugin/commands/commands.c
+++ b/src/plugin/commands/commands.c
@@ -66,6 +66,7 @@ int booton_main(int argc, char **argv)
 int dpmi_main(int argc, char **argv)
 {
 	if (argc == 1) {
+		int len;
 		com_printf("dosemu DPMI control program.\n\n");
 		com_printf("Usage: dpmi <switch> <value>\n\n");
 		com_printf("The following table lists the available parameters, "
@@ -74,8 +75,12 @@ int dpmi_main(int argc, char **argv)
 		com_printf("+--------------------------+-----------+----+---------------------------------+\n");
 		com_printf("| Parameter                |   Value   | Sw | Description                     |\n");
 		com_printf("+--------------------------+-----------+----+---------------------------------+\n");
-		com_printf("|$_dpmi                    |%#6x%s| -m | DPMI memory size in Kbytes      |\n",
-			    config.dpmi, config.dpmi ? "     " : "(off)");
+		com_printf("|$_dpmi                    |");
+		if (config.dpmi)
+			com_printf("%#x%n", config.dpmi, &len);
+		else
+			com_printf("%7s%n", "off", &len);
+		com_printf("%*s| -m | DPMI memory size in Kbytes      |\n", 11-len, "");
 		if (config.dpmi_base == -1)
 			com_printf("|$_dpmi_base               |    auto   | -b | Address of the DPMI memory pool |\n");
 		else

--- a/src/plugin/commands/commands.c
+++ b/src/plugin/commands/commands.c
@@ -20,6 +20,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
+#include <inttypes.h>
 
 #include "config.h"
 #include "emu.h"
@@ -78,7 +79,7 @@ int dpmi_main(int argc, char **argv)
 		if (config.dpmi_base == -1)
 			com_printf("|$_dpmi_base               |    auto   | -b | Address of the DPMI memory pool |\n");
 		else
-			com_printf("|$_dpmi_base               |0x%08lx | -b | Address of the DPMI memory pool |\n", config.dpmi_base);
+			com_printf("|$_dpmi_base               |0x%08" PRIxPTR " | -b | Address of the DPMI memory pool |\n", config.dpmi_base);
 		com_printf("|$_pm_dos_api              |    %s    | -p | Protected mode DOS API support  |\n",
 			    config.pm_dos_api ? "on " : "off");
 		com_printf("|$_ignore_djgpp_null_derefs|    %s    | -n | Disable DJGPP NULL-deref protec.|\n",


### PR DESCRIPTION
This patch series:
- [fixes #230] to remove the 32bit specific compilation warnings. Tested on 32bit, Q_printf formats appear to be correct, but would appreciate confirmation on 64 bit
- fixes the table alignment when printing dpmi info within DOS

Compiled on both 32 and 64 bit okay
