### PR TITLE
fatfs: support for booting OpenDOS 7.01 & 7.02 (971119)

### DIFF
--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -874,6 +874,7 @@ void scan_dir(fatfs_t *f, unsigned oi)
                     while (!strstr(buf_ptr, "IBM DOS") &&
                            !strstr(buf_ptr, "PC-DOS") &&
                            !strstr(buf_ptr, "DR-DOS") &&
+                           !strstr(buf_ptr, "DR-OpenDOS") &&
                            !strstr(buf_ptr, "DIGITAL RESEARCH") &&
                            !strstr(buf_ptr, "Novell") && buf_ptr < buf + size) {
                         buf_ptr += strlen(buf_ptr) + 1;
@@ -881,7 +882,10 @@ void scan_dir(fatfs_t *f, unsigned oi)
                     if (buf_ptr < buf + size) {
                         if (strstr(buf_ptr, "IBM DOS"))
                             sys_type = NEWPCD_D;
-                        else if (strstr(buf_ptr, "DR-DOS") || strstr(buf_ptr, "Novell") || strstr(buf_ptr, "DIGITAL RESEARCH"))
+                        else if (strstr(buf_ptr, "DR-DOS") ||
+                                 strstr(buf_ptr, "DR-OpenDOS") ||
+                                 strstr(buf_ptr, "Novell") ||
+                                 strstr(buf_ptr, "DIGITAL RESEARCH"))
                             sys_type = MIDDRD_D;
                         else
                             sys_type = OLDPCD_D;

--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -875,6 +875,7 @@ void scan_dir(fatfs_t *f, unsigned oi)
                            !strstr(buf_ptr, "PC-DOS") &&
                            !strstr(buf_ptr, "DR-DOS") &&
                            !strstr(buf_ptr, "DR-OpenDOS") &&
+                           !strstr(buf_ptr, "Caldera") &&
                            !strstr(buf_ptr, "DIGITAL RESEARCH") &&
                            !strstr(buf_ptr, "Novell") && buf_ptr < buf + size) {
                         buf_ptr += strlen(buf_ptr) + 1;
@@ -884,6 +885,7 @@ void scan_dir(fatfs_t *f, unsigned oi)
                             sys_type = NEWPCD_D;
                         else if (strstr(buf_ptr, "DR-DOS") ||
                                  strstr(buf_ptr, "DR-OpenDOS") ||
+                                 strstr(buf_ptr, "Caldera") ||
                                  strstr(buf_ptr, "Novell") ||
                                  strstr(buf_ptr, "DIGITAL RESEARCH"))
                             sys_type = MIDDRD_D;


### PR DESCRIPTION
There seem to be at least two versions of DR-DOS 7.02 in the wild and
Wikipedia suggests there may be more. Add the string 'DR-OpenDOS' to the
whilelist of medium age DR-DOS versions so that detection may succeed.
[fixes #250]

Test run after fix applied
~~~
Test DR-DOS-7.02-971119 FAT12 vfs directory ... ok
Test DR-DOS-7.02-971119 FAT16 vfs directory ... ok
Test DR-DOS-7.02-971119 FAT16B vfs directory ... ok
Test DR-DOS-7.02-971119 MFS redirection ... ok
Test DR-DOS-7.02-971119 SysType ... ok
Test DR-DOS-7.02-971119 VBFLPY ... ok

Test DR-DOS-7.02-980123 FAT12 vfs directory ... ok
Test DR-DOS-7.02-980123 FAT16 vfs directory ... ok
Test DR-DOS-7.02-980123 FAT16B vfs directory ... ok
Test DR-DOS-7.02-980123 MFS redirection ... ok
Test DR-DOS-7.02-980123 SysType ... ok
Test DR-DOS-7.02-980123 VBFLPY ... ok
~~~
