### PR TITLE
umb: Split out common device driver stuff

### DIFF
--- a/src/env/commands/devicedriver.S
+++ b/src/env/commands/devicedriver.S
@@ -1,0 +1,82 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+/*
+ * Common Device Driver Skeleton
+ *
+ * Author: Andrew Bird
+ */
+
+// Common
+LEN	=	0
+UNIT	=	1
+CMD	=	2
+STATUS	=	3
+
+// Init function 0
+HSIZE	=	12
+NUNITS	=	13
+ENDOFS	=	14
+ENDSEG	=	16
+DATOFS	=	18
+DATSEG	=	20
+FIRSTD	=	22
+
+.macro CREATE_COMMON devattr devname tabname
+	.long	-1		# link to next device driver
+HdrAttr:
+	.word	\devattr	# attribute word for driver
+				# (char, supports IOCTL strings (it doesn't!)
+	.word	Strat		# ptr to strategy routine
+	.word	Intr		# ptr to interrupt service routine
+HdrStr:
+	.ascii	"\devname"	# logical-device name
+
+.LRHPtr:.long 0			# ptr to request header
+
+Strat:
+	mov	%bx, %cs:.LRHPtr
+	mov	%es, %cs:.LRHPtr+2
+	lret
+
+Intr:
+	pusha
+	pushw	%ds
+	pushw	%es
+
+	pushw	%cs
+	popw	%ds
+	les	.LRHPtr,%di	# let es:di = request header
+
+	movzbw	%es:CMD(%di), %si
+	movw	%si, %bx
+	cmpw	$((\tabname\()_end - \tabname) / 2), %bx
+	jb	1f
+	mov	$0x8003, %ax	# error
+	jmp	2f
+
+1:	shlw	%si
+	callw	*\tabname(%si)
+	les	.LRHPtr,%di
+
+2:	orw	$0x100,%ax	# Merge done bit with status
+	mov	%ax,%es:STATUS(%di)
+
+	popw	%es
+	popw	%ds
+	popa
+	lret
+.endm

--- a/src/env/commands/umb.S
+++ b/src/env/commands/umb.S
@@ -30,27 +30,9 @@
 	.globl	_start16
 _start16:
 
-MaxCmd	=	15
+.include "devicedriver.S"
 
-LEN	=	0
-UNITS	=	1
-CMD	=	2
-STAT	=	3
-
-Header:
-	.long	-1		# link to next device driver
-HdrAttr:
-	.word	0xC000		# attribute word for driver
-				# (char, supports IOCTL strings (it doesn't!)
-	.word	Strat		# ptr to strategy routine
-	.word	Intr		# ptr to interrupt service routine
-UMBStr:
-	.ascii	"UMBXXXX0"	# logical-device name
-
-RHPtr:		.long 0		# ptr to request header
-
-OldXMSCall:	.long 0
-OldInt2f:	.long 0
+CREATE_COMMON 0xc000 "UMBXXXX0" Dispatch
 
 Dispatch:
 	.word	Init		# initialize driver
@@ -70,39 +52,10 @@ Dispatch:
 	.word	Dummy		# open device
 	.word	Dummy		# close device
 	.word	Dummy		# removeable media check
+Dispatch_end:
 
-Strat:
-	mov	%bx, %cs:RHPtr
-	mov	%es, %cs:RHPtr+2
-	lret
-
-Intr:
-	pusha
-	pushw	%ds
-	pushw	%es
-
-	pushw	%cs
-	popw	%ds
-	les	RHPtr,%di	# let es:di = request header
-
-	movzbw	%es:CMD(%di), %si
-	movw	%si, %bx
-	cmpw	$MaxCmd, %bx
-	jle	1f
-	mov	$0x8003, %ax	# error
-	jmp	2f
-
-1:	shlw	%si
-	callw	*Dispatch(%si)
-	les	RHPtr,%di
-
-2:	orw	$0x100,%ax	# Merge done bit with status
-	mov	%ax,%es:STAT(%di)
-
-	popw	%es
-	popw	%ds
-	popa
-	lret
+OldXMSCall:	.long 0
+OldInt2f:	.long 0
 
 Dummy:
 	xorw	%ax, %ax	# no error
@@ -240,8 +193,8 @@ Init:
 	orb	%al, %al
 	jnz	Error
 
-	movw	%cs,%es:16(%di)
-	movw	$InitCodeStart,%es:14(%di)
+	movw	%cs,%es:ENDSEG(%di)
+	movw	$InitCodeStart,%es:ENDOFS(%di)
 
 	movb	$9, %ah
 	movw	$UmbInstalledMsg, %dx
@@ -264,10 +217,10 @@ Init:
 
 Error:
 	movw	$0, %cs:HdrAttr		# Set to block type
-	movw	$0, %es:13(%di)		# Units = 0
+	movw	$0, %es:NUNITS(%di)		# Units = 0
 
-	movw	$0,%es:14(%di)		# Break addr = cs:0000
-	movw	%cs,%es:16(%di)
+	movw	$0,%es:ENDOFS(%di)		# Break addr = cs:0000
+	movw	%cs,%es:ENDSEG(%di)
 
 	movw	$0x8003, %ax		# error
 	ret


### PR DESCRIPTION
Not ready for you to pull yet, but opened this as somewhere to discuss.
Do you think it's worth pursuing using a common file and macro to define the header and standard functions of a device driver? Is there anything else you'd turn into a macro (InitError exit method etc)? 