### PR TITLE
sort linker input files

### DIFF
--- a/mkpluginhooks
+++ b/mkpluginhooks
@@ -15,7 +15,7 @@ PINC=plugin_incdirs
 PCONF=plugin_configure
 PARSDIR=src/base/init
 
-PDIRS="$(cd $SRCDIR; find . -maxdepth 1 ! -name include ! -path . -type d -exec basename {} \;)"
+PDIRS="$(cd $SRCDIR; find . -maxdepth 1 ! -name include ! -path . -type d -exec basename {} \;) | LC_ALL=C sort"
 
 gendummy() {
   for i in $HEADERS; do


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the dosemu.bin output,
thus without the patch, builds (in disposable VMs) would differ.

See https://reproducible-builds.org/ for why this matters.

Note: change is not tested (only a similar one on 1.4.0.1)