### PR TITLE
Allow again the debugging of VGAEMU updates

### DIFF
--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -1826,9 +1826,7 @@ static void print_prot_map()
 static int __vga_emu_update(vga_emu_update_type *veut)
 {
   int i, j;
-#if CYCLIC_UPDATE
-  unsigned start_page;
-#endif
+  unsigned start_page = 0;
   unsigned end_page;
 
   if(veut->display_end > vga.mem.size) veut->display_end = vga.mem.size;


### PR DESCRIPTION
This change is needed to be able to compile with DEBUG_UPDATE set to 1 in 'vgaemu.c'. The variable is currently only used in one debug message. But it's the least invasive way.