### PR TITLE
Little fix to allow boot from a floppy_a under imagedir

### DIFF
--- a/etc/global.conf
+++ b/etc/global.conf
@@ -492,7 +492,17 @@ else
     endif
     if (strlen($zzz))
       if (strchr($zzz, "/") != 0)
-        $zzz = $HOME, "/.dosemu/", $zzz
+        $hzzz = $HOME, "/.dosemu/", $zzz
+        $xxx = shell("test -r ", $hzzz);
+        if (!$DOSEMU_SHELL_RETURN)
+          $zzz = $hzzz
+        else
+          $izzz = $DOSEMU_HDIMAGE_DIR, "/", $zzz
+          $xxx = shell("test -r ", $izzz);
+          if (!$DOSEMU_SHELL_RETURN)
+            $zzz = $izzz
+          endif
+        endif
       endif
       $xxx = shell("test -r ", $zzz);
       if ($DOSEMU_SHELL_RETURN)
@@ -518,7 +528,17 @@ else
     endif
     if (strlen($zzz))
       if (strchr($zzz, "/") != 0)
-        $zzz = $HOME, "/.dosemu/", $zzz
+        $hzzz = $HOME, "/.dosemu/", $zzz
+        $xxx = shell("test -r ", $hzzz);
+        if (!$DOSEMU_SHELL_RETURN)
+          $zzz = $hzzz
+        else
+          $izzz = $DOSEMU_HDIMAGE_DIR, "/", $zzz
+          $xxx = shell("test -r ", $izzz);
+          if (!$DOSEMU_SHELL_RETURN)
+            $zzz = $izzz
+          endif
+        endif
       endif
       $xxx = shell("test -r ", $zzz);
       if ($DOSEMU_SHELL_RETURN)


### PR DESCRIPTION
Allow floppy boot to find images and directories with relative paths under imagedir if not found under ~/.dosemu. Helps ease the path for #236 removal of vbootfloppy