### PR TITLE
Mfs01

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ docs:
 docsclean:
 	@$(MAKE) -C src/doc clean
 
-$(PACKAGE_NAME).spec: $(REALTOPDIR)/$(PACKAGE_NAME).spec.in $(REALTOPDIR)/config.status
-	$(REALTOPDIR)/config.status
+$(PACKAGE_NAME).spec: $(REALTOPDIR)/$(PACKAGE_NAME).spec.in $(top_builddir)/config.status
+	$(top_builddir)/config.status
 
 GIT_SYM := $(shell git rev-parse --symbolic-full-name HEAD)
 GIT_REV := $(shell git rev-parse --git-path $(GIT_SYM))

--- a/man/Makefile
+++ b/man/Makefile
@@ -9,8 +9,8 @@ MANPAGES = dosemu.1 dosemu.bin.1 ru/dosemu.1 ru/dosemu.bin.1
 default all: $(MANPAGES)
 
 .NOTPARALLEL: $(MANPAGES)
-$(MANPAGES): $(top_srcdir)/config.status
-	cd $(top_builddir) && $(top_srcdir)/config.status
+$(MANPAGES): $(top_builddir)/config.status
+	cd $(top_builddir) && $(top_builddir)/config.status
 
 install: all
 	$(INSTALL) -d $(DESTDIR)$(mandir)/man1

--- a/src/base/async/int.c
+++ b/src/base/async/int.c
@@ -1740,7 +1740,7 @@ void redirect_devices(void)
  */
 static int redir_it(void)
 {
-  uint16_t lol_lo, lol_hi, sda_lo, sda_hi, redver;
+  uint16_t lol_lo, lol_hi, sda_lo, sda_hi, sda_size, redver;
   uint8_t major, minor;
 
   /*
@@ -1787,16 +1787,17 @@ static int redir_it(void)
       redir_state, LWORD(cs), LWORD(eip), LWORD(eax), LWORD(ebx), LWORD(ecx), LWORD(edx), LWORD(ds), LWORD(es));
   sda_lo = LWORD(esi);
   sda_hi = SREG(ds);
+  sda_size = LWORD(ecx);
 
   redir_state = 0;
-  ds_printf("INT21: lol = 0x%x\n", (lol_hi << 4) + lol_lo);
-  ds_printf("INT21: sda = 0x%x\n", (sda_hi << 4) + sda_lo);
+  ds_printf("INT21: lol = 0x%04x\n", (lol_hi << 4) + lol_lo);
+  ds_printf("INT21: sda = 0x%04x, size = 0x%04x\n", (sda_hi << 4) + sda_lo, sda_size);
   ds_printf("INT21: ver = 0x%02x, 0x%02x\n", major, minor);
 
   /* Figure out the redirector version */
   if (major == 3)
     if (minor <= 9)
-      redver = REDVER_PC30;
+      redver = (sda_size == SDASIZE_CQ30) ? REDVER_CQ30 : REDVER_PC30;
     else
       redver = REDVER_PC31;
   else

--- a/src/base/async/int.c
+++ b/src/base/async/int.c
@@ -1740,12 +1740,12 @@ void redirect_devices(void)
  */
 static int redir_it(void)
 {
-  static unsigned x0, x1, x2, x3, x4;
-  unsigned u;
-
+  unsigned lol_lo, lol_hi, sda_lo, sda_hi, dosver;
   /*
-   * To start up the redirector we need (1) the list of list, (2) the DOS version and
-   * (3) the swappable data area. To get these, we reuse the original file open call.
+   * To start up the redirector we need
+   * (1) the list of list,
+   * (2) the DOS version and
+   * (3) the swappable data area.
    */
   if(HI(ax) != 0x3d)
     return 0;
@@ -1769,40 +1769,36 @@ static int redir_it(void)
   ds_printf("INT21 +1 (%d) at %04x:%04x: AX=%04x, BX=%04x, CX=%04x, DX=%04x, DS=%04x, ES=%04x\n",
       redir_state, LWORD(cs), LWORD(eip), LWORD(eax), LWORD(ebx), LWORD(ecx), LWORD(edx), LWORD(ds), LWORD(es));
 
-  x0 = LWORD(ebx);
-  x1 = SREG(es);
+  lol_lo = LWORD(ebx);
+  lol_hi = SREG(es);
   LWORD(eax) = 0x3000;
   call_msdos();
   ds_printf("INT21 +2 (%d) at %04x:%04x: AX=%04x, BX=%04x, CX=%04x, DX=%04x, DS=%04x, ES=%04x\n",
       redir_state, LWORD(cs), LWORD(eip), LWORD(eax), LWORD(ebx), LWORD(ecx), LWORD(edx), LWORD(ds), LWORD(es));
 
-  x4 = LWORD(eax);
+  dosver = LWORD(eax);
   LWORD(eax) = 0x5d06;
   call_msdos();
   ds_printf("INT21 +3 (%d) at %04x:%04x: AX=%04x, BX=%04x, CX=%04x, DX=%04x, DS=%04x, ES=%04x\n",
       redir_state, LWORD(cs), LWORD(eip), LWORD(eax), LWORD(ebx), LWORD(ecx), LWORD(edx), LWORD(ds), LWORD(es));
 
-  x2 = LWORD(esi);
-  x3 = SREG(ds);
+  sda_lo = LWORD(esi);
+  sda_hi = SREG(ds);
   redir_state = 0;
-  u = x0 + (x1 << 4);
-  ds_printf("INT21: lol = 0x%x\n", u);
-  ds_printf("INT21: sda = 0x%x\n", x2 + (x3 << 4));
-  ds_printf("INT21: ver = 0x%02x\n", x4);
+  ds_printf("INT21: lol = 0x%x\n", (lol_hi << 4) + lol_lo);
+  ds_printf("INT21: sda = 0x%x\n", (sda_hi << 4) + sda_lo);
+  ds_printf("INT21: ver = 0x%02x\n", dosver);
 
-  if(READ_DWORD(u + 0x16)) {		/* Do we have a CDS entry? */
-        /* Init the redirector. */
-        LWORD(ecx) = x4;
-        LWORD(edx) = x0; SREG(es) = x1;
-        LWORD(esi) = x2; SREG(ds) = x3;
-        LWORD(ebx) = 0x500;
-        LWORD(eax) = 0x20;
-        mfs_inte6();
-
-        redirect_devices();
-  }
-  else {
-        ds_printf("INT21: this DOS has no CDS entry - redirector not used\n");
+  /* Try to init the redirector. */
+  LWORD(ecx) = dosver;
+  LWORD(edx) = lol_lo; SREG(es) = lol_hi;
+  LWORD(esi) = sda_lo; SREG(ds) = sda_hi;
+  LWORD(ebx) = 0x500;
+  LWORD(eax) = 0x20;
+  if (mfs_inte6() == TRUE) {  /* Do we have a functioning redirector? */
+    redirect_devices();
+  } else {
+    ds_printf("INT21: this DOS has an incompatible redirector\n");
   }
 
   post_msdos();

--- a/src/dosext/mfs/lfn.c
+++ b/src/dosext/mfs/lfn.c
@@ -500,7 +500,7 @@ static int truename(char *dest, const char *src, int allowwildcards)
 	d_printf("Absolute logical path: \"%s\"\n", dest);
 
 	/* look for any JOINed drives */
-	if (dest[2] != '/' && lol_njoined(lol)) {
+	if (dest[2] != '/' && lol_njoined_off && lol_njoined(lol)) {
 		cds_t cdsp = cds_base;
 		for(i = 0; i < lol_last_drive(lol); ++i, ++cdsp) {
 			/* How many bytes must match */

--- a/src/dosext/mfs/lfn.c
+++ b/src/dosext/mfs/lfn.c
@@ -90,7 +90,7 @@ static char *handle_to_filename(int handle, int *fd)
 		if (idx < READ_WORD_S(spp, struct sfttbl, sftt_count)) {
 			/* finally, point to the right entry            */
 			sft = LINEAR2UNIX(READ_WORD_S(spp, struct sfttbl,
-				sftt_table[idx * sft_size]));
+				sftt_table[idx * sft_record_size]));
 			break;
 		}
 		idx -= READ_WORD_S(spp, struct sfttbl, sftt_count);

--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -286,7 +286,6 @@ static int dos_major;
 static int dos_minor;
 
 /* initialize 'em to 3.1 to 3.3 */
-
 int sdb_drive_letter_off = 0x0;
 int sdb_template_name_off = 0x1;
 int sdb_template_ext_off = 0x9;
@@ -351,6 +350,29 @@ int lol_njoined_off = 0x34;
 int sda_ext_act_off = 0x2dd;
 int sda_ext_attr_off = 0x2df;
 int sda_ext_mode_off = 0x2e1;
+
+static char *cds_flags_to_str(uint16_t flags) {
+  static char s[5 * 8 + 1]; // 5 names * maxstrlen + terminator;
+  int len = 0;
+
+  s[0] = '\0';
+
+  if (flags & CDS_FLAG_NOTNET)
+    len += sprintf(s + len, "NOTNET,");
+  if (flags & CDS_FLAG_SUBST)
+    len += sprintf(s + len, "SUBST,");
+  if (flags & CDS_FLAG_JOIN)
+    len += sprintf(s + len, "JOIN,");
+  if (flags & CDS_FLAG_READY)
+    len += sprintf(s + len, "READY,");
+  if (flags & CDS_FLAG_REMOTE)
+    len += sprintf(s + len, "REMOTE,");
+
+  if (len)
+    s[len - 1] = '\0'; // trim the trailing comma
+
+  return s;
+}
 
 /* here are the functions used to interface dosemu with the mach
    dos redirector code */
@@ -1590,9 +1612,8 @@ calculate_drive_pointers(int dd)
 
   Debug0((dbg_fd, "Calculated DOS Information for %d:\n", dd));
   Debug0((dbg_fd, "  cwd=%20s\n", cds_current_path(cds)));
-  Debug0((dbg_fd, "  cds flags =%x\n", cds_flags(cds)));
-  Debug0((dbg_fd, "  cdsfar = %x, %x\n", cdsfarptr.segment,
-	  cdsfarptr.offset));
+  Debug0((dbg_fd, "  cds flags = %s\n", cds_flags_to_str(cds_flags(cds))));
+  Debug0((dbg_fd, "  cdsfar = %x, %x\n", cdsfarptr.segment, cdsfarptr.offset));
 
   WRITE_P(cds_flags(cds), cds_flags(cds) | (CDS_FLAG_REMOTE | CDS_FLAG_READY | CDS_FLAG_NOTNET));
 

--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -412,8 +412,7 @@ select_drive(struct vm86_regs *state)
   cdsfarptr = lol_cdsfarptr(lol);
   cds_base = MK_FP32(cdsfarptr.segment, cdsfarptr.offset);
 
-  Debug0((dbg_fd, "selecting drive fn=%x sda_cds=%p\n",
-	  fn, (void *) sda_cds));
+  Debug0((dbg_fd, "selecting drive fn=%x sda_cds=%p\n", fn, sda_cds));
 
   switch (fn) {
   case INSTALLATION_CHECK:	/* 0x0 */
@@ -1301,6 +1300,8 @@ static char *redver_to_str(int ver) {
       return "PC-DOS v3.1";
     case REDVER_PC40:
       return "PC-DOS v4.0";
+    case REDVER_CQ30:
+      return "MS-DOS (Compaq) v3.0";
   }
   return "Unknown";
 }
@@ -1400,6 +1401,58 @@ init_dos_offsets(int ver)
         sda_rename_source_off = 0x2b8;
       }
       lol_njoined_off = 0x34;
+      break;
+    }
+
+  case REDVER_CQ30:
+    {
+      sft_handle_cnt_off = 0x0;
+      sft_open_mode_off = 0x2;
+      sft_attribute_byte_off = 0x4;
+      sft_device_info_off = 0x5;
+      sft_dev_drive_ptr_off = 0x7;
+      sft_fd_off = 0xb;
+      sft_start_cluster_off = 0xb;
+      sft_time_off = 0xd;
+      sft_date_off = 0xf;
+      sft_size_off = 0x11;
+      sft_position_off = 0x15;
+      sft_rel_cluster_off = 0x19;
+      sft_abs_cluster_off = 0x1b;
+      sft_directory_sector_off = 0x1d;
+      sft_directory_entry_off = 0x1f;
+
+      cds_record_size = 0x51;
+      cds_current_path_off = 0x0;
+      cds_flags_off = 0x43;
+      cds_rootlen_off = 0x4f;
+
+      lol_cdsfarptr_off = 0x17;
+      lol_last_drive_off = 0x1b;
+      lol_nuldev_off = 0x28;
+      sft_name_off = 0x21;
+      sft_ext_off = 0x29;
+      sft_record_size = 0x38;
+
+      /*
+       * All of the following determined by looking at dumps of the SDA
+       * between vanilla PC-DOS 3.00 and Compaq MS-DOS 3.00
+       */
+      sda_current_dta_off = 0x16;
+      sda_cur_psp_off = 0x1a;
+
+      sda_cur_drive_off = 0x20;
+      sda_filename1_off = 0x187;
+      sda_filename2_off = 0x207;
+      sda_sdb_off = 0x287;
+      sda_search_attribute_off = 0x32e;
+      sda_open_mode_off = 0x32f;
+
+      sda_user_stack_off = 0x346;
+      sda_cds_off = 0x362;
+
+      // As yet unused, will need proper offset if it is
+      sda_rename_source_off = 0x0;
       break;
     }
 

--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -1381,6 +1381,8 @@ init_dos_offsets(int ver)
         sda_user_stack_off = 0x525;
         sda_cds_off = 0x548;
         sda_rename_source_off = 0x59b;
+
+        lol_njoined_off = 0x00;  // Doesn't exist on v3.00
       } else {
         lol_cdsfarptr_off = 0x16;
         lol_last_drive_off = 0x21;
@@ -1399,8 +1401,9 @@ init_dos_offsets(int ver)
         sda_user_stack_off = 0x250;
         sda_cds_off = 0x26c;
         sda_rename_source_off = 0x2b8;
+
+        lol_njoined_off = 0x34;
       }
-      lol_njoined_off = 0x34;
       break;
     }
 
@@ -1453,6 +1456,8 @@ init_dos_offsets(int ver)
 
       // As yet unused, will need proper offset if it is
       sda_rename_source_off = 0x0;
+
+      lol_njoined_off = 0x00;  // Doesn't exist on v3.00
       break;
     }
 

--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -1608,7 +1608,6 @@ dos_fs_dev(struct vm86_regs *state)
 {
   u_char drive_to_redirect;
   int redver;
-  uint16_t major, minor;
 
   Debug0((dbg_fd, "emufs operation: 0x%08x\n", WORD(state->ebx)));
 
@@ -1618,19 +1617,9 @@ dos_fs_dev(struct vm86_regs *state)
 
     lol = SEGOFF2LINEAR(state->es, WORD(state->edx));
     sda = (sda_t) Addr(state, ds, esi);
-    major = LOW(state->ecx);
-    minor = HIGH(state->ecx);
-    Debug0((dbg_fd, "dos_fs: DOS major:minor = 0x%u:0x%u\n", major, minor));
+    redver = state->ecx;
     Debug0((dbg_fd, "lol=%#x\n", lol));
     Debug0((dbg_fd, "sda=%p\n", (void *) sda));
-
-    if (major == 3)
-      if (minor <= 9)
-        redver = REDVER_PC30;
-      else
-        redver = REDVER_PC31;
-    else
-      redver = REDVER_PC40; /* Most common redirector format */
 
     init_dos_offsets(redver);
 

--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -1310,24 +1310,24 @@ init_dos_offsets(int ver)
 {
   Debug0((dbg_fd, "dos_fs: using %s redirector\n", redver_to_str(ver)));
 
+  sdb_drive_letter_off = 0x0;
+  sdb_template_name_off = 0x1;
+  sdb_template_ext_off = 0x9;
+  sdb_attribute_off = 0xc;
+  sdb_dir_entry_off = 0xd;
+  sdb_p_cluster_off = 0xf;
+  sdb_file_name_off = 0x15;
+  sdb_file_ext_off = 0x1d;
+  sdb_file_attr_off = 0x20;
+  sdb_file_time_off = 0x2b;
+  sdb_file_date_off = 0x2d;
+  sdb_file_st_cluster_off = 0x2f;
+  sdb_file_size_off = 0x31;
+
   switch (ver) {
   case REDVER_PC30:
   case REDVER_PC31:
     {
-      sdb_drive_letter_off = 0x0;
-      sdb_template_name_off = 0x1;
-      sdb_template_ext_off = 0x9;
-      sdb_attribute_off = 0xc;
-      sdb_dir_entry_off = 0xd;
-      sdb_p_cluster_off = 0xf;
-      sdb_file_name_off = 0x15;
-      sdb_file_ext_off = 0x1d;
-      sdb_file_attr_off = 0x20;
-      sdb_file_time_off = 0x2b;
-      sdb_file_date_off = 0x2d;
-      sdb_file_st_cluster_off = 0x2f;
-      sdb_file_size_off = 0x31;
-
       sft_handle_cnt_off = 0x0;
       sft_open_mode_off = 0x2;
       sft_attribute_byte_off = 0x4;
@@ -1406,20 +1406,6 @@ init_dos_offsets(int ver)
   case REDVER_PC40:
   default:
     {
-      sdb_drive_letter_off = 0x0;
-      sdb_template_name_off = 0x1;
-      sdb_template_ext_off = 0x9;
-      sdb_attribute_off = 0xc;
-      sdb_dir_entry_off = 0xd;
-      sdb_p_cluster_off = 0xf;
-      sdb_file_name_off = 0x15;
-      sdb_file_ext_off = 0x1d;
-      sdb_file_attr_off = 0x20;
-      sdb_file_time_off = 0x2b;
-      sdb_file_date_off = 0x2d;
-      sdb_file_st_cluster_off = 0x2f;
-      sdb_file_size_off = 0x31;
-
       sft_handle_cnt_off = 0x0;
       sft_open_mode_off = 0x2;
       sft_attribute_byte_off = 0x4;

--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -2545,15 +2545,26 @@ RedirectDisk(int dsk, char *resourceName, int ro_flag)
   cds_base = MK_FP32(cdsfarptr.segment, cdsfarptr.offset);
 
   /* see if drive is in range of valid drives */
-  if(dsk < 0 || dsk > lol_last_drive(lol)) return 1;
+  if (dsk < 0 || dsk > lol_last_drive(lol))
+    return 1;
 
   cds = drive_cds(dsk);
 
   /* see if drive is already redirected */
-  if(cds_flags(cds) & CDS_FLAG_REMOTE) return 2;
+  if (cds_current_path(cds)[0] && cds_flags(cds) & CDS_FLAG_REMOTE) {
+    Debug0((dbg_fd, "RedirectDisk drive already redirected\n"));
+    Debug0((dbg_fd, "  cur_path is '%s'\n", cds_current_path(cds)));
+    Debug0((dbg_fd, "  cds flags = %s\n", cds_flags_to_str(cds_flags(cds))));
+    return 2;
+  }
 
   /* see if drive is currently substituted */
-  if(cds_flags(cds) & CDS_FLAG_SUBST) return 3;
+  if (cds_current_path(cds)[0] && cds_flags(cds) & CDS_FLAG_SUBST) {
+    Debug0((dbg_fd, "RedirectDisk drive already substituted\n"));
+    Debug0((dbg_fd, "  cur_path is '%s'\n", cds_current_path(cds)));
+    Debug0((dbg_fd, "  cds flags = %s\n", cds_flags_to_str(cds_flags(cds))));
+    return 3;
+  }
 
   path_to_ufs(path, 0, &resourceName[strlen(LINUX_RESOURCE)], 1, 0);
 

--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -282,9 +282,6 @@ static far_t cdsfarptr;
 cds_t cds_base;
 sda_t sda;
 
-static int dos_major;
-static int dos_minor;
-
 /* initialize 'em to 3.1 to 3.3 */
 int sdb_drive_letter_off = 0x0;
 int sdb_template_name_off = 0x1;
@@ -1629,6 +1626,7 @@ dos_fs_dev(struct vm86_regs *state)
 {
   u_char drive_to_redirect;
   int dos_ver;
+  uint16_t dos_major, dos_minor;
 
   Debug0((dbg_fd, "emufs operation: 0x%08x\n", WORD(state->ebx)));
 
@@ -1640,8 +1638,6 @@ dos_fs_dev(struct vm86_regs *state)
     sda = (sda_t) Addr(state, ds, esi);
     dos_major = LOW(state->ecx);
     dos_minor = HIGH(state->ecx);
-//    if (running_DosC)
-  //      Debug0((dbg_fd, "dos_fs: running DosC build 0x%x\n", running_DosC));
     Debug0((dbg_fd, "dos_fs: dos_major:minor = 0x%d:%d.\n",
 	    dos_major, dos_minor));
     Debug0((dbg_fd, "lol=%#x\n", lol));
@@ -1666,8 +1662,12 @@ dos_fs_dev(struct vm86_regs *state)
 	 *                             --Hans 990703
 	 */
 //    if (running_DosC) dos_ver = DOSVER_41;
+
     init_dos_offsets(dos_ver);
+
     SETWORD(&(state->eax), 1);
+
+    return (lol_cdsfarptr(lol).segment || lol_cdsfarptr(lol).offset) ? TRUE : FALSE;
   }
 
   if (WORD(state->ebx) == 0) {

--- a/src/env/builtins/lredir.c
+++ b/src/env/builtins/lredir.c
@@ -139,8 +139,8 @@ static void InitMFS(void)
 {
     FAR_PTR LOL;
     FAR_PTR SDA;
-    unsigned char _osmajor;
-    unsigned char _osminor;
+    unsigned char major, minor;
+    unsigned int redver;
     struct vm86_regs preg;
 
     LOL = GetListOfLists();
@@ -150,12 +150,19 @@ static void InitMFS(void)
     pre_msdos();
     HI(ax) = 0x30;
     call_msdos();
-    _osmajor = LO(ax);
-    _osminor = HI(ax);
+    major = LO(ax);
+    minor = HI(ax);
     post_msdos();
 
-    /* get DOS version into CX */
-    preg.ecx = _osmajor | (_osminor <<8);
+    /* get Redirector version into CX */
+    if (major == 3)
+      if (minor <= 9)
+        redver = REDVER_PC30;
+      else
+        redver = REDVER_PC31;
+    else
+      redver = REDVER_PC40; /* Most common redirector format */
+    preg.ecx = redver;
 
     preg.edx = FP_OFF16(LOL);
     preg.es = FP_SEG16(LOL);

--- a/src/env/builtins/lredir.c
+++ b/src/env/builtins/lredir.c
@@ -119,7 +119,7 @@ GetListOfLists(void)
 }
 
 static FAR_PTR /* char far * */
-GetSDAPointer(void)
+GetSDAPointer(uint16_t *size)
 {
     FAR_PTR SDA;
     struct REGPACK preg = REGPACK_INIT;
@@ -127,6 +127,7 @@ GetSDAPointer(void)
     preg.r_ax = DOS_GET_SDA_POINTER;
     intr(0x21, &preg);
     SDA = MK_FP(preg.r_ds, preg.r_si);
+    *size = preg.r_cx;
 
     return (SDA);
 }
@@ -139,12 +140,12 @@ static void InitMFS(void)
 {
     FAR_PTR LOL;
     FAR_PTR SDA;
-    unsigned char major, minor;
-    unsigned int redver;
+    uint8_t major, minor;
+    uint16_t redver, sda_size;
     struct vm86_regs preg;
 
     LOL = GetListOfLists();
-    SDA = GetSDAPointer();
+    SDA = GetSDAPointer(&sda_size);
 
     /* now get the DOS version */
     pre_msdos();
@@ -157,7 +158,7 @@ static void InitMFS(void)
     /* get Redirector version into CX */
     if (major == 3)
       if (minor <= 9)
-        redver = REDVER_PC30;
+        redver = (sda_size == SDASIZE_CQ30) ? REDVER_CQ30 : REDVER_PC30;
       else
         redver = REDVER_PC31;
     else

--- a/src/env/commands/emufs.S
+++ b/src/env/commands/emufs.S
@@ -39,6 +39,7 @@
 #
 
 #include "doshelpers.h"
+#include "redirect.h"
 
 .code16
 .text
@@ -90,6 +91,8 @@ BPBptr:	.word	Bpb
 RHPtr:	.long	0		# ptr to request header
 
 InitDone: .word 0		# 1 when initialisation is complete
+major:	.byte	0
+minor:	.byte	0
 
 Dispatch:
 
@@ -237,7 +240,8 @@ MFSini:
 	movw	$0x3000, %ax
 	xorb	%bh,%bh
 	int	$0x21
-	pushw	%ax
+	mov	%al, major
+	mov	%ah, minor
 
 	mov	$0x52, %ah
 	int	$0x21
@@ -245,12 +249,27 @@ MFSini:
 	movw	$0x5d06, %ax
 	int	$0x21
 
-	popw	%cx
+	mov	major, %ah
+	cmp	$3, %ah
+	jne	.LisPC40
+	mov	minor, %ah
+	cmp	$9, %ah
+	ja	.LisPC31
+.LisPC30:
+	movw	$REDVER_PC30, %cx
+	jmp	.Ldoit
+.LisPC31:
+	movw	$REDVER_PC31, %cx
+	jmp	.Ldoit
+.LisPC40:
+	movw	$REDVER_PC40, %cx
+
+.Ldoit:
 	pushw	%bx
 	popw	%dx
 	movw	$0x500, %bx
 	movw    $0x20, %ax
-	int	$Linuxfs	
+	int	$Linuxfs
 
 	pushw %cs
 	popw %ds

--- a/src/env/commands/emufs.S
+++ b/src/env/commands/emufs.S
@@ -93,6 +93,7 @@ RHPtr:	.long	0		# ptr to request header
 InitDone: .word 0		# 1 when initialisation is complete
 major:	.byte	0
 minor:	.byte	0
+sdasize: .word  0
 
 Dispatch:
 
@@ -248,6 +249,7 @@ MFSini:
 
 	movw	$0x5d06, %ax
 	int	$0x21
+	movw	%cx, sdasize
 
 	mov	major, %ah
 	cmp	$3, %ah
@@ -255,6 +257,10 @@ MFSini:
 	mov	minor, %ah
 	cmp	$9, %ah
 	ja	.LisPC31
+	movw	sdasize, %cx
+	cmpw	$SDASIZE_CQ30, %cx
+	je	.LisCQ30
+
 .LisPC30:
 	movw	$REDVER_PC30, %cx
 	jmp	.Ldoit
@@ -263,6 +269,9 @@ MFSini:
 	jmp	.Ldoit
 .LisPC40:
 	movw	$REDVER_PC40, %cx
+	jmp	.Ldoit
+.LisCQ30:
+	movw	$REDVER_CQ30, %cx
 
 .Ldoit:
 	pushw	%bx

--- a/src/include/dos2linux.h
+++ b/src/include/dos2linux.h
@@ -137,10 +137,12 @@ extern int cds_record_size;
 #define	cds_rootlen(cds)	(*(u_short *)&cds[cds_rootlen_off])
 #define drive_cds(dd) ((cds_t)(((char *)cds_base)+(cds_record_size*(dd))))
 
-#define CDS_FLAG_REMOTE		0x8000
-#define CDS_FLAG_READY		0x4000
-#define CDS_FLAG_NOTNET		0x0080
-#define CDS_FLAG_SUBST		0x1000
+#define CDS_FLAG_NOTNET 0x0080
+#define CDS_FLAG_SUBST  0x1000
+#define CDS_FLAG_JOIN   0x2000
+#define CDS_FLAG_READY  0x4000
+#define CDS_FLAG_REMOTE 0x8000
+
 #define CDS_DEFAULT_ROOT_LEN	2
 
 typedef u_char *sda_t;

--- a/src/include/dos2linux.h
+++ b/src/include/dos2linux.h
@@ -80,11 +80,6 @@ struct lowstring {
 	char s[0];
 } __attribute__((packed));
 
-#define DOSVER_31_33	1
-#define DOSVER_41	2
-#define DOSVER_50	3
-#define DOSVER_60	4
-
 typedef u_char *sdb_t;
 
 #define sdb_drive_letter(sdb)	(*(u_char  *)&sdb[sdb_drive_letter_off])
@@ -209,7 +204,7 @@ extern int sft_directory_sector_off;
 extern int sft_directory_entry_off;
 extern int sft_name_off;
 extern int sft_ext_off;
-extern int sft_size;
+extern int sft_record_size;
 
 extern int cds_record_size;
 extern int cds_current_path_off;

--- a/src/include/redirect.h
+++ b/src/include/redirect.h
@@ -7,6 +7,8 @@
 #ifndef REDIRECT_H
 #define REDIRECT_H
 
+#ifndef __ASSEMBLER__
+
 #define LINUX_RESOURCE "\\\\LINUX\\FS"
 #define LINUX_PRN_RESOURCE "\\\\LINUX\\PRN"
 
@@ -19,5 +21,10 @@ void redirect_devices(void);
 extern void mfs_set_stk_offs(int);
 /* temporary solution til QUALIFY_FILENAME works */
 int build_posix_path(char *dest, const char *src, int allowwildcards);
+#endif
+
+#define REDVER_PC30    1
+#define REDVER_PC31    2
+#define REDVER_PC40    3
 
 #endif

--- a/src/include/redirect.h
+++ b/src/include/redirect.h
@@ -27,4 +27,7 @@ int build_posix_path(char *dest, const char *src, int allowwildcards);
 #define REDVER_PC31    2
 #define REDVER_PC40    3
 
+#define REDVER_CQ30    4	// Microsoft Compaq v3.00 variant
+#define SDASIZE_CQ30   0x0832
+
 #endif


### PR DESCRIPTION
Firstly, this is probably post 'pre7' material :)

That said It
1/ Fixes the automatic vfs directory redirection for >= v3.1 < v4.0 DOS
2/ Adds support for vanilla PC-DOS 3.0 redirector
3/ Adds support for Compaq MS-DOS 3.0 redirector
4/ Moves some MFS specific code from int.c back to mfs.c
