### PR TITLE
mfs: Fix long filename support for v3.10 .. v3.21 DOS

### DIFF
--- a/src/base/async/int.c
+++ b/src/base/async/int.c
@@ -1415,6 +1415,11 @@ static int msdos(void)
       return 0;
   }
 
+  case 0x57:
+  case 0x71:
+  case 0x73:
+     return (config.lfn) ? mfs_lfn() : 0;
+
   default:
     return 0;
   }
@@ -1424,10 +1429,6 @@ static int msdos(void)
 static int int21(void)
 {
   int ret = msdos();
-  if (!ret && config.lfn) {
-    if (HI(ax) == 0x71 || HI(ax) == 0x73 || HI(ax) == 0x57)
-      ret = mfs_lfn();
-  }
   if (!ret)
     chain_int_norevect(&s_int21);
   return 1;


### PR DESCRIPTION
As per discussion in #347, mfs_lfn() was not being called in DOS versions 3.10 ..  3.21

@bartoldeman 
>dos_post_boot is triggered by int2f/ax=ae00, called by command.com in DOS 3.3+. See http://www.ctyme.com/intr/rb-5189.htm. For DOS < 3.3 something else would need to trigger dos_post_boot (e.g. Stas' proposal of using emufs.sys). 
