### PR TITLE
More patches to make separate $srcdir work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,13 @@ SUBDIR:=.
 ifneq "deb" "$(MAKECMDGOALS)"
   -include Makefile.conf
 endif
+REALTOPDIR?=$(srcdir)
 
-configure: configure.ac install-sh
-	autoreconf -v -I m4
+$(REALTOPDIR)/configure: $(REALTOPDIR)/configure.ac $(REALTOPDIR)/install-sh
+	cd $(@D) && autoreconf -v -I m4
 
-config.status: configure
-	./configure
+config.status: $(REALTOPDIR)/configure
+	$<
 
 Makefile.conf: $(srcdir)/Makefile.conf.in $(srcdir)/configure $(srcdir)/default-configure
 	@echo "Running $(srcdir)/default-configure ..."
@@ -60,6 +61,8 @@ rpm: $(PACKETNAME).tar.gz $(PACKAGE_NAME).spec
 	rm -f $(PACKETNAME).tar.gz
 
 deb:
+	# about to zap `build' directory...
+	sleep 3 && rm -rf build
 	debuild -i -us -uc -b
 
 changelog:

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 export DH_ALWAYS_EXCLUDE=fonts.dir:fonts.alias
 
 %:
-	dh $@ --parallel --builddir=build
+	dh $@ --parallel --builddirectory=build
 
 override_dh_auto_configure:
 	./autogen.sh

--- a/src/arch/linux/Makefile.main
+++ b/src/arch/linux/Makefile.main
@@ -8,8 +8,8 @@ dosemudir = $(datadir)/dosemu
 sysdir = $(DESTDIR)$(dosemudir)/$(cmdsuff)
 cmddir = $(sysdir)/dosemu
 etcdir = $(sysconfdir)/$(confdir)
-FONTS = $(shell ls ../etc/*.bdf)
-TFONTS = $(FONTS:.bdf=.pcf.gz)
+FONTS = $(wildcard $(REALTOPDIR)/etc/*.bdf)
+TFONTS = $(FONTS:$(REALTOPDIR)/etc/%.bdf=../etc/%.pcf.gz)
 
 NET=dosext/net
 
@@ -74,7 +74,7 @@ default: version include/version.h include/confpath.h ../$(PACKAGE_NAME).spec do
 	@echo >> ../etc/xinstallvgafont
 	@cat $(REALTOPDIR)/etc/xinstallvgafont.sh >> ../etc/xinstallvgafont
 
-%.pcf.gz: %.bdf
+../etc/%.pcf.gz: $(REALTOPDIR)/etc/%.bdf
 	bdftopcf $< | gzip -c -9 -n > $@
 
 emu.o: emu.c
@@ -122,7 +122,7 @@ versetup:
 	@ln -sf $(THISVERSION)/commands ../commands
 
 GIT_REV := $(shell $(REALTOPDIR)/git-rev.sh)
-include/version.h: ../Makefile.conf ../VERSION $(GIT_REV)
+include/version.h: ../Makefile.conf $(REALTOPDIR)/VERSION $(GIT_REV)
 	echo "Updating version.h"; \
 	echo "#ifndef	VERSION_H" > $@; \
 	echo "#define	VERSION_H" >> $@; \
@@ -132,7 +132,7 @@ include/version.h: ../Makefile.conf ../VERSION $(GIT_REV)
 	echo "#define	PATCHLEVEL1	\"$(PATCHLEVEL1)\"" >> $@; \
 	echo "#define	REVISION	$(REVISION)" >> $@; \
 	echo "#define	VERDATE \"$(RELEASE_DATE)\"" >> $@; \
-	echo "#endif /* VERSION_H */" >> $@; \
+	echo "#endif /* VERSION_H */" >> $@
 
 include/confpath.h: ../Makefile.conf
 	echo '#define  ALTERNATE_ETC      "$(etcdir)"' > $@
@@ -141,7 +141,7 @@ include/confpath.h: ../Makefile.conf
 	echo '#define  DOSEMUHDIMAGE_DEFAULT "$(syshdimagedir)"' >> $@
 	echo '#define  SYSTEM_XFONTS_PATH "$(x11fontdir)"' >> $@
 
-../$(PACKAGE_NAME).spec: ../$(PACKAGE_NAME).spec.in ../VERSION
+../$(PACKAGE_NAME).spec: $(REALTOPDIR)/$(PACKAGE_NAME).spec.in $(REALTOPDIR)/VERSION
 	sed -e 's,@PACKAGE_VERSION\@,$(PACKVERSION),g' $< > $@
 
 doslib: $(REQUIRED) $(DOCS) dosemu
@@ -226,9 +226,7 @@ install:
 	$(INSTALL) -d $(DESTDIR)$(x11fontdir)
 	echo "-> Installing the X PC fonts..."
 	for i in ../etc/*.pcf.gz; do \
-          if [ -f $$i ]; then \
 	    install -m 0644 $$i $(DESTDIR)$(x11fontdir); \
-          fi; \
 	done
 	$(INSTALL) -m 0644 $(REALTOPDIR)/etc/$(PACKAGE_NAME).alias $(DESTDIR)$(x11fontdir)/fonts.alias; \
 	mkfontdir $(DESTDIR)$(x11fontdir)


### PR DESCRIPTION
These patches fix the problem with `*.pcf.gz` not being built, and a few other issues, when the source directory differs from the build directory.