### PR TITLE
regs: Don't use LWORD macro for segments

### DIFF
--- a/src/base/async/int.c
+++ b/src/base/async/int.c
@@ -140,7 +140,7 @@ static void mbr_jmp(void *arg)
     unsigned offs = (long) arg;
     fake_iret();
     LWORD(esp) = 0x7c00;
-    LWORD(cs) = LWORD(ds) = LWORD(es) = LWORD(ss) = 0;
+    SREG(cs) = SREG(ds) = SREG(es) = SREG(ss) = 0;
     LWORD(edi) = 0x7dfe;
     LWORD(eip) = 0x7c00;
     LWORD(ebp) = LWORD(esi) = offs;
@@ -339,10 +339,10 @@ int dos_helper(void)
 
 	    ssp = SEGOFF2LINEAR(SREG(ss), 0);
 	    sp = LWORD(esp);
-	    pushw(ssp, sp, LWORD(cs));
+	    pushw(ssp, sp, SREG(cs));
 	    pushw(ssp, sp, LWORD(eip));
 	    LWORD(esp) -= 4;
-	    LWORD(cs) = config.vbios_seg;
+	    SREG(cs) = config.vbios_seg;
 	    LWORD(eip) = 3;
 	    show_regs();
 	}
@@ -866,7 +866,7 @@ static int int15(void)
 	}
 	break;
     case 0xc0:
-	LWORD(es) = ROM_CONFIG_SEG;
+	SREG(es) = ROM_CONFIG_SEG;
 	LWORD(ebx) = ROM_CONFIG_OFF;
 	HI(ax) = 0;
 	break;
@@ -1315,8 +1315,8 @@ static int msdos(void)
 {
     ds_printf
 	("INT21 (%d) at %04x:%04x: AX=%04x, BX=%04x, CX=%04x, DX=%04x, DS=%04x, ES=%04x\n",
-	 redir_state, LWORD(cs), LWORD(eip), LWORD(eax), LWORD(ebx),
-	 LWORD(ecx), LWORD(edx), LWORD(ds), LWORD(es));
+	 redir_state, SREG(cs), LWORD(eip), LWORD(eax), LWORD(ebx),
+	 LWORD(ecx), LWORD(edx), SREG(ds), SREG(es));
 
     if (redir_state && redir_it())
 	return 0;
@@ -1923,8 +1923,8 @@ static int redir_it(void)
     call_msdos();
     ds_printf
 	("INT21 +1 (%d) at %04x:%04x: AX=%04x, BX=%04x, CX=%04x, DX=%04x, DS=%04x, ES=%04x\n",
-	 redir_state, LWORD(cs), LWORD(eip), LWORD(eax), LWORD(ebx),
-	 LWORD(ecx), LWORD(edx), LWORD(ds), LWORD(es));
+	 redir_state, SREG(cs), LWORD(eip), LWORD(eax), LWORD(ebx),
+	 LWORD(ecx), LWORD(edx), SREG(ds), SREG(es));
     lol_lo = LWORD(ebx);
     lol_hi = SREG(es);
 
@@ -1932,8 +1932,8 @@ static int redir_it(void)
     call_msdos();
     ds_printf
 	("INT21 +2 (%d) at %04x:%04x: AX=%04x, BX=%04x, CX=%04x, DX=%04x, DS=%04x, ES=%04x\n",
-	 redir_state, LWORD(cs), LWORD(eip), LWORD(eax), LWORD(ebx),
-	 LWORD(ecx), LWORD(edx), LWORD(ds), LWORD(es));
+	 redir_state, SREG(cs), LWORD(eip), LWORD(eax), LWORD(ebx),
+	 LWORD(ecx), LWORD(edx), SREG(ds), SREG(es));
     major = LO(ax);
     minor = HI(ax);
 
@@ -1941,8 +1941,8 @@ static int redir_it(void)
     call_msdos();
     ds_printf
 	("INT21 +3 (%d) at %04x:%04x: AX=%04x, BX=%04x, CX=%04x, DX=%04x, DS=%04x, ES=%04x\n",
-	 redir_state, LWORD(cs), LWORD(eip), LWORD(eax), LWORD(ebx),
-	 LWORD(ecx), LWORD(edx), LWORD(ds), LWORD(es));
+	 redir_state, SREG(cs), LWORD(eip), LWORD(eax), LWORD(ebx),
+	 LWORD(ecx), LWORD(edx), SREG(ds), SREG(es));
     sda_lo = LWORD(esi);
     sda_hi = SREG(ds);
     sda_size = LWORD(ecx);
@@ -2020,8 +2020,8 @@ static int int2f(int stk_offs)
 #if 1
     ds_printf
 	("INT2F at %04x:%04x: AX=%04x, BX=%04x, CX=%04x, DX=%04x, DS=%04x, ES=%04x\n",
-	 LWORD(cs), LWORD(eip), LWORD(eax), LWORD(ebx), LWORD(ecx),
-	 LWORD(edx), LWORD(ds), LWORD(es));
+	 SREG(cs), LWORD(eip), LWORD(eax), LWORD(ebx), LWORD(ecx),
+	 LWORD(edx), SREG(ds), SREG(es));
 #endif
 
     switch (LWORD(eax)) {
@@ -2383,7 +2383,7 @@ void fake_int(int cs, int ip)
     unsigned int ssp, sp;
 
     g_printf("fake_int: CS:IP %04x:%04x\n", cs, ip);
-    ssp = SEGOFF2LINEAR(LWORD(ss), 0);
+    ssp = SEGOFF2LINEAR(SREG(ss), 0);
     sp = LWORD(esp);
 
     pushw(ssp, sp, vflags);
@@ -2408,7 +2408,7 @@ void fake_call(int cs, int ip)
 {
     unsigned int ssp, sp;
 
-    ssp = SEGOFF2LINEAR(LWORD(ss), 0);
+    ssp = SEGOFF2LINEAR(SREG(ss), 0);
     sp = LWORD(esp);
 
     g_printf("fake_call() CS:IP %04x:%04x\n", cs, ip);
@@ -2428,7 +2428,7 @@ void fake_pusha(void)
 {
     unsigned int ssp, sp;
 
-    ssp = SEGOFF2LINEAR(LWORD(ss), 0);
+    ssp = SEGOFF2LINEAR(SREG(ss), 0);
     sp = LWORD(esp);
 
     pushw(ssp, sp, LWORD(eax));

--- a/src/base/misc/dos2linux.c
+++ b/src/base/misc/dos2linux.c
@@ -869,7 +869,7 @@ int com_doswrite(int dosfilefd, char *buf32, u_short size)
 	pre_msdos();
 	LWORD(ecx) = size;
 	LWORD(ebx) = dosfilefd;
-	LWORD(ds) = DOSEMU_LMHEAP_SEG;
+	SREG(ds) = DOSEMU_LMHEAP_SEG;
 	LWORD(edx) = DOSEMU_LMHEAP_OFFS_OF(s);
 	LWORD(eax) = 0x4000;	/* write handle */
 	/* write() can be interrupted with ^C. Therefore we set int0x23 here
@@ -903,7 +903,7 @@ int com_dosread(int dosfilefd, char *buf32, u_short size)
 	pre_msdos();
 	LWORD(ecx) = size;
 	LWORD(ebx) = dosfilefd;
-	LWORD(ds) = DOSEMU_LMHEAP_SEG;
+	SREG(ds) = DOSEMU_LMHEAP_SEG;
 	LWORD(edx) = DOSEMU_LMHEAP_OFFS_OF(s);
 	LWORD(eax) = 0x3f00;
 	/* read() can be interrupted with ^C, esp. when it reads from a
@@ -975,7 +975,7 @@ int com_dosprint(char *buf32)
 	pre_msdos();
 	LWORD(ebx) = STDOUT_FILENO;
 	LWORD(ecx) = size;
-	LWORD(ds) = DOSEMU_LMHEAP_SEG;
+	SREG(ds) = DOSEMU_LMHEAP_SEG;
 	LWORD(edx) = DOSEMU_LMHEAP_OFFS_OF(s);
 	HI(ax) = 0x40;
 	/* write() can be interrupted with ^C. Therefore we set int0x23 here

--- a/src/base/misc/dump.c
+++ b/src/base/misc/dump.c
@@ -64,8 +64,8 @@ void show_regs(void)
     sp = SEGOFF2LINEAR(_SS, _SP);
 
   dbug_printf("Real-mode state dump:\n");
-  dbug_printf("EIP: %04x:%08x", LWORD(cs), REG(eip));
-  dbug_printf(" ESP: %04x:%08x", LWORD(ss), REG(esp));
+  dbug_printf("EIP: %04x:%08x", SREG(cs), REG(eip));
+  dbug_printf(" ESP: %04x:%08x", SREG(ss), REG(esp));
 #if 1
   dbug_printf("  VFLAGS(b): ");
   for (i = (1 << 0x14); i > 0; i = (i >> 1)) {
@@ -82,7 +82,7 @@ void show_regs(void)
   dbug_printf("\nESI: %08x EDI: %08x EBP: %08x",
 	      REG(esi), REG(edi), REG(ebp));
   dbug_printf(" DS: %04x ES: %04x FS: %04x GS: %04x\n",
-	      LWORD(ds), LWORD(es), LWORD(fs), LWORD(gs));
+	      SREG(ds), SREG(es), SREG(fs), SREG(gs));
 
   /* display vflags symbolically...the #f "stringizes" the macro name */
 #define PFLAG(f)  if (REG(eflags)&(f)) dbug_printf(#f" ")

--- a/src/base/mouse/mouse.c
+++ b/src/base/mouse/mouse.c
@@ -368,7 +368,7 @@ void mouse_ps2bios(void)
     break;
   case 0x0007:
     m_printf("PS2MOUSE: set device handler %04x:%04x\n", SREG(es), LWORD(ebx));
-    mouse.ps2.cs = LWORD(es);
+    mouse.ps2.cs = SREG(es);
     mouse.ps2.ip = LWORD(ebx);
     HI(ax) = 0;
     NOCARRY;
@@ -794,7 +794,7 @@ mouse_restorestate(void)
   	mouse_cursor(-1);
   }
 
-  memcpy((void *)&mouse, MK_FP32(LWORD(es),LWORD(edx)), sizeof(mouse));
+  memcpy((void *)&mouse, MK_FP32(SREG(es),LWORD(edx)), sizeof(mouse));
 
   /* regenerate mouse graphics cursor from masks; they take less
   	space than the "compiled" version. */
@@ -824,7 +824,7 @@ mouse_storestate(void)
   }
   mouse.cursor_on = current_state;
 
-  memcpy(MK_FP32(LWORD(es),LWORD(edx)), (void *)&mouse, sizeof(mouse));
+  memcpy(MK_FP32(SREG(es),LWORD(edx)), (void *)&mouse, sizeof(mouse));
 
   /* now turn it back on */
   if (mouse.cursor_on >= 0) {
@@ -854,7 +854,7 @@ mouse_excevhand(void)
   tmp3 = mouse.ip;
   mouse_setsub();
   LWORD(ecx) = tmp1;
-  LWORD(es) = tmp2;
+  SREG(es) = tmp2;
   LWORD(edx) = tmp3;
 }
 
@@ -1406,10 +1406,10 @@ mouse_setyminmax(void)
 void
 mouse_set_gcur(void)
 {
-  unsigned short *ptr = MK_FP32(LWORD(es),LWORD(edx));
+  unsigned short *ptr = MK_FP32(SREG(es),LWORD(edx));
 
   m_printf("MOUSE: set gfx cursor...hspot: %d, vspot: %d, masks: %04x:%04x\n",
-	   LWORD(ebx), LWORD(ecx), LWORD(es), LWORD(edx));
+	   LWORD(ebx), LWORD(ecx), SREG(es), LWORD(edx));
 
   /* remember hotspot location */
   mouse.hotx = LWORD(ebx);
@@ -1448,12 +1448,12 @@ mouse_set_tcur(void)
 void
 mouse_setsub(void)
 {
-  mouse.cs = LWORD(es);
+  mouse.cs = SREG(es);
   mouse.ip = LWORD(edx);
   mouse.mask = LWORD(ecx);
 
   m_printf("MOUSE: user defined sub %04x:%04x, mask 0x%02x\n",
-	   LWORD(es), LWORD(edx), LWORD(ecx));
+	   SREG(es), LWORD(edx), LWORD(ecx));
 }
 
 void
@@ -1494,7 +1494,7 @@ void
 mouse_disable_internaldriver()
 {
   LWORD(eax) = 0x001F;
-  LWORD(es) = mouse.cs;
+  SREG(es) = mouse.cs;
   LWORD(ebx) = mouse.ip;
 
   mouse.enabled = FALSE;
@@ -1954,7 +1954,7 @@ static void call_int15_mouse_event_handler(void)
   unsigned int ssp, sp;
   int dx, dy, cnt = 0;
 
-  ssp = SEGOFF2LINEAR(LWORD(ss), 0);
+  ssp = SEGOFF2LINEAR(SREG(ss), 0);
   sp = LWORD(esp);
   saved_regs = REGS;
 

--- a/src/base/serial/fossil.c
+++ b/src/base/serial/fossil.c
@@ -97,7 +97,7 @@ static void fossil_init(void)
   irq_hlt = hlt_register_handler(hlt_hdlr);
 
   fossil_tsr_installed = TRUE;
-  fossil_id_segment = LWORD(es);
+  fossil_id_segment = SREG(es);
   fossil_id_offset = LWORD(edi);
 }
 
@@ -583,7 +583,7 @@ void serial_helper(void)
       LWORD(ebx) = FOSSIL_MAX_FUNCTION;
       NOCARRY;
       s_printf("SER: FOSSIL helper 1: TSR install, ES:DI=%04x:%04x\n",
-               LWORD(es), LWORD(edi));
+               SREG(es), LWORD(edi));
       break;
 
     default:

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -3218,7 +3218,7 @@ void dpmi_init(void)
 
     D_printf("Going protected with fingers crossed\n"
 		"32bit=%d, CS=%04x SS=%04x DS=%04x ip=%04x sp=%04x\n",
-		LO(ax), my_cs, LWORD(ss), LWORD(ds), my_ip, REG(esp));
+		LO(ax), my_cs, SREG(ss), SREG(ds), my_ip, REG(esp));
   /* display the 10 bytes before and after CS:EIP.  the -> points
    * to the byte at address CS:EIP
    */
@@ -3246,9 +3246,9 @@ void dpmi_init(void)
   if (SetSelector(CS, (unsigned long) (my_cs << 4), 0xffff, 0,
                   MODIFY_LDT_CONTENTS_CODE, 0, 0, 0, 0)) goto err;
 
-  if (!(SS = ConvertSegmentToDescriptor(LWORD(ss)))) goto err;
+  if (!(SS = ConvertSegmentToDescriptor(SREG(ss)))) goto err;
   /* if ds==ss, the selectors will be equal too */
-  if (!(DS = ConvertSegmentToDescriptor(LWORD(ds)))) goto err;
+  if (!(DS = ConvertSegmentToDescriptor(SREG(ds)))) goto err;
   if (!(ES = AllocateDescriptors(1))) goto err;
   SetSegmentBaseAddress(ES, dos_get_psp() << 4);
   SetSegmentLimit(ES, 0xff);

--- a/src/dosext/misc/emm.c
+++ b/src/dosext/misc/emm.c
@@ -1197,7 +1197,7 @@ alter_map_and_call(struct vm86_regs * state)
 
     /* call user fn */
     /* save parameters on the stack */
-    ssp = SEGOFF2LINEAR(LWORD(ss), 0);
+    ssp = SEGOFF2LINEAR(SREG(ss), 0);
     sp = LWORD(esp);
     pushw(ssp, sp, method);
     pushw(ssp, sp, handle);
@@ -1258,7 +1258,7 @@ static void emm_apmap_ret_hlt(Bit16u offs, void *arg)
   fake_retf(0);
 
   /* pop parameters from stack */
-  ssp = SEGOFF2LINEAR(LWORD(ss), 0);
+  ssp = SEGOFF2LINEAR(SREG(ss), 0);
   sp = LWORD(esp);
   off = popw(ssp, sp);
   seg = popw(ssp, sp);

--- a/src/dosext/net/pktnew.c
+++ b/src/dosext/net/pktnew.c
@@ -288,7 +288,7 @@ static int pkt_int(void)
 		LWORD(eax),LWORD(ebx),LWORD(ecx),LWORD(edx),REG(eflags));
     pd_printf("      SI=%04x DI=%04x BP=%04x SP=%04x CS=%04x DS=%04x ES=%04x SS=%04x\n",
 		LWORD(esi),LWORD(edi),LWORD(ebp),LWORD(esp),
-		LWORD(cs),LWORD(ds),LWORD(es),LWORD(ss));
+		SREG(cs),SREG(ds),SREG(es),SREG(ss));
   }
 #endif
 
@@ -399,7 +399,7 @@ static int pkt_int(void)
 	    hdlp = &pg.handle[free_handle];
 	    memset(hdlp, 0, sizeof(struct per_handle));
 	    hdlp->in_use = 1;
-	    hdlp->rcvr_cs = LWORD(es);
+	    hdlp->rcvr_cs = SREG(es);
 	    hdlp->rcvr_ip = LWORD(edi);
 	    hdlp->packet_type_len = LWORD(ecx);
 	    memcpy(hdlp->packet_type, SEG_ADR((char *),ds,si), LWORD(ecx));
@@ -562,7 +562,7 @@ static int pkt_int(void)
 		LWORD(eax),LWORD(ebx),LWORD(ecx),LWORD(edx),REG(eflags));
     pd_printf("      SI=%04x DI=%04x BP=%04x SP=%04x CS=%04x DS=%04x ES=%04x SS=%04x\n",
 		LWORD(esi),LWORD(edi),LWORD(ebp),LWORD(esp),
-		LWORD(cs),LWORD(ds),LWORD(es),LWORD(ss));
+		SREG(cs),SREG(ds),SREG(es),SREG(ss));
 
     return 1;
 }

--- a/src/emu-i386/do_vm86.c
+++ b/src/emu-i386/do_vm86.c
@@ -275,7 +275,7 @@ static int handle_GP_fault(void)
 
   case 0x6e:			/* (rep) outsb */
     LWORD(eip)++;
-    if (pref_seg < 0) pref_seg = LWORD(ds);
+    if (pref_seg < 0) pref_seg = SREG(ds);
     /* WARNING: no test for _SI wrapping! */
     LWORD(esi) += port_rep_outb(LWORD(edx), __SEG_ADR((Bit8u *),pref_seg,si),
 	LWORD(eflags)&DF, (is_rep? LWECX:1));
@@ -284,7 +284,7 @@ static int handle_GP_fault(void)
 
   case 0x6f:			/* (rep) outsw / outsd */
     LWORD(eip)++;
-    if (pref_seg < 0) pref_seg = LWORD(ds);
+    if (pref_seg < 0) pref_seg = SREG(ds);
     /* WARNING: no test for _SI wrapping! */
     if (prefix66) {
       LWORD(esi) += port_rep_outd(LWORD(edx), __SEG_ADR((Bit32u *),pref_seg,si),

--- a/src/env/builtins/builtins.c
+++ b/src/env/builtins/builtins.c
@@ -109,10 +109,10 @@ static int load_and_run_DOS_program(char *command, char *cmdline, int quit)
 	BMEM(pa4)->cmdline = MK_FARt(DOSEMU_LMHEAP_SEG, DOSEMU_LMHEAP_OFFS_OF(BMEM(cmdl)));
 	BMEM(pa4)->fcb1 = MK_FARt(COM_PSP_SEG, offsetof(struct PSP, FCB1));
 	BMEM(pa4)->fcb2 = MK_FARt(COM_PSP_SEG, offsetof(struct PSP, FCB2));
-	LWORD(es) = DOSEMU_LMHEAP_SEG;
+	SREG(es) = DOSEMU_LMHEAP_SEG;
 	LWORD(ebx) = DOSEMU_LMHEAP_OFFS_OF(BMEM(pa4));
 	/* path of programm to load */
-	LWORD(ds) = DOSEMU_LMHEAP_SEG;
+	SREG(ds) = DOSEMU_LMHEAP_SEG;
 	LWORD(edx) = DOSEMU_LMHEAP_OFFS_OF(BMEM(cmd));
 
 	fake_call_to(BIOSSEG, GET_RETCODE_HELPER);
@@ -288,7 +288,7 @@ int com_dossetcurrentdir(char *path)
         if (!s) return -1;
         pre_msdos();
         HI(ax) = 0x3b;
-        LWORD(ds) = DOSEMU_LMHEAP_SEG;
+        SREG(ds) = DOSEMU_LMHEAP_SEG;
         LWORD(edx) = DOSEMU_LMHEAP_OFFS_OF(s);
         call_msdos();    /* call MSDOS */
         com_strfree(s);

--- a/src/tools/debugger/mhpdbg.c
+++ b/src/tools/debugger/mhpdbg.c
@@ -390,10 +390,10 @@ unsigned int mhp_debug(enum dosdebug_event code, unsigned int parm1, unsigned in
 	  if (test_bit(DBG_ARG(mhpdbgc.currcode), mhpdbg.intxxtab)) {
 	    if ((mhpdbgc.bpload==1) && (DBG_ARG(mhpdbgc.currcode) == 0x21) && (LWORD(eax) == 0x4b00) ) {
 
-	      /* mhpdbgc.bpload_bp=((long)LWORD(cs) << 4) +LWORD(eip); */
+	      /* mhpdbgc.bpload_bp=((long)SREG(cs) << 4) +LWORD(eip); */
 	      mhpdbgc.bpload_bp = SEGOFF2LINEAR(SREG(cs), LWORD(eip));
 	      if (mhp_setbp(mhpdbgc.bpload_bp)) {
-		mhp_printf("bpload: intercepting EXEC\n", LWORD(cs), REG(eip));
+		mhp_printf("bpload: intercepting EXEC\n", SREG(cs), REG(eip));
 		/*
 		mhp_cmd("r");
 		mhp_cmd("d ss:sp 30h");
@@ -401,10 +401,10 @@ unsigned int mhp_debug(enum dosdebug_event code, unsigned int parm1, unsigned in
 
 		mhpdbgc.bpload++;
 		mhpdbgc.bpload_par=MK_FP32(BIOSSEG,(long)DBGload_parblock-(long)bios_f000);
-		MEMCPY_2UNIX(mhpdbgc.bpload_par, SEGOFF2LINEAR(LWORD(es), LWORD(ebx)), 14);
+		MEMCPY_2UNIX(mhpdbgc.bpload_par, SEGOFF2LINEAR(SREG(es), LWORD(ebx)), 14);
 		MEMCPY_2UNIX(mhpdbgc.bpload_cmdline, PAR4b_addr(commandline_ptr), 128);
-		MEMCPY_2UNIX(mhpdbgc.bpload_cmd, SEGOFF2LINEAR(LWORD(ds), LWORD(edx)), 128);
-		LWORD(es)=BIOSSEG;
+		MEMCPY_2UNIX(mhpdbgc.bpload_cmd, SEGOFF2LINEAR(SREG(ds), LWORD(edx)), 128);
+		SREG(es)=BIOSSEG;
 		LWORD(ebx)=(void *)mhpdbgc.bpload_par - MK_FP32(BIOSSEG, 0);
 		LWORD(eax)=0x4b01; /* load, but don't execute */
 	      }
@@ -475,7 +475,7 @@ unsigned int mhp_debug(enum dosdebug_event code, unsigned int parm1, unsigned in
 		    mhp_modify_eip(-1);
 		    if (mhpdbgc.bpload == 2) {
 		      mhp_printf("bpload: INT3 caught\n");
-		      LWORD(cs)=BIOSSEG;
+		      SREG(cs)=BIOSSEG;
 		      LWORD(eip)=(long)DBGload-(long)bios_f000;
 		      mhpdbgc.trapcmd = 1;
 		      mhpdbgc.bpload = 0;

--- a/src/tools/debugger/mhpdbgc.c
+++ b/src/tools/debugger/mhpdbgc.c
@@ -464,12 +464,12 @@ static unsigned long mhp_getreg(char * regn)
 {
   if (IN_DPMI) return dpmi_mhp_getreg(decode_symreg(regn));
   else switch (decode_symreg(regn)) {
-    case _SSr: return LWORD(ss);
-    case _CSr: return LWORD(cs);
-    case _DSr: return LWORD(ds);
-    case _ESr: return LWORD(es);
-    case _FSr: return LWORD(fs);
-    case _GSr: return LWORD(gs);
+    case _SSr: return SREG(ss);
+    case _CSr: return SREG(cs);
+    case _DSr: return SREG(ds);
+    case _ESr: return SREG(es);
+    case _FSr: return SREG(fs);
+    case _GSr: return SREG(gs);
     case _AXr: return LWORD(eax);
     case _BXr: return LWORD(ebx);
     case _CXr: return LWORD(ecx);
@@ -501,12 +501,12 @@ static void mhp_setreg(char * regn, unsigned long val)
     return;
   }
   else switch (decode_symreg(regn)) {
-    case _SSr: LWORD(ss) = val; break;
-    case _CSr: LWORD(cs) = val; break;
-    case _DSr: LWORD(ds) = val; break;
-    case _ESr: LWORD(es) = val; break;
-    case _FSr: LWORD(fs) = val; break;
-    case _GSr: LWORD(gs) = val; break;
+    case _SSr: SREG(ss) = val; break;
+    case _CSr: SREG(cs) = val; break;
+    case _DSr: SREG(ds) = val; break;
+    case _ESr: SREG(es) = val; break;
+    case _FSr: SREG(fs) = val; break;
+    case _GSr: SREG(gs) = val; break;
     case _AXr: LWORD(eax) = val; break;
     case _BXr: LWORD(ebx) = val; break;
     case _CXr: LWORD(ecx) = val; break;
@@ -993,10 +993,10 @@ static unsigned int mhp_getadr(char * a1, unsigned int * s1, unsigned int *o1, u
         selector=2;
       }
       else {
-        *s1 = LWORD(cs);
+        *s1 = SREG(cs);
         *o1 = LWORD(eip);
 	*lim = 0xFFFF;
-        return makeaddr(LWORD(cs), LWORD(eip));
+        return makeaddr(SREG(cs), LWORD(eip));
       }
    }
    if (selector != 2) {
@@ -1007,10 +1007,10 @@ static unsigned int mhp_getadr(char * a1, unsigned int * s1, unsigned int *o1, u
           selector=2;
         }
         else {
-          *s1 = LWORD(ss);
+          *s1 = SREG(ss);
           *o1 = LWORD(esp);
 	  *lim = 0xFFFF;
-          return makeaddr(LWORD(ss), LWORD(esp));
+          return makeaddr(SREG(ss), LWORD(esp));
         }
      }
      if (selector != 2) {
@@ -1372,9 +1372,9 @@ static void mhp_regs(int argc, char * argv[])
     mhp_printf("  SI=%04x  DI=%04x  SP=%04x  BP=%04x",
                 LWORD(esi), LWORD(edi), LWORD(esp), LWORD(ebp));
     mhp_printf("\nDS=%04x  ES=%04x  FS=%04x  GS=%04x  FL=%08x",
-                LWORD(ds), LWORD(es), LWORD(fs), LWORD(gs), REG(eflags));
+                SREG(ds), SREG(es), SREG(fs), SREG(gs), REG(eflags));
     mhp_printf("\nCS:IP=%04x:%04x       SS:SP=%04x:%04x\n",
-                LWORD(cs), LWORD(eip), LWORD(ss), LWORD(esp));
+                SREG(cs), LWORD(eip), SREG(ss), LWORD(esp));
   }
   mhp_cmd("u * 1");
 }
@@ -1395,10 +1395,10 @@ static void mhp_regs32(int argc, char * argv[])
               REG(esi), REG(edi), REG(ebp));
 
   mhp_printf(" DS: %04x ES: %04x FS: %04x GS: %04x\n",
-              LWORD(ds), LWORD(es), LWORD(fs), LWORD(gs));
+              SREG(ds), SREG(es), SREG(fs), SREG(gs));
 
   mhp_printf(" CS: %04x IP: %04x SS: %04x SP: %04x\n",
-              LWORD(cs), LWORD(eip), LWORD(ss), LWORD(esp));
+              SREG(cs), LWORD(eip), SREG(ss), LWORD(esp));
 }
 
 static void mhp_kill(int argc, char * argv[])
@@ -1483,7 +1483,7 @@ int mhp_getcsip_value()
 {
   unsigned int  seg, off, limit;
   if (IN_DPMI) return mhp_getadr("cs:eip", &seg, &off, &limit);
-  else return (LWORD(cs) << 4) + LWORD(eip);
+  else return (SREG(cs) << 4) + LWORD(eip);
 }
 
 void mhp_modify_eip(int delta)


### PR DESCRIPTION
Here's the search/replace LWORD(?s) -> SREG(?s). I tried playing with updating the LWORD macro to use the static_assert to check the arg size, but was unable to figure out the syntax within the macro to allow assignment and reference of the value properly. Perhaps you could add a follow up commit for that?