### PR TITLE
build: Search plugindir for plugins

### DIFF
--- a/src/arch/linux/Makefile.main
+++ b/src/arch/linux/Makefile.main
@@ -131,7 +131,7 @@ include/version.h: ../Makefile.conf ../VERSION
 
 include/confpath.h: ../Makefile.conf
 	echo '#define  ALTERNATE_ETC      "$(etcdir)"' > $@
-	echo '#define  LIB_DEFAULT  "$(libdir)"' >> $@
+	echo '#define  DOSEMUPLUGINDIR "$(plugindir)"' >> $@
 	echo '#define  DOSEMULIB_DEFAULT  "$(dosemudir)"' >> $@
 	echo '#define  DOSEMUHDIMAGE_DEFAULT "$(syshdimagedir)"' >> $@
 	echo '#define  SYSTEM_XFONTS_PATH "$(x11fontdir)"' >> $@

--- a/src/base/misc/utilities.c
+++ b/src/base/misc/utilities.c
@@ -741,8 +741,8 @@ void *load_plugin(const char *plugin_name)
     if (handle != NULL)
 	return handle;
 
-    ret = asprintf(&fullname, "%s/dosemu/libplugin_%s.so",
-	     LIB_DEFAULT, plugin_name);
+    ret = asprintf(&fullname, "%s/libplugin_%s.so",
+	     DOSEMUPLUGINDIR, plugin_name);
     assert(ret != -1);
 
     handle = dlopen(fullname, RTLD_LAZY);


### PR DESCRIPTION
Dosemu executables installed via Debian packages were mistakenly
looking in /usr/lib/x86_64-linux-gnu/dosemu/ for the plugins. Change
the location to use the value supplied via --with-plugindir= as is
used for their installation. [ fixes #282 ]