### PR TITLE
Ndd 01

### DIFF
--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -752,6 +752,12 @@ static void dir_setup(struct disk *dp)
     mbr[0x02] = 0xff;
     mbr[0x03] = 0xcd;
     mbr[0x04] = DOS_HELPER_INT;
+
+    /* This is an instruction that we never execute and is present only to
+     * convince Norton Disk Doctor that we are a valid mbr */
+    mbr[0x05] = 0xcd; /* int 0x13 */
+    mbr[0x06] = 0x13;
+
     *mp = p;
     mbr[SECTOR_SIZE - 2] = 0x55;
     mbr[SECTOR_SIZE - 1] = 0xaa;

--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -1597,6 +1597,11 @@ void build_boot_blk(fatfs_t *f, unsigned char *b)
   b[0x43] = 0xcd;	/* int 0e6h */
   b[0x44] = DOS_HELPER_INT;
 
+  /* This is an instruction that we never execute and is present only to
+   * convince Norton Disk Doctor that we are a valid boot program */
+  b[0x45] = 0xcd;                   /* int 0x13 */
+  b[0x46] = 0x13;
+
   /*
    * IO.SYS from MS-DOS 7 normally re-uses the boot block's error message.
    * Please note that the address points to four bytes before the string to


### PR DESCRIPTION
These commits add an, unused by dosemu, int 13h to both the fatfs boot program and our mbr so that Norton Disk Doctor can recognise therm as valid and not propose 'fixing' them.