### PR TITLE
deb: Change the xfont install location

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,4 +6,5 @@ override_dh_auto_configure:
 	./autogen.sh
 	dh_auto_configure -O--parallel -- \
 		--with-plugindir=/usr/lib/dosemu \
+		--with-x11fontdir=/usr/share/fonts/X11/misc \
 		--enable-plugin=vde


### PR DESCRIPTION
By changing the location that the xfonts are installed to be the
standard place, the Debian packaging helpers are used automatically
to update the font cache, and there's no need to mess with the font
path. [fixes #364]