### PR TITLE
Bugfix, install.c was still asking the old download script for a list…

### DIFF
--- a/src/base/init/install.c
+++ b/src/base/init/install.c
@@ -222,7 +222,9 @@ static void call_installdos(void)
 	output = malloc(80 + 1);
 
 	printf_("Please choose which DOS flavour to install:\n");
-	fp = popen("loaddosinstall -l", "r");
+	ret = asprintf(&system_str, "%s/downloaddos -l", DOSEMULIB_DEFAULT);
+	assert(ret != 1);
+	fp = popen(system_str, "r");
 	while (fgets(output, 80 + 1, fp) != NULL) {
 		char *short_name = malloc(20);
 		char *name = malloc(255);


### PR DESCRIPTION
…. This could only work if a left over loadinstalldos was present.

I just found this bug. Things could never work if you never had installed a previous revision which still had a loaddosinstall script with the -l option.