### PR TITLE
Prevent problems when using paths containing spaces.

### DIFF
--- a/src/bindist/autodos7.bat
+++ b/src/bindist/autodos7.bat
@@ -6,9 +6,9 @@ SET OPENDOSCFG=D:\OPENDOS
 CALL D:\EMUBIN\UXMACROS.BAT
 system -s CDROM_PATH
 if "%CDROM_PATH%" == "" goto nocdrom
-lredir2 -nC linux\fs%CDROM_PATH%
+lredir2 -nC "linux\fs%CDROM_PATH%"
 :nocdrom
 system -s DOSDRIVE_EXTRA
 if "%DOSDRIVE_EXTRA%" == "" goto nodrived
-lredir2 -n linux\fs%DOSDRIVE_EXTRA%
+lredir2 -n "linux\fs%DOSDRIVE_EXTRA%"
 :nodrived

--- a/src/bindist/autoemu.bat
+++ b/src/bindist/autoemu.bat
@@ -5,11 +5,11 @@ sound /e
 prompt $P$G
 system -s CDROM_PATH
 if "%CDROM_PATH%" == "" goto nocdrom
-lredir2 -nC linux\fs%CDROM_PATH%
+lredir2 -nC "linux\fs%CDROM_PATH%"
 :nocdrom
 system -s DOSDRIVE_EXTRA
 if "%DOSDRIVE_EXTRA%" == "" goto nodrived
-lredir2 -n linux\fs%DOSDRIVE_EXTRA%
+lredir2 -n "linux\fs%DOSDRIVE_EXTRA%"
 :nodrived
 mode con codepage prepare=((850) d:\dos\ega.cpi)
 mode con codepage select=850

--- a/src/bindist/autoexec.bat
+++ b/src/bindist/autoexec.bat
@@ -7,11 +7,11 @@ sound /e
 prompt $P$G
 system -s CDROM_PATH
 if "%CDROM_PATH%" == "" goto nocdrom
-lredir2 -nC linux\fs%CDROM_PATH%
+lredir2 -nC "linux\fs%CDROM_PATH%"
 :nocdrom
 system -s DOSDRIVE_EXTRA
 if "%DOSDRIVE_EXTRA%" == "" goto nodrived
-lredir2 -n linux\fs%DOSDRIVE_EXTRA%
+lredir2 -n "linux\fs%DOSDRIVE_EXTRA%"
 :nodrived
 rem uncomment to load another bitmap font
 rem lh display con=(vga,437,2)


### PR DESCRIPTION
This allows -cdrom to work when it points to a path with spaces.