### PR TITLE
WIP: wheel API support

### DIFF
--- a/src/base/mouse/mousedrv.c
+++ b/src/base/mouse/mousedrv.c
@@ -163,6 +163,7 @@ void mouse_##n DEF \
 }
 MOUSE_DO(move_buttons, (int lbutton, int mbutton, int rbutton),
 	(lbutton, mbutton, rbutton))
+MOUSE_DO(move_wheel, (int dy), (dy))
 MOUSE_DO(move_relative, (int dx, int dy, int x_range, int y_range),
 	(dx, dy, x_range, y_range))
 MOUSE_DO(move_mickeys, (int dx, int dy), (dx, dy))
@@ -206,5 +207,6 @@ void mouse_##n##_id DID DEF \
 }
 MOUSE_ID_DO(move_buttons, (int lbutton, int mbutton, int rbutton),
 	(lbutton, mbutton, rbutton))
+MOUSE_ID_DO(move_wheel, (int dy), (dy))
 MOUSE_ID_DO(move_mickeys, (int dx, int dy), (dx, dy))
 MOUSE_ID_DO(enable_native_cursor, (int flag), (flag))

--- a/src/base/serial/sermouse.c
+++ b/src/base/serial/sermouse.c
@@ -104,6 +104,11 @@ static void ser_mouse_move_buttons(int lbutton, int mbutton, int rbutton,
   add_buf(com, buf, sizeof(buf));
 }
 
+static void ser_mouse_move_wheel(int dy, void *udata)
+{
+  dosemu_error("serial wheel mouse\n");
+}
+
 static void ser_mouse_move_mickeys(int dx, int dy, void *udata)
 {
   com_t *com = udata;
@@ -151,6 +156,7 @@ struct mouse_drv ser_mouse = {
   NULL, /* init */
   ser_mouse_accepts,
   ser_mouse_move_buttons,
+  ser_mouse_move_wheel,
   ser_mouse_move_relative,
   ser_mouse_move_mickeys,
   ser_mouse_move_absolute,

--- a/src/include/mouse.h
+++ b/src/include/mouse.h
@@ -35,6 +35,7 @@
 #define DELTA_RIGHTBUP		16
 #define DELTA_MIDDLEBDOWN  32
 #define DELTA_MIDDLEBUP    64
+#define DELTA_WHEEL		128
 
 #define MICKEY			9	/* mickeys per move */
 #define M_DELTA			8
@@ -72,11 +73,12 @@ struct mouse_struct {
   unsigned char lbutton, mbutton, rbutton;
   unsigned char oldlbutton, oldmbutton, oldrbutton;
 
-  int lpcount, lrcount, mpcount, mrcount, rpcount, rrcount;
+  int lpcount, lrcount, mpcount, mrcount, rpcount, rrcount, wmcount;
 
   /* positions for last press/release for each button */
   int lpx, lpy, mpx, mpy, rpx, rpy;
   int lrx, lry, mrx, mry, rrx, rry;
+  int wmx, wmy;
 
   /* TRUE if we're in a graphics mode */
   boolean gfx_cursor;
@@ -174,6 +176,7 @@ struct mouse_drv {
   int  (*init)(void);
   int  (*accepts)(void *udata);
   void (*move_buttons)(int lbutton, int mbutton, int rbutton, void *udata);
+  void (*move_wheel)(int dy, void *udata);
   void (*move_relative)(int dx, int dy, int x_range, int y_range, void *udata);
   void (*move_mickeys)(int dx, int dy, void *udata);
   void (*move_absolute)(int x, int y, int x_range, int y_range, void *udata);
@@ -186,6 +189,7 @@ void register_mouse_driver(struct mouse_drv *mouse);
 void mousedrv_set_udata(const char *name, void *udata);
 
 void mouse_move_buttons(int lbutton, int mbutton, int rbutton);
+void mouse_move_wheel(int dy);
 void mouse_move_relative(int dx, int dy, int x_range, int y_range);
 void mouse_move_mickeys(int dx, int dy);
 void mouse_move_absolute(int x, int y, int x_range, int y_range);
@@ -194,6 +198,7 @@ void mouse_enable_native_cursor(int flag);
 
 void mouse_move_buttons_id(int lbutton, int mbutton, int rbutton,
 	const char *id);
+void mouse_move_wheel_id(int dy, const char *id);
 void mouse_move_mickeys_id(int dx, int dy, const char *id);
 void mouse_enable_native_cursor_id(int flag, const char *id);
 int mousedrv_accepts(const char *id);

--- a/src/plugin/sdl/sdl.c
+++ b/src/plugin/sdl/sdl.c
@@ -855,6 +855,9 @@ static void SDL_handle_events(void)
 	mouse_move_absolute(event.motion.x, event.motion.y, m_x_res,
 			    m_y_res);
       break;
+    case SDL_MOUSEWHEEL:
+      mouse_move_wheel(event.wheel.y);
+      break;
     case SDL_QUIT:
       leavedos(0);
       break;


### PR DESCRIPTION
I indicated a while ago that I would look into this, I only recently started. This is not working yet. The test program included with ctmouse detects a wheel, but that's it. I also only changed the SDL/int33 parts. I haven't looked at the hardware emulation and X11/GPM parts yet.

I'm just opening this to ask for initial comments, suggestions and verifying I'm on the right track.

Apparently there's also an undocumented feature in some Genius mouse drivers which is currently implemented and which conflicts with the wheel API. I guess it would be necessary to add a (runtime) switch to support both variants.