### PR TITLE
mfs/lfn.c: correctly advance through SFT containers

### DIFF
--- a/src/dosext/mfs/lfn.c
+++ b/src/dosext/mfs/lfn.c
@@ -96,7 +96,7 @@ static char *handle_to_filename(int handle, int *fd)
 		idx -= READ_WORD_S(spp, struct sfttbl, sftt_count);
 		sp = READ_DWORD_S(spp, struct sfttbl, sftt_next);
 	}
-	if (sp == 0xffffffff)
+	if ( (sp & 0xFFFF) == 0xffff )
 		return NULL;
 
 	/* do we "own" the drive? */

--- a/src/dosext/mfs/lfn.c
+++ b/src/dosext/mfs/lfn.c
@@ -85,7 +85,7 @@ static char *handle_to_filename(int handle, int *fd)
 	/* Get the SFT block that contains the SFT      */
 	sp = READ_DWORD(lol + 4);
 	sft = NULL;
-	while (sp != 0xffffffff) {
+	while ( (sp & 0xFFFF) != 0xffff) {
 		spp = rFAR_PTR(dosaddr_t, sp);
 		if (idx < READ_WORD_S(spp, struct sfttbl, sftt_count)) {
 			/* finally, point to the right entry            */
@@ -94,7 +94,7 @@ static char *handle_to_filename(int handle, int *fd)
 			break;
 		}
 		idx -= READ_WORD_S(spp, struct sfttbl, sftt_count);
-		sp = READ_WORD_S(spp, struct sfttbl, sftt_next);
+		sp = READ_DWORD_S(spp, struct sfttbl, sftt_next);
 	}
 	if (sp == 0xffffffff)
 		return NULL;


### PR DESCRIPTION
The structure field sftt_next is a dword (far) pointer. Correctly load
a dword from this into the variable sp.

Also modifies the test for the end-of-list indicator to check only the
low 16 bits, ie the offset portion.