### PR TITLE
build: Add -static to link DOS executables

### DIFF
--- a/src/commands/Makefile
+++ b/src/commands/Makefile
@@ -41,10 +41,10 @@ PD=precompiled
 all: $(COM2) $(SYS)
 
 %.sys.elf: %.o
-	$(LD) $(ALL_LDFLAGS) -Wl,--section-start=.text=0,-e,_start16 -nostdlib -o $@ $<
+	$(LD) $(ALL_LDFLAGS) -static -Wl,--section-start=.text=0,-e,_start16 -nostdlib -o $@ $<
 
 %.com.elf: %.o
-	$(LD) $(ALL_LDFLAGS) -Wl,--section-start=.text=0x100,-e,_start16 -nostdlib -o $@ $<
+	$(LD) $(ALL_LDFLAGS) -static -Wl,--section-start=.text=0x100,-e,_start16 -nostdlib -o $@ $<
 
 $(D)/%: %.elf
 	objcopy -j .text -O binary $< $@

--- a/src/plugin/commands/Makefile
+++ b/src/plugin/commands/Makefile
@@ -35,7 +35,7 @@ $(STUBSYMLINK): $(D)/generic.com
 	ln -sf $(<F) $@
 
 %.com.elf: %.o
-	$(LD) $(ALL_LDFLAGS) -Wl,--section-start=.text=0x100,-e,_start16 -nostdlib -o $@ $<
+	$(LD) $(ALL_LDFLAGS) -static -Wl,--section-start=.text=0x100,-e,_start16 -nostdlib -o $@ $<
 
 $(D)/%: %.elf
 	objcopy -j .text -O binary $< $@


### PR DESCRIPTION
This is required by the later toolchains used on Ubuntu Yakkety & Zesty
else we get the following during build on 64 bit:

~~~
gcc -Wl,-warn-common -Wl,-Bsymbolic-functions -Wl,-z,relro
-Wl,--section-start=.text=0x100,-e,_start16 -nostdlib -o isemu.com.elf
isemu.o
/usr/bin/ld: isemu.o: relocation R_X86_64_16 against `.text' can not be
used when making a shared object; recompile with -fPIC
/usr/bin/ld: section .interp LMA [0000000000000200,000000000000021b]
overlaps section .text LMA [0000000000000100,00000000000002a4]
/usr/bin/ld: final link failed: Nonrepresentable section on output
collect2: error: ld returned 1 exit status
Makefile:47: recipe for target 'isemu.com.elf' failed
make[3]: *** [isemu.com.elf] Error 1
~~~

Tested for basic functionality and build on Yakkety 64bit, Xenial
32bit. [fixes #262]