### PR TITLE
Rename win31 to win3x as it also applies to win30 and win311 (and

### DIFF
--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -2559,10 +2559,10 @@ void dpmi_cleanup(void)
     SETIVEC(0x1c, s_i1c.segment, s_i1c.offset);
     SETIVEC(0x23, s_i23.segment, s_i23.offset);
     SETIVEC(0x24, s_i24.segment, s_i24.offset);
-    if (win31_mode)
+    if (win3x_mode != INACTIVE)
       SETIVEC(0x66, 0, 0);	// winos2
 
-    win31_mode = 0;
+    win3x_mode = INACTIVE;
   }
   cli_blacklisted = 0;
   dpmi_is_cli = 0;
@@ -3151,7 +3151,7 @@ void dpmi_init(void)
     inherit_idt = DPMI_CLIENT.is_32 == PREV_DPMI_CLIENT.is_32
 #if WINDOWS_HACKS
 /* work around the disability of win31 in Standard mode to run the DPMI apps */
-	&& (win31_mode != 2)
+	&& (win3x_mode != STANDARD)
 #endif
     ;
   else

--- a/src/dosext/misc/emm.c
+++ b/src/dosext/misc/emm.c
@@ -1470,7 +1470,7 @@ get_mpa_array(struct vm86_regs * state)
 #if WINDOWS_HACKS
       /* the array must be given in ascending order of segment,
          so give the page frame only after other pages */
-      if (win31_mode == 1 && config.ems_cnv_pages > 4) {
+      if (win3x_mode == REAL && config.ems_cnv_pages > 4) {
         /* windows-3.0 doesn't like the ascending order so swap
          * the last few pages */
         for (i = cnv_pages_start; i < phys_pages - 4; i++) {

--- a/src/include/int.h
+++ b/src/include/int.h
@@ -6,7 +6,8 @@
 
 #define WINDOWS_HACKS 1
 #if WINDOWS_HACKS
-extern int win31_mode;
+enum win3x_mode_enum { INACTIVE, REAL, STANDARD, ENHANCED };
+extern enum win3x_mode_enum win3x_mode;
 #endif
 
 extern unsigned int  check_date;


### PR DESCRIPTION
Chinese win32?). Use an enum to indicate the the mode instead. This
should not have any functional impact.