### PR TITLE
asm: Remove the hardcoded segment prefixes

### DIFF
--- a/src/include/detect.h
+++ b/src/include/detect.h
@@ -31,29 +31,25 @@
 # assuming we have a *.com file (CS=DS=SS=ES)
 # assuming we are included just at the start point of the program
 
-#ifndef SEGES
-#  define SEGES .byte 0x26;
-#endif
-
 	cld
 	pushw	%es
 	les	magicptr,%si
-	SEGES lodsl
+	lods	%es:(%si),%eax
 	cmpl	exp_magic, %eax
 	jne	check_old
-	SEGES lodsl
+	lods	%es:(%si),%eax
 	cmpl	exp_magic+4, %eax
 	jne	check_old
-	SEGES lodsl
+	lods	%es:(%si),%eax
 	movl	%eax, real_version	# save dosemu version
 	popw	%es
 	jmp	ok_start_label
 
 check_old:
 	les	dateptr,%si
-	SEGES lodsl
+	lods	%es:(%si),%eax
 	cmpl	exp_date,%eax
-	SEGES lodsl
+	lods	%es:(%si),%eax
 	pop	%es
 	jne	check_failed
 	cmpl	exp_date+4,%eax

--- a/src/include/macros86.h
+++ b/src/include/macros86.h
@@ -30,18 +30,4 @@
 #define FILL_SHORT(x,v) FILL_OPCODE x, .short v
 #define FILL_LONG(x,v) FILL_OPCODE x, .long v
 
-/* NOTE: we need the following only for prefixing string instructions
- *       (such as lodsb, lodsw, lodsl, etc.)
- *       In all other cases prefixing can be imbedded in the operant itself
- */
-#ifndef SEGES
-#define SEGES .byte	0x26;
-#endif
-#define SEGCS .byte	0x2e;
-#define SEGSS .byte	0x36;
-#define SEGDS .byte	0x3e;
-#define SEGFS .byte	0x64;
-#define SEGGS .byte	0x65;
-
-
 #endif


### PR DESCRIPTION
We don't need to specify the segment prefixes by hardcoding in this way.
Replace them with assembler code to generate the same.

Test:
```
.code16

.byte 0x26
lodsl

lods   %es:(%si),%eax
```

Dump:
```
$ as -march=i386 test.S && objdump -d -M addr16,data16 a.out

a.out:     file format elf32-i386

Disassembly of section .text:

00000000 <.text>:
   0:	26 66 ad             	lods   %es:(%si),%eax
   3:	26 66 ad             	lods   %es:(%si),%eax
```

Validated that isemu.o is byte for byte equal now to before this change.

[fixes #429]