### PR TITLE
Fatfs01

### DIFF
--- a/src/include/disks.h
+++ b/src/include/disks.h
@@ -37,6 +37,50 @@ char *disk_t_str(disk_t t);
 #define  DISK_IS_DEXE		1
 #define  DISK_DEXE_RDWR		2
 
+struct on_disk_bpb {
+  uint16_t bytes_per_sector;
+  uint8_t sectors_per_cluster;
+  uint16_t reserved_sectors;
+  uint8_t num_fats;
+  uint16_t num_root_entries;
+  uint16_t num_sectors_small;
+  uint8_t media_type;
+  uint16_t sectors_per_fat;
+  uint16_t sectors_per_track;
+  uint16_t num_heads;
+  union {
+    struct {
+      uint16_t hidden_sectors;
+    } __attribute__((packed)) v300;
+    struct {
+      uint16_t hidden_sectors;
+      uint16_t num_sectors_large;
+    } __attribute__((packed)) v320;
+    struct {
+      uint32_t hidden_sectors;
+      uint32_t num_sectors_large;
+    } __attribute__((packed)) v331;
+    struct {
+      uint32_t hidden_sectors;
+      uint32_t num_sectors_large;
+      uint8_t drive_number;
+      uint8_t flags;
+      uint8_t signature;  // 0x28
+      uint32_t serial_number;
+    } __attribute__((packed)) v340;
+    struct {
+      uint32_t hidden_sectors;
+      uint32_t num_sectors_large;
+      uint8_t drive_number;
+      uint8_t flags;
+      uint8_t signature;  // 0x29
+      uint32_t serial_number;
+      char vol_label[11];
+      char fat_type[8];
+    } __attribute__((packed)) v400;
+  };
+} __attribute__((packed));
+
 struct on_disk_partition {
   unsigned char bootflag;		/* 0x80 - active */
   unsigned char start_head;

--- a/src/tools/periph/mkfatimage16.c
+++ b/src/tools/periph/mkfatimage16.c
@@ -501,7 +501,7 @@ int main(int argc, char *argv[])
   write_buffer();
 
   /* Write FATs. */
-  memset(fat, 0, sizeof(sectors_per_fat*BYTES_PER_SECTOR));
+  memset(fat, 0, sectors_per_fat*BYTES_PER_SECTOR);
   put_fat(0, 0xfff8);
   put_fat(1, 0xffff);
   for (n = 0; (n < input_file_count); n++)


### PR DESCRIPTION
This tidies up the creation of the BPB for creation of virtual FAT directories and real FAT images. In doing so it corrects some issues with both fatfs.c and mkfatimage16.c, such that 10 more tests in my 300 test testsuite now pass instead of failing.
1/ mkfatimage16 when using a bootblk now respects its format instead of writing a v4 blk on boot code.
2/ mkfatimage16 some field offsets were wrong in BPB
3/ mkfatimage16 fixed odd memset with sizeof operator used incorrectly
4/ fatfs can use bpb v3.31 for geometry if size indicates that it must be fat16b

