### PR TITLE
emu: Include sys/syscall.h [fixes #297]

### DIFF
--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -10,6 +10,7 @@
 #define X86_EMULATOR
 #define USE_MHPDBG
 #include <stdio.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
 #include "types.h"
 #include "cpu.h"


### PR DESCRIPTION
Add missing include for SYS_vm86 etc or we don't compile support for
kernel vm86() support.