### PR TITLE
mfs: Update SDA layouts for PC-DOS 3.00

### DIFF
--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -1359,7 +1359,10 @@ init_dos_offsets(int ver)
         sft_ext_off = 0x29;
         sft_record_size = 0x38;
         sda_current_dta_off = 0x10;
-        sda_cur_psp_off = 0x14;
+
+        // NOTE - this value contradicts the 'fixed' phantom.c, but has been
+        // proven correct by examining dumps of sda and the resultant psp.
+        sda_cur_psp_off = 0x05;
 
         // NOTE - not defined in phantom.c, examination of dumped sda gives
         // possible candidates as 0x09, 0x33. Subsequent dumps after lredir2
@@ -1443,7 +1446,9 @@ init_dos_offsets(int ver)
        * between vanilla PC-DOS 3.00 and Compaq MS-DOS 3.00
        */
       sda_current_dta_off = 0x16;
-      sda_cur_psp_off = 0x1a;
+
+      // Note - confirmed by following the value to see a valid PSP
+      sda_cur_psp_off = 0x0c;
 
       sda_cur_drive_off = 0x20;
       sda_filename1_off = 0x187;


### PR DESCRIPTION
Under both vanilla and Compaq PC-DOS the PSP was not being found due to
bad offsets within the SDA [fixes #421]. This has now been corrected,
the PSP dumped to file and sanity checked.

Here is the PSP from vanilla PC-DOS 3.00
~~~
000000 cd 20 00 a0 00 9a f0 fe 1d f0 2c 01 e8 08 39 01 >.  ........,...9.<
000010 e8 08 81 04 e8 08 e8 08 01 01 01 00 02 03 ff ff >................<
000020 ff ff ff ff ff ff ff ff ff ff ff ff bf 00 e8 01 >................<
000030 ce 0d 14 00 18 00 bd 09 00 00 00 00 00 00 00 00 >................<
000040 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 >................<
000050 cd 21 cb 00 00 00 00 00 00 00 00 00 00 54 48 49 >.!...........THI<
000060 53 20 20 20 20 20 20 20 00 00 00 00 00 49 53 20 >S       .....IS <
000070 20 20 20 20 20 20 20 20 00 00 00 00 00 00 00 00 > ........<
000080 19 20 54 48 49 53 20 49 53 20 54 48 45 20 43 4f >. THIS IS THE CO<
000090 4d 4d 41 4e 44 20 4c 49 4e 45 0d 00 00 00 00 00 >MMAND LINE......<
0000a0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 >................<
0000b0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 >................<
0000c0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 >................<
0000d0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 >................<
0000e0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 >................<
0000f0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 >................<
~~~