### PR TITLE
disks: Hd type and number fixes

### DIFF
--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1349,18 +1349,26 @@ int disk_is_bootable(const struct disk *dp)
 int disk_validate_boot_part(struct disk *dp)
 {
   int hdtype;
+
   if (dp->type != DIR_TYPE || dp->floppy)
     return 1;
+
   hdtype = fatfs_get_part_type(dp->fatfs);
   if (hdtype == -1)
     return 0;
-  if (!hdtype || hdtype == dp->hdtype)
+  if (!hdtype)
     return 1;
-  d_printf("DISK: changing hdtype from %i to %i\n", dp->hdtype, hdtype);
-  dp->hdtype = hdtype;
-  dp->sectors = -1;
+
+  if (dp->hdtype == 0) { /* Unspecified disk type */
+    d_printf("DISK: Automatically selecting IBM disk type %i\n", hdtype);
+    dp->hdtype = hdtype;
+    dp->sectors = -1;
+  }
+
   /* some old DOSes only boot if there are no more than 2 drives */
+  d_printf("DISK: Clamping number of hdisks to 2\n");
   hdisk_reset(2);
+
   return fatfs_is_bootable(dp->fatfs);
 }
 


### PR DESCRIPTION
    disks: Hd type and number fixes
    
    1/ Don't change an explicit hdtype
       On older DOS versions that don't support FAT16B we change the hdtype
       so that the geometry falls inside FAT16 filesystem limits. If the
       user has explicitly specified a hdtype, for example to use
       FAT12, don't change it to type 2.  Fixes #444
    
    2/ Make hd type and clampimg independent
       If a user specified an hdtype the same as the one we would set if
       incompatible, the number of disks was not clamped on those versions
       of DOS that require it.
    
    Testing

    MS-DOS 6.22
    dosemu.conf drives/c         auto
    dosemu.conf drives/c:hdtype1 set type 1
    dosemu.conf drives/c:hdtype2 set type 2
    dosemu.conf drives/c:hdtype9 set type 9
    
    MS-DOS 3.30
    dosemu.conf drives/c         change to type2, clamp disks 2
    dosemu.conf drives/c:hdtype1 set type 1, clamp disks 2
    dosemu.conf drives/c:hdtype2 set type 2, clamp disks 2
    dosemu.conf drives/c:hdtype9 set type 9, clamp disks 2 (fail to boot)


