### PR TITLE
Make $LN_S and separate $srcdir work under autoconf 2.69

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ all: default configure src/include/config.h
 srcdir=.
 top_builddir=.
 SUBDIR:=.
--include Makefile.conf
+ifneq "deb" "$(MAKECMDGOALS)"
+  -include Makefile.conf
+endif
 
 configure: configure.ac install-sh
 	autoreconf -v -I m4
@@ -59,11 +61,11 @@ rpm: $(PACKETNAME).tar.gz $(PACKAGE_NAME).spec
 
 deb:
 	debuild -i -us -uc -b
-	make distclean
+	rm -rf build
 
 changelog:
-	if [ -d .git -o -f .git ]; then \
-		git log >$@ ; \
+	if [ -d $(srcdir)/.git -o -f $(srcdir)/.git ]; then \
+		git --git-dir=$(srcdir)/.git log >$@ ; \
 	else \
 		echo "Unofficial build by `whoami`@`hostname`, `date`" >$@ ; \
 	fi

--- a/configure.ac
+++ b/configure.ac
@@ -180,28 +180,27 @@ dnl try to hook in available plug-ins
 $srcdir/mkpluginhooks
 if test -f plugin_libdirs; then
     PLUGINSUBDIRS=`cat plugin_libdirs`
-    cd src
     for i in $PLUGINSUBDIRS; do
-      if ! grep USE_DL_PLUGINS $i/Makefile >/dev/null ; then
+      if ! grep USE_DL_PLUGINS $srcdir/src/$i/Makefile >/dev/null ; then
         ST_PLUGINSUBDIRS="$ST_PLUGINSUBDIRS $i"
       fi
     done
-    cd ..
     if test -f plugin_incdirs; then
-      cd src
-      for i in `cat ../plugin_incdirs`; do
-        if test -f ../configure.ac; then
-          for j in $i/*.h; do
-            $LN_S -f ../../$j plugin/include/`basename $j`
-          done
-        else
-	  abssrcdir=`cd .. && cd $srcdir && pwd`
-          for j in $abssrcdir/src/$i/*.h; do
-            $LN_S -f $j plugin/include/`basename $j`
-          done
-        fi
+      PLUGININCDIRS=`cat plugin_incdirs`
+      for i in $PLUGININCDIRS; do
+        for j in $srcdir/src/$i/*.h; do
+          case $srcdir in
+            /*)
+              $LN_S $j src/plugin/include/`basename $j`;;
+            *)
+              if test 'ln -s' = "$LN_S" ; then
+                ln -s ../../../$j src/plugin/include/`basename $j`
+              else
+                $LN_S $j src/plugin/include/`basename $j`
+              fi;;
+          esac
+        done
       done
-      cd ..
     fi
 else
     AC_MSG_NOTICE(Compiling without plug-ins...)
@@ -338,7 +337,8 @@ dnl Create output files. If you add new ones, please do it in order.
 AC_CONFIG_FILES([Makefile.conf])
 
 AC_CONFIG_COMMANDS([Makefile],
-[ if ! test -f configure.ac; then
+[ AC_PROG_LN_S
+  if ! test -f configure.ac; then
     abssrcdir=`cd $srcdir && pwd`
     mkdir -p `(cd $abssrcdir; find . -name .git -prune -o -name .svn -prune -o -name CVS -prune -o -type d -print)`
     for i in `(cd $abssrcdir; find . -name Makefile)`; do

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 export DH_ALWAYS_EXCLUDE=fonts.dir:fonts.alias
 
 %:
-	dh $@ --parallel
+	dh $@ --parallel --builddir=build
 
 override_dh_auto_configure:
 	./autogen.sh

--- a/default-configure
+++ b/default-configure
@@ -4,13 +4,14 @@ if [ -n "$DOSEMU_DEFAULT_CONFIGURE" ] ; then
   exit 0
 fi
 
-CONF_FILE=`dirname $0`/compiletime-settings
+srcdir="`dirname "$0"`"
+CONF_FILE="$srcdir"/compiletime-settings
 
 if [ "$1" != "" ]; then
   if [ "${1#--}" = "$1" -a "${1#*=}" = "$1" ]; then
     CONF_FILE=$1
     if [ "$CONF_FILE" = "-d" ]; then
-      CONF_FILE=`dirname $0`/compiletime-settings.devel
+      CONF_FILE="$srcdir"/compiletime-settings.devel
     fi
     shift
   fi
@@ -66,7 +67,7 @@ while [ "$1" != "" ]; do
       STRING="$STRING --with-$1=$2"
       ;;
     fdtarball)
-      STRING="$STRING --with-$1=`realpath $2`"
+      STRING="$STRING --with-$1=`realpath "$srcdir"/$2`"
       ;;
     docdir|mandir|datadir|libdir|sysconfdir|bindir|prefix)
       STRING="$STRING --$1=`echo $2`"
@@ -102,11 +103,11 @@ while [ "$1" != "" ]; do
   shift; shift;
 done
 
-[ -f `dirname $0`/configure ] || `dirname $0`/autogen.sh || exit $?
+[ -f "$srcdir"/configure ] || "$srcdir"/autogen.sh || exit $?
 
-echo `dirname $0`/mkpluginhooks enable $PLUGIN $EXTRA_PLUGINS
-`dirname $0`/mkpluginhooks enable $PLUGIN $EXTRA_PLUGINS || exit $?
+echo "$srcdir"/mkpluginhooks enable $PLUGIN $EXTRA_PLUGINS
+"$srcdir"/mkpluginhooks enable $PLUGIN $EXTRA_PLUGINS || exit $?
 
 export DOSEMU_DEFAULT_CONFIGURE=1
-echo exec `dirname $0`/configure $STRING $SUFFIX
-eval exec `dirname $0`/configure $STRING $SUFFIX
+echo exec "$srcdir"/configure $STRING $SUFFIX
+eval exec "$srcdir"/configure $STRING $SUFFIX

--- a/man/Makefile
+++ b/man/Makefile
@@ -20,9 +20,12 @@ edit = sed \
 install: all
 	$(INSTALL) -d $(DESTDIR)$(mandir)/man1
 	$(INSTALL) -m 0644 *.1 $(DESTDIR)$(mandir)/man1
+	$(INSTALL) -m 0644 $(REALTOPDIR)/man/*.1 $(DESTDIR)$(mandir)/man1
 	for i in $(LANGUAGES); do \
 	    $(INSTALL) -d $(DESTDIR)$(mandir)/$$i/man1; \
 	    $(INSTALL) -m 0644 $$i/*.1 $(DESTDIR)$(mandir)/$$i/man1; \
+	    $(INSTALL) -m 0644 $(REALTOPDIR)/man/$$i/*.1 \
+	      $(DESTDIR)$(mandir)/$$i/man1; \
 	done
 
 clean realclean:

--- a/src/arch/linux/Makefile.main
+++ b/src/arch/linux/Makefile.main
@@ -156,6 +156,7 @@ install:
 	-rm -rf $(cmddir)
 	-rm -rf $(sysdir)
 	$(INSTALL) -d $(DESTDIR)$(etcdir)
+	cd $(REALTOPDIR); \
 	if [ -n "$(fdtarball)" -a -f "$(fdtarball)" ]; then \
 	  rm -rf $(DESTDIR)$(dosemudir)/freedos; \
 	  tar -C $(DESTDIR)$(dosemudir)/.. --no-same-owner -xpzvf $(fdtarball); \

--- a/src/arch/linux/Makefile.main
+++ b/src/arch/linux/Makefile.main
@@ -211,7 +211,11 @@ install:
 	done
 	$(INSTALL) -d $(DESTDIR)$(docdir)
 	for i in README.bindist NEWS THANKS BUGS changelog; do \
-	  $(INSTALL) -m 0644 $(REALTOPDIR)/$$i $(DESTDIR)$(docdir); \
+	  if [ -f $(REALTOPDIR)/$$i ]; then \
+	    $(INSTALL) -m 0644 $(REALTOPDIR)/$$i $(DESTDIR)$(docdir); \
+	  else \
+	    $(INSTALL) -m 0644 ../$$i $(DESTDIR)$(docdir); \
+	  fi; \
 	done
 	for i in README EMUfailure tweaks; do \
 	  $(INSTALL) -m 0644 $(REALTOPDIR)/doc/$$i.html $(DESTDIR)$(docdir); \
@@ -221,7 +225,9 @@ install:
 	$(INSTALL) -d $(DESTDIR)$(x11fontdir)
 	echo "-> Installing the X PC fonts..."
 	for i in ../etc/*.pcf.gz; do \
+          if [ -f $$i ]; then \
 	    install -m 0644 $$i $(DESTDIR)$(x11fontdir); \
+          fi; \
 	done
 	$(INSTALL) -m 0644 $(REALTOPDIR)/etc/$(PACKAGE_NAME).alias $(DESTDIR)$(x11fontdir)/fonts.alias; \
 	mkfontdir $(DESTDIR)$(x11fontdir)

--- a/src/arch/linux/async/Makefile
+++ b/src/arch/linux/async/Makefile
@@ -6,7 +6,7 @@ ifeq ($(HAVE_LIBBFD),1)
 CFILES += backtrace-symbols.c
 endif
 
-ALL_CPPFLAGS += -I../mcontext
+ALL_CPPFLAGS += -I$(REALTOPDIR)/src/arch/linux/mcontext
 
 include $(REALTOPDIR)/src/Makefile.common
 

--- a/src/base/misc/libpcl/Makefile
+++ b/src/base/misc/libpcl/Makefile
@@ -6,7 +6,7 @@
 
 top_builddir=../../../..
 include $(top_builddir)/Makefile.conf
-ALL_CPPFLAGS += -I$(top_builddir)/src/arch/linux/mcontext
+ALL_CPPFLAGS += -I$(REALTOPDIR)/src/arch/linux/mcontext
 
 CFILES=pcl.c pcl_ctx.c
 

--- a/src/dosext/dpmi/Makefile
+++ b/src/dosext/dpmi/Makefile
@@ -3,7 +3,9 @@ include $(top_builddir)/Makefile.conf
 
 CFILES = dpmi.c memory.c emu-ldt.c msdoshlp.c vxd.c
 SFILES = dpmisel.S
-ALL_CPPFLAGS += -I$(srcdir)/msdos -I../../base/misc/libpcl -DDOSEMU
+ALL_CPPFLAGS += -I$(REALTOPDIR)/src/dosext/dpmi/msdos \
+    -I$(REALTOPDIR)/src/base/misc/libpcl \
+    -DDOSEMU
 
 all:  lib
 

--- a/src/plugin/fluidsynth/Makefile
+++ b/src/plugin/fluidsynth/Makefile
@@ -8,7 +8,8 @@ top_builddir=../../..
 include $(top_builddir)/Makefile.conf
 include Makefile.conf
 
-ALL_CFLAGS+=$(DL_CFLAGS) $(FLUSCFLAGS) -Ifluid_rip
+ALL_CFLAGS+=$(DL_CFLAGS) $(FLUSCFLAGS) \
+	-I$(REALTOPDIR)/src/plugin/fluidsynth/fluid_rip
 CFILES = mid_o_flus.c mid_o_file.c \
 	fluid_rip/fluid_midi.c fluid_rip/fluid_seqbind.c
 ALL_LDFLAGS += -Bsymbolic

--- a/src/plugin/modemu/Makefile
+++ b/src/plugin/modemu/Makefile
@@ -9,7 +9,7 @@ include $(top_builddir)/Makefile.conf
 
 CFILES = modemu.c sockbuf.c ttybuf.c stty.c telopt.c sock.c atcmd.c \
 	timeval.c commx.c verbose.c
-ALL_CPPFLAGS += -DDOSEMU
+ALL_CPPFLAGS += -DDOSEMU -I$(REALTOPDIR)/src/plugin/modemu
 GENSRC = lex.zz.c
 
 include $(REALTOPDIR)/src/Makefile.common
@@ -19,4 +19,4 @@ all: lib
 install: all
 
 lex.zz.c: cmdlex.l
-	$(LEX) $(LFLAGS) --prefix=zz cmdlex.l
+	$(LEX) $(LFLAGS) --prefix=zz $<


### PR DESCRIPTION
These patches fixes some problems I encountered when building `dosemu2` on Ubuntu Xenial x86-64 with `autoconf` 2.69.