### PR TITLE
Disks06

### DIFF
--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -1431,10 +1431,6 @@ void build_boot_blk(fatfs_t *f, unsigned char *b)
   b[0x02] = 0x90;
   memcpy(b + 0x40, boot_prog, boot_prog_end - boot_prog);
 
-  /* tell our boot block where the txfr data is */
-  b[0x3e] = ((boot_txfr-boot_prog) + 0x7c40);
-  b[0x3f] = ((boot_txfr-boot_prog) + 0x7c40) >> 8;
-
   /* add the boot block signature */
   b[0x1fe] = 0x55;
   b[0x1ff] = 0xaa;

--- a/src/base/misc/fatfs.h
+++ b/src/base/misc/fatfs.h
@@ -74,5 +74,7 @@ int fatfs_write(fatfs_t *, unsigned, unsigned, int);
 /* boot sector */
 extern const unsigned char boot_prog[];
 extern const unsigned char boot_prog_end[];
+extern unsigned char boot_txfr[];
+extern unsigned char boot_message[];
 
 #endif

--- a/src/base/misc/fatfs_boot.S
+++ b/src/base/misc/fatfs_boot.S
@@ -30,8 +30,6 @@ read_cnt        = 0x12
 drive           = 0x13
 read_tabs       = 0x14
 
-tab	=	boot_ofs + 0x3e
-
 main:
 	cli
 	cld
@@ -41,7 +39,7 @@ main:
 	sti
 	movw	%ax,%ds
 	movw	%ax,%es
-	movw	tab,%bp
+	movw	$((boot_txfr - main) + 0x7c40),%bp
 	leaw	read_tabs(%bp),%si
 	cmpb	read_cnt(%bp), %al
 	je	main_30

--- a/src/base/misc/fatfs_boot.S
+++ b/src/base/misc/fatfs_boot.S
@@ -102,7 +102,19 @@ boot_txfr:
 	.fill	0x10*4 /* sizeof(struct ibm_ms_diskaddr_pkt) * list length */
 
 	.align 4
-	.byte	4, 3, 2, 1, 13 // 5 magic bytes (for IO.SYS compatibility) :-)
+/*
+ * Currently this sequence is ignored in fatfs.c as we are unable to trigger
+ * MS-DOS 7.10 to print it to confirm it's actually required. After checking
+ * over 40 different boot blocks I cannot find this sequence occuring so I
+ * doubt the actual values are significant. If subsequently we find that a
+ * failing MS-DOS 7+ boot is printing our failure message with five bytes
+ * missing off the front we can investigate adjusting the string address for
+ * MS-DOS 7+ in fatfs.c and reenable this if necessary.
+ *
+ * 5 magic bytes (for IO.SYS compatibility) :-)
+ *
+	.byte	4, 3, 2, 1, 13
+ */
 	.globl	boot_message
 boot_message:
 	.asciz "Default fatfs_boot.S message\r\n"

--- a/src/base/misc/fatfs_boot.S
+++ b/src/base/misc/fatfs_boot.S
@@ -11,7 +11,7 @@
 
 #include "doshelpers.h"
 
-.code16	
+.code16
 .text
 	.globl	boot_prog
 boot_prog:
@@ -70,7 +70,7 @@ main_20:
 	movw	_bp(%bp),%bp
 	lret
 main_30:
-	mov	$((text - main) + 0x7c40),%si
+	mov	$((boot_message - main) + 0x7c40),%si
 write_msg:
 	lodsb
 	orb	%al,%al
@@ -87,9 +87,27 @@ write_msg_20:
 	int	$0x10
 	jmp	write_msg
 
-/*# 5 magic bytes (for IO.SYS compatibility) :-))*/
-	.byte	4, 3, 2, 1, 13
-text:
+	.align 2
+	.globl	boot_txfr
+boot_txfr:
+	.word	0x0    /* start ofs */
+	.word	0x0    /* start seg */
+	.word	0x0    /* ax */
+	.word	0x0    /* bx */
+	.word	0x0    /* cx */
+	.word	0x0    /* dx */
+	.word	0x0    /* si */
+	.word	0x0    /* di */
+	.word	0x0    /* bp */
+	.byte	0x0    /* number of list items */
+	.byte	0x0    /* drive */
+	.fill	0x10*4 /* sizeof(struct ibm_ms_diskaddr_pkt) * list length */
+
+	.align 4
+	.byte	4, 3, 2, 1, 13 // 5 magic bytes (for IO.SYS compatibility) :-)
+	.globl	boot_message
+boot_message:
+	.asciz "Default fatfs_boot.S message\r\n"
 
 	.globl	boot_prog_end
 boot_prog_end:


### PR DESCRIPTION
Here are some more disk commits:

1/ Clean ups to the boot block that dosemu provides for hdimage directory.

2/ There is also a commit for the MS-DOS Nec v3.30 to finally fix #49
~~~
Test MS-DOS-3.30-Nec FAT12 image file ... ok                                    
Test MS-DOS-3.30-Nec FAT12 vfs directory ... ok                                 
Test MS-DOS-3.30-Nec FAT12 vfs directory boot.blk ... ok                        
Test MS-DOS-3.30-Nec FAT16 image file ... ok                                    
Test MS-DOS-3.30-Nec FAT16 vfs directory ... ok                                 
Test MS-DOS-3.30-Nec FAT16 vfs directory boot.blk ... ok                        
Test MS-DOS-3.30-Nec FAT16B image file ... SKIP: Not supported by OS            
Test MS-DOS-3.30-Nec FAT16B vfs directory ... SKIP: Not supported by OS         
Test MS-DOS-3.30-Nec FAT16B vfs directory boot.blk ... SKIP: Not supported by OS
Test MS-DOS-3.30-Nec Floppy image file ... ok                                   
Test MS-DOS-3.30-Nec Floppy vfs directory ... ok                                
Test MS-DOS-3.30-Nec MFS redirection ... FAIL                                   
Test MS-DOS-3.30-Nec SysType ... ok                                             
Test MS-DOS-3.30 FAT12 image file ... ok                                        
Test MS-DOS-3.30 FAT12 vfs directory ... ok                                     
Test MS-DOS-3.30 FAT12 vfs directory boot.blk ... ok                            
Test MS-DOS-3.30 FAT16 image file ... ok                                        
Test MS-DOS-3.30 FAT16 vfs directory ... ok                                     
Test MS-DOS-3.30 FAT16 vfs directory boot.blk ... ok                            
Test MS-DOS-3.30 FAT16B image file ... SKIP: Not supported by OS                
Test MS-DOS-3.30 FAT16B vfs directory ... SKIP: Not supported by OS             
Test MS-DOS-3.30 FAT16B vfs directory boot.blk ... SKIP: Not supported by OS    
Test MS-DOS-3.30 Floppy image file ... ok                                       
Test MS-DOS-3.30 Floppy vfs directory ... ok                                    
Test MS-DOS-3.30 MFS redirection ... FAIL                                       
Test MS-DOS-3.30 SysType ... ok                                                 
~~~

I ran the Test suite of 42 different flavours of DOS, with no regressions and two fixes (MS-DOS Nec v3.30 vfs directory)

Questions:
- The OS missing default case in fatfs.c currently jumps to a hardcoded address(0x7c8c) I'd like make that update at assembly time by adding a global symbol. It wasn't obvious to me which instruction in the .S file should be the target, even before the reorg so it may already be wrong. Can you suggest where the jump should land?
- The OS case in fatfs.c for MS-DOS >= 7.0 references a magic string ('\4\3\2\1\r') that IO.SYS needs to validate the boot failure message. I could not find this string in a real MS-DOS 7.10 boot block, Do you know where the requirement came from, as git shows it was present in the initial commit?

  
