### PR TITLE
Floppy02

### DIFF
--- a/doc/README.html
+++ b/doc/README.html
@@ -1220,10 +1220,6 @@ CLASS="SCREEN"
     # such as "hdimage_c directory_d hdimage_e"
     # Absolute pathnames are also allowed.
       $_hdimage = "drives/*"
-      $_vbootfloppy = ""    # if you want to boot from a virtual floppy:
-                            # file name of the floppy image under DOSEMU_LIB_DIR
-                            # e.g. "floppyimage" disables $_hdimage
-                            #      "floppyimage +hd" does _not_ disable $_hdimage
       $_floppy_a ="threeinch" # or "fiveinch" or empty, if not existing
       $_floppy_b = ""       # dito for B:
       $_cdrom = "/dev/cdrom" # list of CDROM devices</PRE
@@ -1370,48 +1366,10 @@ CLASS="SCREEN"
 
 will assign C: to drives/a and D: to drives/x, keep that in mind.</P
 ><P
->Now, what does the above `vbootfloppy' mean? Instead of booting
-from a virtual `disk' you may have an image of a virtual `floppy' which
-you just created such as `dd if=/dev/fd0 of=floppy_image'. If this
-floppy contains a bootable DOS, then</P
-><P
->&#13;<TABLE
-BORDER="0"
-BGCOLOR="#E0E0E0"
-WIDTH="100%"
-><TR
-><TD
-><PRE
-CLASS="SCREEN"
->      $_vbootfloppy = "floppy_image"</PRE
-></TD
-></TR
-></TABLE
->&#13;</P
-><P
->will boot that floppy. Once running in DOS you can make the floppy
-available by (virtually) removing the `media' via `bootoff.com'.
-If want the disk access specified via `$_hdimage' anyway, you may add the
-keyword `+hd' such as</P
-><P
->&#13;<TABLE
-BORDER="0"
-BGCOLOR="#E0E0E0"
-WIDTH="100%"
-><TR
-><TD
-><PRE
-CLASS="SCREEN"
->      $_vbootfloppy = "floppy_image +hd"</PRE
-></TD
-></TR
-></TABLE
->&#13;</P
-><P
 >In some rare cases you may have problems accessing Lredir'ed drives
 (especially when your DOS application refuses to run on a 'network drive'),
 For this to overcome you may need to use so-called `partition access',
-use a floppy (or a "vbootfloppy"), or a special-purpose hdimage. The odd
+use a floppy, or a special-purpose hdimage. The odd
 with partition access is, that you <SPAN
 CLASS="emphasis"
 ><I

--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -91,13 +91,6 @@
 
 # $_hdimage = "drives/*"
 
-# if you want to boot from a virtual floppy:
-# file name of the floppy image under DOSEMU_LIB_DIR
-# e.g. "floppyimage" disables $_hdimage
-#      "floppyimage +hd" does _not_ disable $_hdimage. Default: ""
-
-# $_vbootfloppy = ""
-
 # floppy drives.
 # May be set up to directory or to /dev/fdX device node.
 # Optionally the device type may be prepended, such as

--- a/etc/global.conf
+++ b/etc/global.conf
@@ -174,7 +174,7 @@ else
       $_sound_driver, $_midi_driver, $_snd_plugin_params, $_pcm_hpf, $_midi_file, $_wav_file,
       $_midi_synth, $_mpu_irq_mt32, $_munt_roms,
       $_joy_device, $_joy_dos_min, $_joy_dos_max, $_joy_granularity, $_joy_latency,
-      $_vbootfloppy, $_cdrom, $_aspi,
+      $_cdrom, $_aspi,
       $_SDL_nogl
     $xxx = $_vnet
     checkuservar $_vnet
@@ -432,55 +432,9 @@ else
 
   $_disks = shell("eval echo -n ", $_hdimage)
   dexe { allowdisk }
-  if (!strlen($_vbootfloppy))
-    bootdrive $_bootdrive
-    swap_bootdrive $_swap_bootdrive
-  else
-    bootdrive "a"
-    $yyy = ""; $zzz = "";
-    if (strlen($_vbootfloppy))
-      foreach $xxx ($LIST_DELIM, $_vbootfloppy)
-        if (strlen($yyy))
-          $zzz = $xxx
-        else
-          $yyy = $xxx
-        endif
-      done
-    endif
-    if (strchr($yyy, "/") != 0)
-      $yyyy = $HOME, "/.dosemu/", $yyy
-      shell("test -r '", $yyyy, "'")
-      if ($DOSEMU_SHELL_RETURN)
-        $yyyy = $DOSEMU_HDIMAGE_DIR, "/", $yyy
-      endif
-      $yyy = $yyyy
-    endif
-    $_vbootfloppy = $yyy
-    shell("test -d '", $yyy, "'")
-    if ($DOSEMU_SHELL_RETURN)
-      $size = shell("stat --printf=%s '", $yyy, "'")
-      if ($size == 2949120)        # 2.88M 3 1/2 inches
-        bootdisk { heads 2  sectors 36  tracks 80  threeinch_2880 file $_vbootfloppy }
-      else if ($size == 1474560)   # 1.44M 3 1/2 inches
-        bootdisk { heads 2  sectors 18  tracks 80  threeinch file $_vbootfloppy }
-      else if ($size == 737280)    # 720K 3 1/2 inches
-        bootdisk { heads 2  sectors 9  tracks 80  threeinch_720 file $_vbootfloppy }
-      else if ($size == 1228800)   # 1.2M 5 1/4 inches
-        bootdisk { heads 2  sectors 15  tracks 80  fiveinch file $_vbootfloppy }
-      else if ($size == 368640)    # 360K 5 1/4 inches
-        bootdisk { heads 2  sectors 9  tracks 40  fiveinch_360 file $_vbootfloppy }
-      else if ($size == 184320)    # 180K 5 1/4 inches
-        bootdisk { heads 1  sectors 9  tracks 40  fiveinch_360 file $_vbootfloppy }
-      else if ($size == 163840)    # 160K 5 1/4 inches
-        bootdisk { heads 1  sectors 8  tracks 40  fiveinch_360 file $_vbootfloppy }
-      endif endif endif endif endif endif endif
-    else
-      bootdisk { threeinch directory $_vbootfloppy readonly }
-    endif
-    if (strlen($zzz))
-      $_disks = shell("eval echo -n ", $_hdimage)
-    endif
-  endif
+  bootdrive $_bootdrive
+  swap_bootdrive $_swap_bootdrive
+
   if (strlen($_floppy_a))
     $zzz = strsplit($_floppy_a, strstr($_floppy_a, ":"), 999);
     if (strlen($zzz))

--- a/src/base/async/int.c
+++ b/src/base/async/int.c
@@ -377,10 +377,6 @@ int dos_helper(void)
     serial_helper();
     break;
 
-  case DOS_HELPER_BOOTDISK:	/* set/reset use bootdisk flag */
-    use_bootdisk = LO(bx) ? 1 : 0;
-    break;
-
   case DOS_HELPER_MOUSE_HELPER:	/* set mouse vector */
     mouse_helper(&vm86s.regs);
     break;

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -185,8 +185,8 @@ void dump_config_status(void (*printfunc)(const char *, ...))
         config.console_keyb, config.console_video);
     (*print)("kbd_tty %d\nexitearly %d\n",
         config.kbd_tty, config.exitearly);
-    (*print)("fdisks %d\nhdisks %d\nbootdisk %d\n",
-        config.fdisks, config.hdisks, config.bootdisk);
+    (*print)("fdisks %d\nhdisks %d\n",
+        config.fdisks, config.hdisks);
     (*print)("term_esc_char 0x%x\nterm_color %d\n",
         config.term_esc_char, config.term_color);
     (*print)("X_updatelines %d\n\n",

--- a/src/base/init/install.c
+++ b/src/base/init/install.c
@@ -358,8 +358,7 @@ void install_dos(int post_boot)
 	if (!disclaimer_shown())
 		do_liability_disclaimer_prompt(post_boot, !config.quiet);
 	first_time = first_boot_time();
-	if (!config.install && !first_time &&
-			(config.hdisks || config.bootdisk))
+	if (!config.install && !first_time && config.hdisks)
 		return;
 	if (config.emusys) {
 		error("$_emusys must be disabled before installing DOS\n");

--- a/src/base/init/lexer.l.in
+++ b/src/base/init/lexer.l.in
@@ -378,7 +378,6 @@ sillyint		RETURN(SILLYINT);
 irqpassing		RETURN(SILLYINT);
 hardware_ram		RETURN(HARDWARE_RAM);
 disk			RETURN(DISK);
-bootdisk		RETURN(BOOTDISK);
 bootfile		RETURN(BOOTFILE);
 printer			RETURN(PRINTER);
 emusys                  RETURN(EMUSYS);

--- a/src/base/init/parser.y.in
+++ b/src/base/init/parser.y.in
@@ -705,7 +705,7 @@ line		: HOGTHRESH expression	{ config.hogthreshold = $2; }
 		    { stop_disk(DISK); }
 		| L_FLOPPY
 		    { start_floppy(); }
-		  '{' disk_flags '}'
+		  '{' floppy_flags '}'
 		    { stop_disk(L_FLOPPY); }
                 | CDROM '{' string_expr '}'
                     {
@@ -1433,16 +1433,59 @@ optbootfile	: BOOTFILE string_expr
 		| /* empty */
 		;
 
-disk_flags	: disk_flag
-		| disk_flags disk_flag
+floppy_flags	: floppy_flag
+		| floppy_flags floppy_flag
 		;
-disk_flag	: READONLY		{ dptr->wantrdonly = 1; }
+floppy_flag	: READONLY              { dptr->wantrdonly = 1; }
 		| THREEINCH	{ dptr->default_cmos = THREE_INCH_FLOPPY; }
 		| THREEINCH_2880	{ dptr->default_cmos = THREE_INCH_288MFLOP; }
 		| THREEINCH_720	{ dptr->default_cmos = THREE_INCH_720KFLOP; }
 		| ATAPI		{ dptr->default_cmos = ATAPI_FLOPPY; }
 		| FIVEINCH	{ dptr->default_cmos = FIVE_INCH_FLOPPY; }
 		| FIVEINCH_360	{ dptr->default_cmos = FIVE_INCH_360KFLOP; }
+		| L_FLOPPY string_expr
+		  {
+		  struct stat st;
+
+		  if (dptr->dev_name != NULL)
+		    yyerror("Two names for a floppy-device given.");
+		  if (stat($2, &st) < 0) {
+		    yyerror("Could not stat floppy device.");
+		  }
+		  if (S_ISREG(st.st_mode)) {
+		    dptr->type = IMAGE;
+		  } else if (S_ISBLK(st.st_mode)) {
+		    dptr->type = FLOPPY;
+		  } else if (S_ISDIR(st.st_mode)) {
+		    dptr->type = DIR_TYPE;
+		  } else {
+		    yyerror("Floppy device/file %s is wrong type", $2);
+		  }
+		  dptr->dev_name = $2;
+		  dptr->floppy = 1;  // tell IMAGE and DIR we are a floppy
+		  }
+		| DEVICE string_expr optbootfile
+		  {
+		  if (dptr->dev_name != NULL)
+		    yyerror("Two names for a disk-image file or device given.");
+		  dptr->dev_name = $2;
+		  }
+		| DIRECTORY string_expr
+		  {
+		  if (dptr->dev_name != NULL)
+		    yyerror("Two names for a directory given.");
+		  dptr->type = DIR_TYPE;
+		  dptr->dev_name = $2;
+		  }
+		| STRING
+		    { yyerror("unrecognized floppy disk flag '%s'\n", $1); free($1); }
+		| error
+		;
+
+disk_flags	: disk_flag
+		| disk_flags disk_flag
+		;
+disk_flag	: READONLY		{ dptr->wantrdonly = 1; }
 		| DISKCYL4096	{ dptr->diskcyl4096 = 1; }
 		| HDTYPE1	{ dptr->hdtype = 1; }
 		| HDTYPE2	{ dptr->hdtype = 2; }
@@ -1478,27 +1521,6 @@ disk_flag	: READONLY		{ dptr->wantrdonly = 1; }
 		    yyerror("Two names for a harddisk given.");
 		  dptr->type = HDISK;
 		  dptr->dev_name = $2;
-		  }
-		| L_FLOPPY string_expr
-		  {
-		  struct stat st;
-
-		  if (dptr->dev_name != NULL)
-		    yyerror("Two names for a floppy-device given.");
-		  if (stat($2, &st) < 0) {
-		    yyerror("Could not stat floppy device.");
-		  }
-		  if (S_ISREG(st.st_mode)) {
-		    dptr->type = IMAGE;
-		  } else if (S_ISBLK(st.st_mode)) {
-		    dptr->type = FLOPPY;
-		  } else if (S_ISDIR(st.st_mode)) {
-		    dptr->type = DIR_TYPE;
-		  } else {
-		    yyerror("Floppy device/file %s is wrong type", $2);
-		  }
-		  dptr->dev_name = $2;
-		  dptr->floppy = 1;  // tell IMAGE and DIR we are a floppy
 		  }
 		| L_PARTITION string_expr INTEGER optbootfile
 		  {

--- a/src/base/init/parser.y.in
+++ b/src/base/init/parser.y.in
@@ -2114,7 +2114,7 @@ static void stop_disk(int token)
   if (dptr->type == NODISK)    /* Is it one of bootdisk, floppy, harddisk ? */
     yyerror("disk: no device/file-name given!"); /* No, error */
   else
-    c_printf("type %d ", dptr->type);
+    c_printf("type '%s' ", disk_t_str(dptr->type));
 
   if (dptr->type == PARTITION) {
     c_printf("partition# %d ", dptr->part_info.number);

--- a/src/base/init/parser.y.in
+++ b/src/base/init/parser.y.in
@@ -1486,10 +1486,24 @@ disk_flag	: READONLY		{ dptr->wantrdonly = 1; }
 		  }
 		| L_FLOPPY string_expr
 		  {
+		  struct stat st;
+
 		  if (dptr->dev_name != NULL)
 		    yyerror("Two names for a floppy-device given.");
-		  dptr->type = FLOPPY;
+		  if (stat($2, &st) < 0) {
+		    yyerror("Could not stat floppy device.");
+		  }
+		  if (S_ISREG(st.st_mode)) {
+		    dptr->type = IMAGE;
+		  } else if (S_ISBLK(st.st_mode)) {
+		    dptr->type = FLOPPY;
+		  } else if (S_ISDIR(st.st_mode)) {
+		    dptr->type = DIR_TYPE;
+		  } else {
+		    yyerror("Floppy device/file %s is wrong type", $2);
+		  }
 		  dptr->dev_name = $2;
+		  dptr->floppy = 1;  // tell IMAGE and DIR we are a floppy
 		  }
 		| L_PARTITION string_expr INTEGER optbootfile
 		  {
@@ -2103,21 +2117,20 @@ static void stop_disk(int token)
     yyerror("disk: no device/file-name given!");
   else                                /* check the file/device for existance */
     {
-      struct stat file_status;        /* date for checking that file */
+      struct stat st;
 
-      c_printf("device: %s ", dptr->dev_name);
-      if (stat(dptr->dev_name,&file_status) != 0) { /* Does this file exist? */
-        yyerror("Disk-device/file %s doesn't exist.",dptr->dev_name);
+      if (stat(dptr->dev_name, &st) != 0) { /* Does this file exist? */
+        yyerror("disk: device/file %s doesn't exist.", dptr->dev_name);
       }
     }
 
-  if (dptr->type == NODISK)    /* Is it one of bootdisk, floppy, harddisk ? */
+  if (dptr->type == NODISK)    /* Is it one of image, floppy, harddisk ? */
     yyerror("disk: no device/file-name given!"); /* No, error */
   else
-    c_printf("type '%s' ", disk_t_str(dptr->type));
+    c_printf("CONF: disk type '%s'", disk_t_str(dptr->type));
 
   if (dptr->type == PARTITION) {
-    c_printf("partition# %d ", dptr->part_info.number);
+    c_printf(" partition# %d", dptr->part_info.number);
 #ifdef __linux__
     mtab = NULL;
     if ((f = setmntent(MOUNTED, "r")) != NULL) {
@@ -2144,10 +2157,9 @@ static void stop_disk(int token)
   }
 
   if (dptr->header)
-    c_printf("header_size: %ld ", (long) dptr->header);
+    c_printf(" header_size: %ld", (long) dptr->header);
 
-  c_printf("h: %d  s: %d   t: %d", dptr->heads, dptr->sectors,
-	   dptr->tracks);
+  c_printf(" h: %d  s: %d  t: %d", dptr->heads, dptr->sectors, dptr->tracks);
 
   if (token == BOOTDISK) {
     config.bootdisk = 1;

--- a/src/base/init/parser.y.in
+++ b/src/base/init/parser.y.in
@@ -133,7 +133,6 @@ static void dump_keytables_to_file(char *name);
 static void stop_terminal(void);
 static void start_disk(void);
 static void do_part(char *);
-static void start_bootdisk(void);
 static void start_floppy(void);
 static void stop_disk(int token);
 static void start_vnet(char *);
@@ -245,7 +244,7 @@ while (0)
 %token TTYLOCKS L_SOUND L_SND_OSS L_JOYSTICK FULL_FILE_LOCKS
 %token DEXE ALLOWDISK FORCEXDOS XDOSONLY
 %token ABORT WARN
-%token BOOTDISK L_FLOPPY EMUSYS EMUINI L_X L_SDL
+%token L_FLOPPY EMUSYS EMUINI L_X L_SDL
 %token DOSEMUMAP LOGBUFSIZE LOGFILESIZE MAPPINGDRIVER
 %token LFN_SUPPORT
 	/* speaker */
@@ -704,10 +703,6 @@ line		: HOGTHRESH expression	{ config.hogthreshold = $2; }
 		    { start_disk(); }
 		  '{' disk_flags '}'
 		    { stop_disk(DISK); }
-		| BOOTDISK
-		    { start_bootdisk(); }
-		  '{' disk_flags '}'
-		    { stop_disk(BOOTDISK); }
 		| L_FLOPPY
 		    { start_floppy(); }
 		  '{' disk_flags '}'
@@ -2002,26 +1997,6 @@ static void stop_printer(void)
 
 	/* disk */
 
-static void start_bootdisk(void)
-{
-  if (config.bootdisk)           /* Already a bootdisk configured ? */
-    yyerror("There is already a bootdisk configured");
-
-  dptr = &bootdisk;              /* set pointer do bootdisk-struct */
-
-  dptr->diskcyl4096 = 0;
-  dptr->sectors = 0;             /* setup default-values           */
-  dptr->heads   = 0;
-  dptr->tracks  = 0;
-  dptr->type    = FLOPPY;
-  dptr->default_cmos = THREE_INCH_FLOPPY;
-  dptr->timeout = 0;
-  dptr->dev_name = NULL;              /* default-values */
-  dptr->boot_name = NULL;
-  dptr->wantrdonly = 0;
-  dptr->header = 0;
-}
-
 static void start_floppy(void)
 {
   if (c_fdisks >= MAX_FDISKS)
@@ -2159,14 +2134,7 @@ static void stop_disk(int token)
   if (dptr->header)
     c_printf(" header_size: %ld", (long) dptr->header);
 
-  c_printf(" h: %d  s: %d  t: %d", dptr->heads, dptr->sectors, dptr->tracks);
-
-  if (token == BOOTDISK) {
-    config.bootdisk = 1;
-    use_bootdisk = 1;
-    c_printf(" bootdisk\n");
-  }
-  else if (token == L_FLOPPY) {
+  if (token == L_FLOPPY) {
     c_printf(" floppy %c:\n", 'A'+c_fdisks);
     c_fdisks++;
     config.fdisks = c_fdisks;

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -91,6 +91,27 @@ static struct disk_fptr disk_fptrs[NUM_DTYPES] =
   {dir_auto, dir_setup}
 };
 
+char *disk_t_str(disk_t t) {
+  static char tmp[32];
+
+  switch (t) {
+    case NODISK:
+      return "None";
+    case IMAGE:
+      return "Image";
+    case HDISK:
+      return "Hard Disk";
+    case FLOPPY:
+      return "Floppy";
+    case PARTITION:
+      return "Partition";
+    case DIR_TYPE:
+      return "Directory";
+    default:
+      sprintf(tmp, "Unknown Type %d", t);
+      return tmp;
+  }
+}
 
 static void dump_disk_blks(unsigned tb, int count, int ssiz)
 {

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -44,8 +44,6 @@
 static int disks_initiated = 0;
 struct disk disktab[MAX_FDISKS];
 struct disk hdisktab[MAX_HDISKS];
-struct disk bootdisk;
-int use_bootdisk;
 
 #define FDISKS config.fdisks
 #define HDISKS config.hdisks
@@ -1058,13 +1056,9 @@ disk_close_all(void)
 {
   struct disk *dp;
 
-  if (!disks_initiated) return;  /* prevent idiocy */
-  if (config.bootdisk && bootdisk.fdesc >= 0) {
-    d_printf("Boot disk Closing %x\n", bootdisk.fdesc);
-    (void) close(bootdisk.fdesc);
-    bootdisk.fdesc = -1;
-    d_printf("BOOTDISK Closing\n");
-  }
+  if (!disks_initiated)
+    return;  /* prevent idiocy */
+
   for (dp = disktab; dp < &disktab[FDISKS]; dp++) {
     ATAPI_buf0[0] = 0;
     if (dp->fdesc >= 0) {
@@ -1122,12 +1116,6 @@ disk_init(void)
   disks_initiated = 1;  /* disk_init has been called */
   init_all_DOS_tables();
 
-  if (!FDISKS && use_bootdisk) {
-  /* if we don't have any configured floppies, we have to use bootdisk instead */
-    memcpy(&disktab[0], &bootdisk, sizeof(bootdisk));
-    FDISKS++;	/* now we have one */
-  }
-
   if (FDISKS) {
     emu_iodev_t  io_device;
 
@@ -1151,30 +1139,6 @@ static void disk_reset2(void)
   struct stat stbuf;
   struct disk *dp;
   int i;
-
-  if (config.bootdisk) {
-    bootdisk.fdesc = -1;
-    bootdisk.rdonly = bootdisk.wantrdonly;
-    bootdisk.removeable = 1;
-    bootdisk.floppy = 1;
-    bootdisk.drive_num = 0;
-    bootdisk.serial = 0xB00B00B0;
-    if (bootdisk.type == DIR_TYPE) {
-      bootdisk.removeable = 0;
-      disk_fptrs[bootdisk.type].autosense(&bootdisk);
-      disk_fptrs[bootdisk.type].setup(&bootdisk);
-    } else {
-      if (stat(bootdisk.dev_name, &stbuf) < 0) {
-        error("can't stat %s\n", bootdisk.dev_name);
-        config.exitearly = 1;
-        return;
-      }
-      if (S_ISREG(stbuf.st_mode)) {
-        d_printf("dev %s is an image\n", bootdisk.dev_name);
-        bootdisk.type = IMAGE;
-      }
-    }
-  }
 
   /*
    * Open floppy disks
@@ -1327,10 +1291,6 @@ void disk_reset(void)
   for (i = 0; i < 26; i++)
     ResetRedirection(i);
   set_int21_revectored(redir_state = 1);
-  if (config.bootdisk && bootdisk.type == DIR_TYPE) {
-    if (bootdisk.fatfs) fatfs_done(&bootdisk);
-    fatfs_init(&bootdisk);
-  }
   for (dp = disktab; dp < &disktab[FDISKS]; dp++) {
     if(dp->type == DIR_TYPE) {
       if (dp->fatfs) fatfs_done(dp);
@@ -1369,10 +1329,8 @@ int int13(void)
   int checkdp_val;
 
   disk = LO(dx);
-  if (!disk && use_bootdisk)
-    dp = &bootdisk;
-  else if (disk < FDISKS) {
-      dp = &disktab[disk];
+  if (disk < FDISKS) {
+    dp = &disktab[disk];
     switch (HI(ax)) {
       /* NOTE: we use this counter for closing. Also older games seem to rely
        * on it. We count it down in INT08 (bios.S) --SW, --Hans, --Bart
@@ -1992,8 +1950,7 @@ floppy_tick(void)
 fatfs_t *get_fat_fs_by_serial(unsigned long serial)
 {
   struct disk *dp;
-  if (bootdisk.type == DIR_TYPE && bootdisk.fatfs && bootdisk.serial == serial)
-    return bootdisk.fatfs;
+
   for (dp = disktab; dp < &disktab[FDISKS]; dp++) {
     if(dp->type == DIR_TYPE && dp->fatfs && dp->serial == serial)
       return dp->fatfs;
@@ -2009,9 +1966,8 @@ fatfs_t *get_fat_fs_by_drive(unsigned char drv_num)
 {
   struct disk *dp = NULL;
   int num = drv_num & 0x7f;
-  if (!drv_num && config.bootdisk)
-    dp = &bootdisk;
-  else if (drv_num & 0x80) {
+
+  if (drv_num & 0x80) {
     if (num >= HDISKS)
       return NULL;
     dp = &hdisktab[num];

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -676,8 +676,6 @@ static void dir_setup(struct disk *dp)
 
   while(--i >= 0) if(dp->dev_name[i] == '/') dp->dev_name[i] = 0; else break;
 
-  d_printf("partition setup for directory %s\n", dp->dev_name);
-
   pi->p.start_head = 1;
   pi->p.start_sector = 1;
   pi->p.start_track = 0;
@@ -727,18 +725,17 @@ static void dir_setup(struct disk *dp)
     mp->num_sectors = pi->p.num_sectors;
     mbr[SECTOR_SIZE - 2] = 0x55;
     mbr[SECTOR_SIZE - 1] = 0xaa;
+
+    d_printf("DIR partition setup for directory %s\n", dp->dev_name);
+
+    d_printf("DIR partition table entry for device %s is:\n", dp->dev_name);
+    d_printf("beg head %d, sec %d, cyl %d = end head %d, sec %d, cyl %d\n",
+             pi->p.start_head, pi->p.start_sector, pi->p.start_track,
+             pi->p.end_head, pi->p.end_sector, pi->p.end_track);
+    d_printf("pre_secs %d, num_secs %d = %x, -dp->header %ld = 0x%lx\n",
+             pi->p.num_sect_preceding, pi->p.num_sectors, pi->p.num_sectors,
+             (long) -dp->header, (unsigned long) -dp->header);
   }
-  d_printf("partition table entry for device %s is:\n", dp->dev_name);
-  d_printf(
-    "beg head %d, sec %d, cyl %d = end head %d, sec %d, cyl %d\n",
-    pi->p.start_head, pi->p.start_sector, pi->p.start_track,
-    pi->p.end_head, pi->p.end_sector, pi->p.end_track
-  );
-  d_printf(
-    "pre_secs %d, num_secs %d = %x, -dp->header %ld = 0x%lx\n",
-    pi->p.num_sect_preceding, pi->p.num_sectors, pi->p.num_sectors,
-    (long) -dp->header, (unsigned long) -dp->header
-  );
 
   dp->fatfs = NULL;
 }

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1104,11 +1104,6 @@ static void floppy_io_write(ioport_t port, Bit8u value)
 void
 disk_init(void)
 {
-#ifdef SILLY_GET_GEOMETRY
-  int s;
-  char buf[512], label[12];
-#endif
-
   struct disk *dp;
   int i;
 
@@ -1153,6 +1148,11 @@ disk_init(void)
 
 static void disk_reset2(void)
 {
+#ifdef SILLY_GET_GEOMETRY
+  int s;
+  char buf[512], label[12];
+#endif
+
   struct stat stbuf;
   struct disk *dp;
   int i;

--- a/src/base/misc/userhook.c
+++ b/src/base/misc/userhook.c
@@ -61,7 +61,6 @@ static void uhook_version(int argc, char **argv);
 static void uhook_keystroke(int argc, char **argv);
 static void uhook_log(int argc, char **argv);
 static void uhook_hog(int argc, char **argv);
-static void uhook_boot(int argc, char **argv);
 static void uhook_xmode(int argc, char **argv);
 static void uhook_lredir(int argc, char **argv);
 static void uhook_help(int argc, char **argv);
@@ -76,7 +75,6 @@ static const struct cmd_db cmdtab[] = {
 	{"keystroke",	uhook_keystroke},
 	{"log",		uhook_log},
 	{"hog",		uhook_hog},
-	{"boot",	uhook_boot},
 	{"xmode",	uhook_xmode},
 	{"lredir",	uhook_lredir},
 	{"help",	uhook_help},
@@ -93,7 +91,6 @@ static char help_string[] =
 	"keystroke <strokes> insert keystrokes into the DOS session\n"
 	"log [debugflags]    get/set debugflags which control log output\n"
 	"hog [value]         get/set the HogThreshold\n"
-	"boot [{on|off}]     get/set the mode of the vbootfloppy\n"
 	"xmode [<args>]      set X parameters, without args gives help\n"
 	"lredir n: dir [ro]  redirect directory 'dir' to DOS drive 'n:'\n"
 	"help                this screen\n"
@@ -193,16 +190,6 @@ static void uhook_hog(int argc, char **argv)
 		config.hogthreshold = hog;
 	}
 	uhook_printf("hogthreshold=%d\n", config.hogthreshold);
-}
-
-static void uhook_boot(int argc, char **argv)
-{
-	do_syn(argv[0]);
-	if (argv[1]) {
-		if (!strcmp(argv[1], "on")) use_bootdisk = 1;
-		else if (!strcmp(argv[1], "off")) use_bootdisk = 0;
-	}
-	uhook_printf("bootdisk=%s\n", use_bootdisk ? "on" : "off");
 }
 
 static void uhook_xmode(int argc, char **argv)

--- a/src/doc/DANG/DANG.sgml
+++ b/src/doc/DANG/DANG.sgml
@@ -3530,7 +3530,7 @@ The Helper Interrupt uses the following groups:
 0x21-0x22 - EMS functions
 0x28      - Garrot Functions for use with the mouse
 0x29      - Serial functions
-0x30      - Whether to use the BOOTDISK predicate
+0x30      - (removed functionality)
 0x33      - Mouse Functions
 0x40      - CD-ROM functions
 0x50-0x5f - DOSEMU/Linux communications

--- a/src/doc/README/commands
+++ b/src/doc/README/commands
@@ -12,22 +12,6 @@ These are some utitlies to assist you in using Dosemu.
 <variablelist>
 
 <varlistentry>
-<term>bootoff.com</term>
-<listitem>
-<para>
- switch off the bootfile to access disk
-see examples/config.dist at bootdisk option
-</para>
-</listitem></varlistentry>
-<varlistentry>
-<term>booton.com</term>
-<listitem>
-<para>
- switch on the bootfile to access bootfile
-see examples/config.dist at bootdisk option
-</para>
-</listitem></varlistentry>
-<varlistentry>
 <term>uchdir.com</term>
 <listitem>
 <para>

--- a/src/doc/README/config
+++ b/src/doc/README/config
@@ -290,10 +290,6 @@ setup:
 # such as "hdimage_c directory_d hdimage_e"
 # Absolute pathnames are also allowed.
   $_hdimage = "drives/*"
-  $_vbootfloppy = ""    # if you want to boot from a virtual floppy:
-                        # file name of the floppy image under DOSEMU_LIB_DIR
-                        # e.g. "floppyimage" disables $_hdimage
-                        #      "floppyimage +hd" does _not_ disable $_hdimage
   $_floppy_a ="threeinch" # or "fiveinch" or empty, if not existing
   $_floppy_b = ""       # dito for B:
   $_cdrom = "/dev/cdrom" # list of CDROM devices
@@ -379,40 +375,10 @@ will assign C: to drives/a and D: to drives/x, keep that in mind.
 </para>
 
 <para>
-Now, what does the above `vbootfloppy' mean? Instead of booting
-from a virtual `disk' you may have an image of a virtual `floppy' which
-you just created such as `dd if=/dev/fd0 of=floppy_image'. If this
-floppy contains a bootable DOS, then
-</para>
-
-<para>
-
-<screen>
-  $_vbootfloppy = "floppy_image"
-</screen>
-
-</para>
-
-<para>
-will boot that floppy. Once running in DOS you can make the floppy
-available by (virtually) removing the `media' via `bootoff.com'.
-If want the disk access specified via `$_hdimage' anyway, you may add the
-keyword `+hd' such as
-</para>
-
-<para>
-
-<screen>
-  $_vbootfloppy = "floppy_image +hd"
-</screen>
-
-</para>
-
-<para>
 In some rare cases you may have problems accessing Lredir'ed drives
 (especially when your DOS application refuses to run on a 'network drive'),
 For this to overcome you may need to use so-called `partition access',
-use a floppy (or a "vbootfloppy"), or a special-purpose hdimage. The odd
+use a floppy, or a special-purpose hdimage. The odd
 with partition access is, that you <emphasis>never</emphasis> should have
 those partition
 mounted in the Linux file system at the same time as you use it in DOSEMU

--- a/src/emu.c
+++ b/src/emu.c
@@ -133,9 +133,7 @@ void boot(void)
 
     switch (config.hdiskboot) {
     case 0:
-	if (config.bootdisk)
-	    dp = &bootdisk;
-	else if (config.fdisks > 0)
+	if (config.fdisks > 0)
 	    dp = &disktab[0];
 	else {
 	    error("Drive A: not defined, can't boot!\n");

--- a/src/include/disks.h
+++ b/src/include/disks.h
@@ -81,19 +81,11 @@ struct disk {
   fatfs_t *fatfs;		/* for FAT file system emulation */
 };
 
-#if 0
 /* NOTE: the "header" element in the structure above can (and will) be
  * negative. This facilitates treating partitions as disks (i.e. using
  * /dev/hda1 with a simulated partition table) by adjusting out the
  * simulated partition table offset...
  */
-
-struct disk_fptr {
-  void (*autosense) (struct disk *);
-  void (*setup) (struct disk *);
-};
-
-#endif
 
 /*
  * this header appears only in hdimage files
@@ -169,20 +161,7 @@ int read_mbr(struct disk *dp, unsigned buffer);
 int read_sectors(struct disk *, unsigned, long, long, long, long);
 int write_sectors(struct disk *, unsigned, long, long, long, long);
 
-void d_nullf(struct disk *);
-
-void image_auto(struct disk *);
-void hdisk_auto(struct disk *);
-void dir_auto(struct disk *);
 void disk_open(struct disk *dp);
-
-#define partition_auto	hdisk_auto
-#define floppy_auto	d_nullf
-
-#define hdisk_setup	d_nullf
-void partition_setup(struct disk *);
-void image_setup(struct disk *);
-void dir_setup(struct disk *);
 
 void fdkernel_boot_mimic(void);
 

--- a/src/include/disks.h
+++ b/src/include/disks.h
@@ -134,16 +134,6 @@ extern struct disk disktab[MAX_FDISKS];
  */
 extern struct disk hdisktab[MAX_HDISKS];
 
-/*
- * Special bootdisk which can be temporarily swapped out for drive A,
- * during the boot process.  The idea is to boot off the bootdisk, and
- * then have the autoexec.bat swap out the boot disk for the "real"
- * drive A.
- */
-extern struct disk bootdisk;
-
-extern int use_bootdisk;
-
 #if 1
 #ifdef __linux__
 #define DISK_OFFSET(dp,h,s,t) \

--- a/src/include/disks.h
+++ b/src/include/disks.h
@@ -28,6 +28,8 @@ typedef enum {
   NUM_DTYPES
 } disk_t;
 
+char *disk_t_str(disk_t t);
+
 #define DISK_RDWR	0
 #define DISK_RDONLY	1
 

--- a/src/include/doshelpers.h
+++ b/src/include/doshelpers.h
@@ -10,7 +10,7 @@
  * 0x21-0x22 - EMS functions
  * 0x28      - Garrot Functions for use with the mouse
  * 0x29      - Serial functions
- * 0x30      - Whether to use the BOOTDISK predicate
+ * 0x30      - (removed functionality)
  * 0x33      - Mouse Functions
  * 0x40      - CD-ROM functions
  * 0x50-0x5f - DOSEMU/Linux communications
@@ -61,7 +61,8 @@
 #define DOS_HELPER_SERIAL_HELPER    0x29
 
 
-#define DOS_HELPER_BOOTDISK         0x30
+#define DOS_HELPER_BOOTDISK         0x30  /* OLD, removed functionality */
+
 
 #define DOS_HELPER_MOUSE_HELPER     0x33
 

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -252,7 +252,6 @@ typedef struct config_info {
        						     32K for vbios_seg=0xc000) */
        boolean vbios_post;
 
-       boolean bootdisk;	/* Special bootdisk defined */
        int  fastfloppy;
        char *emusys;		/* map CONFIG.SYS to CONFIG.EMU */
        char *emuini;           /* map system.ini to  system.EMU */

--- a/src/plugin/commands/Makefile
+++ b/src/plugin/commands/Makefile
@@ -20,7 +20,7 @@ DEPENDS=$(CFILES:.c=.d) $(SFILES:.S=.d)
 D:=$(BINPATH)/commands
 
 COM = $(D)/generic.com
-STUBSYMLINK = $(D)/bootoff.com $(D)/booton.com $(D)/ecpuon.com $(D)/ecpuoff.com $(D)/eject.com \
+STUBSYMLINK = $(D)/ecpuon.com $(D)/ecpuoff.com $(D)/eject.com \
   $(D)/exitemu.com $(D)/speed.com $(D)/cmdline.com \
   $(D)/vgaoff.com $(D)/vgaon.com $(D)/lredir.com $(D)/emumouse.com $(D)/xmode.com $(D)/dosdbg.com \
   $(D)/unix.com $(D)/system.com $(D)/blaster.com $(D)/sound.com $(D)/dpmi.com $(D)/lredir2.com

--- a/src/plugin/commands/commands.c
+++ b/src/plugin/commands/commands.c
@@ -50,19 +50,6 @@ static int do_doshelper(int ax, int bx)
 	return LWORD(ebx);
 }
 
-int bootoff_main(int argc, char **argv)
-{
-	do_doshelper(DOS_HELPER_BOOTDISK, 0);
-	return 0;
-}
-
-
-int booton_main(int argc, char **argv)
-{
-	do_doshelper(DOS_HELPER_BOOTDISK, 1);
-	return 0;
-}
-
 int dpmi_main(int argc, char **argv)
 {
 	if (argc == 1) {
@@ -227,8 +214,6 @@ void commands_plugin_init(void)
 	register_com_program("GENERIC", generic_main);
 
 	/* old xxx.S files */
-	register_com_program("BOOTOFF", bootoff_main);
-	register_com_program("BOOTON", booton_main);
 	register_com_program("DPMI", dpmi_main);
 	register_com_program("ECPUON", ecpuon_main);
 	register_com_program("ECPUOFF", ecpuoff_main);


### PR DESCRIPTION
Hi as you suggested in PR #257, it gets a lot smaller if you don't add another type, use the 'dp->floppy' to determine the flavour of the image, and just use the cmos type if size is unrecognised. I have only converted half the PR as yet, the vbootfloppy stuff is still in etc, but I would like you to have a look at a strange problem please?
In disks.c at line 1179 you'll see that I have left a FIXME next to the invalidation of dp->fdesc. It shouldn't be necessary to do that for an image, in fact it forces a reopen in disk_reset2(), but if I don't do it I get messages about invalid file descriptors and a crash. It's as if some other thread jumps in and closes the file elsewhere. I notice that emu.c is also fiddling with disks at boot, are these run in different threads concurrently?

Thanks