### PR TITLE
Add remapper for 15/16-bit to 32-bit colours in fullscreen under X

### DIFF
--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1420,7 +1420,9 @@ void gen_32to32_1(RemapObject *);
 void gen_24to32_1(RemapObject *);
 
 void gen_15to32_1(RemapObject *);
+void gen_15to32_all(RemapObject *);
 void gen_16to32_1(RemapObject *);
+void gen_16to32_all(RemapObject *);
 
 void gen_1to8p_all(RemapObject *);
 void gen_1to8_all(RemapObject *);
@@ -1627,10 +1629,26 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
+    MODE_TRUE_15,
+    MODE_TRUE_32,
+    gen_15to32_all,
+    NULL
+  ),
+
+  REMAP_DESC(
     RFF_SCALE_1  | RFF_REMAP_LINES,
     MODE_TRUE_16,
     MODE_TRUE_32,
     gen_16to32_1,
+    NULL
+  ),
+
+  REMAP_DESC(
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
+    MODE_TRUE_16,
+    MODE_TRUE_32,
+    gen_16to32_all,
     NULL
   ),
 
@@ -2655,6 +2673,38 @@ void gen_15to32_1(RemapObject *ro)
 }
 
 /*
+ * 15 bit true color --> 32 bit true color
+ * supports arbitrary scaling
+ */
+void gen_15to32_all(RemapObject *ro)
+{
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+
+  const unsigned char *src, *src0;
+  unsigned char *dst;
+  unsigned short *src_2;
+  unsigned *dst_4;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+  d_x_len = ro->dst_width;
+
+  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    src_2 = (unsigned short *) src;
+    dst_4 = (unsigned *) dst;
+    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
+      dst_4[d_x++] = bgr_2int(ro->dst_color_space, 5, 5, 5, src_2[s_x]);
+      s_x += *(bre_x++);
+    }
+  }
+}
+
+/*
  * 16 bit true color --> 32 bit true color
  * Source format is BGR (see vesa.c:vbe_mode_info() )
  */
@@ -2683,6 +2733,38 @@ void gen_16to32_1(RemapObject *ro)
 
     src += ro->src_scan_len;
     dst += ro->dst_scan_len;
+  }
+}
+
+/*
+ * 16 bit true color --> 32 bit true color
+ * supports arbitrary scaling
+ */
+void gen_16to32_all(RemapObject *ro)
+{
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+
+  const unsigned char *src, *src0;
+  unsigned char *dst;
+  unsigned short *src_2;
+  unsigned *dst_4;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+  d_x_len = ro->dst_width;
+
+  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    src_2 = (unsigned short *) src;
+    dst_4 = (unsigned *) dst;
+    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
+      dst_4[d_x++] = bgr_2int(ro->dst_color_space, 5, 6, 5, src_2[s_x]);
+      s_x += *(bre_x++);
+    }
   }
 }
 


### PR DESCRIPTION
Remappers for converting 15/16-bit VESA mode to 32-bit X mode when running in fullscreen.

Support for 24/32-bit VESA modes and 16/24-bit X modes has to come later.