### PR TITLE
disks.c: Use LBA addressing, determine an image's tracks from file size, error codes

### DIFF
--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -564,6 +564,7 @@ static void hdisk_auto(struct disk *dp)
       error("Hmm... BLKSSZGET failed (not fatal): %s\n", strerror(errno));
       sector_size = SECTOR_SIZE;
     }
+    dp->num_secs += sector_size - 1;	/* round up */
     dp->num_secs /= sector_size;
   }
   else

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1692,6 +1692,7 @@ int int13(void)
     /* beginning of Alan's additions */
   case 0x9:			/* initialise drive from bpb */
     CARRY;
+    HI(ax) = DERR_BADCMD;
     break;
 
   case 0x0A:			/* We dont have access to ECC info */
@@ -2011,6 +2012,7 @@ int int13(void)
 	  LWORD(eax));
     show_regs();
     CARRY;
+    HI(ax) = DERR_BADCMD;
     break;
   }
   return 1;

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1446,6 +1446,8 @@ int int13(void)
     else
       head = HI(dx);
     sect = (REG(ecx) & 0x3f) - 1;
+    /* Note that the unsigned int sect will underflow if cl & 3Fh is 0.
+       Further on this is detected as a too-large value for the sector. */
     track = (HI(cx)) |
       ((REG(ecx) & 0xc0) << 2);
     if (!checkdp_val && dp->diskcyl4096 && dp->heads <= 64 && (HI(dx) & 0xc0))
@@ -1504,6 +1506,8 @@ int int13(void)
     else
       head = HI(dx);
     sect = (REG(ecx) & 0x3f) - 1;
+    /* Note that the unsigned int sect will underflow if cl & 3Fh is 0.
+       Further on this is detected as a too-large value for the sector. */
     track = (HI(cx)) |
       ((REG(ecx) & 0xc0) << 2);
     if (!checkdp_val && dp->diskcyl4096 && dp->heads <= 64 && (HI(dx) & 0xc0))

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -538,11 +538,12 @@ static void image_auto(struct disk *dp)
     dp->num_secs = (unsigned long long)dp->tracks * dp->heads * dp->sectors;
   } else if (sect[510] == 0x55 && sect[511] == 0xaa) {
     filesize = lseek64(dp->fdesc, 0, SEEK_END);
-    dp->num_secs = (filesize + SECTOR_SIZE - 1) / SECTOR_SIZE;
+    dp->num_secs = (filesize /* + SECTOR_SIZE - 1 */ ) / SECTOR_SIZE;
     dp->heads = 255;
     dp->sectors = 63;
-    dp->tracks = (dp->num_secs + (dp->heads * dp->sectors - 1))
+    dp->tracks = (dp->num_secs /* + (dp->heads * dp->sectors - 1) */ )
 		  / (dp->heads * dp->sectors);
+		/* round down number of sectors and number of tracks */
     dp->header = 0;
   } else {
     error("IMAGE %s header lacks magic string - cannot autosense!\n",
@@ -581,7 +582,8 @@ static void hdisk_auto(struct disk *dp)
       error("Hmm... BLKSSZGET failed (not fatal): %s\n", strerror(errno));
       sector_size = SECTOR_SIZE;
     }
-    dp->num_secs += sector_size - 1;	/* round up */
+    /* dp->num_secs += sector_size - 1; */ /* round up */
+		/* round down! */
     dp->num_secs /= sector_size;
   }
   else

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1666,10 +1666,16 @@ int int13(void)
 
       /* these numbers are "zero based" */
       HI(dx) = dp->heads - 1;
-      HI(cx) = (dp->tracks - 1) & 0xff;
+      track = dp->tracks - 1;
+      if (track > 0x3FF)
+      {
+	/* if tracks do not fit, clamp to the maximum representable */
+	track = 0x3FF;
+      }
+      HI(cx) = track & 0xff;
 
       LO(dx) = (disk < 0x80) ? FDISKS : HDISKS;
-      LO(cx) = (dp->sectors & 0x3f) | (((dp->tracks -1) & 0x300) >> 2);
+      LO(cx) = (dp->sectors & 0x3f) | ((track & 0x300) >> 2);
       LO(ax) = 0;
       HI(ax) = DERR_NOERR;
       REG(eflags) &= ~CF;	/* no error */

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -200,7 +200,7 @@ int read_mbr(struct disk *dp, unsigned buffer)
  */
 
 int
-read_sectors(struct disk *dp, unsigned buffer, unsigned long sector,
+read_sectors(struct disk *dp, unsigned buffer, uint64_t sector,
 	     long count)
 {
   off64_t  pos;
@@ -215,7 +215,7 @@ read_sectors(struct disk *dp, unsigned buffer, unsigned long sector,
 
   /* XXX - header hack. dp->header can be negative for type PARTITION */
   pos = sector * SECTOR_SIZE + dp->header;
-  d_printf("DISK: %s: Trying to read %ld sectors at LBA %lu",
+  d_printf("DISK: %s: Trying to read %ld sectors at LBA %"PRIu64"",
 	   dp->dev_name,count,sector);
 #if defined(__linux__) && defined(__i386__)
   d_printf("%+lld at pos %lld\n", dp->header, pos);
@@ -300,7 +300,7 @@ read_sectors(struct disk *dp, unsigned buffer, unsigned long sector,
 }
 
 int
-write_sectors(struct disk *dp, unsigned buffer, unsigned long sector,
+write_sectors(struct disk *dp, unsigned buffer, uint64_t sector,
 	     long count)
 {
   off64_t  pos;
@@ -324,7 +324,7 @@ write_sectors(struct disk *dp, unsigned buffer, unsigned long sector,
 
   /* XXX - header hack */
   pos = sector * SECTOR_SIZE + dp->header;
-  d_printf("DISK: %s: Trying to write %ld sectors at LBA %lu",
+  d_printf("DISK: %s: Trying to write %ld sectors at LBA %"PRIu64"",
 	   dp->dev_name,count,sector);
 #if defined(__linux__) && defined(__i386__)
   d_printf(" at pos %lld\n", pos);
@@ -1880,13 +1880,13 @@ int int13(void)
     buffer = SEGOFF2LINEAR(diskaddr->buf_seg, diskaddr->buf_ofs);
     number = diskaddr->blocks;
     WRITE_P(diskaddr->blocks, 0);
-    d_printf("DISK %02x ext read [LBA %"PRIu32"](%d)->%04x:%04x\n",
-	     disk, diskaddr->block_lo, number, diskaddr->buf_seg, diskaddr->buf_ofs);
+    d_printf("DISK %02x ext read [LBA %"PRIu64"](%d)->%04x:%04x\n",
+	     disk, diskaddr->block, number, diskaddr->buf_seg, diskaddr->buf_ofs);
 
-    if (checkdp_val || diskaddr->block_hi != 0) {
+    if (checkdp_val) {
       d_printf("Sector not found, AH=0x42!\n");
-      d_printf("DISK %02x ext read [LBA %"PRIu32"<32 + %"PRIu32"](%d)->%#x\n",
-	       disk, diskaddr->block_hi, diskaddr->block_lo, number, buffer);
+      d_printf("DISK %02x ext read [LBA %"PRIu64"](%d)->%#x\n",
+	       disk, diskaddr->block, number, buffer);
       if (dp) {
 	  d_printf("DISK dev %s GEOM %d heads %d sects %d trk\n",
 		   dp->dev_name, dp->heads, dp->sectors, dp->tracks);
@@ -1900,7 +1900,7 @@ int int13(void)
       break;
     }
 
-    res = read_sectors(dp, buffer, diskaddr->block_lo, number);
+    res = read_sectors(dp, buffer, diskaddr->block, number);
 
     if (res < 0) {
       HI(ax) = -res;
@@ -1917,8 +1917,8 @@ int int13(void)
     WRITE_P(diskaddr->blocks, res >> 9);
     HI(ax) = 0;
     REG(eflags) &= ~CF;
-    R_printf("DISK ext read LBA %"PRIu32" (%d) -> %#x OK.\n",
-	     diskaddr->block_lo, res >> 9, buffer);
+    R_printf("DISK ext read LBA %"PRIu64" (%d) -> %#x OK.\n",
+	     diskaddr->block, res >> 9, buffer);
     break;
   }
 
@@ -1932,13 +1932,13 @@ int int13(void)
     buffer = SEGOFF2LINEAR(diskaddr->buf_seg, diskaddr->buf_ofs);
     number = diskaddr->blocks;
     WRITE_P(diskaddr->blocks, 0);
-    d_printf("DISK %02x ext write [LBA %"PRIu32"](%d)->%04x:%04x\n",
-	     disk, diskaddr->block_lo, number, diskaddr->buf_seg, diskaddr->buf_ofs);
+    d_printf("DISK %02x ext write [LBA %"PRIu64"](%d)->%04x:%04x\n",
+	     disk, diskaddr->block, number, diskaddr->buf_seg, diskaddr->buf_ofs);
 
-    if (checkdp_val || diskaddr->block_hi != 0) {
+    if (checkdp_val) {
       error("Sector not found, AH=0x43!\n");
-      d_printf("DISK %02x ext write [LBA %"PRIu32"<<32 + %"PRIu32"](%d)->%#x\n",
-	       disk, diskaddr->block_hi, diskaddr->block_lo, number, buffer);
+      d_printf("DISK %02x ext write [LBA %"PRIu64"](%d)->%#x\n",
+	       disk, diskaddr->block, number, buffer);
       if (dp) {
 	  d_printf("DISK dev %s GEOM %d heads %d sects %d trk\n",
 		   dp->dev_name, dp->heads, dp->sectors, dp->tracks);
@@ -1965,7 +1965,7 @@ int int13(void)
 
     if (dp->rdonly)
       error("CONTINUED!!!!!\n");
-    res = write_sectors(dp, buffer, diskaddr->block_lo, number);
+    res = write_sectors(dp, buffer, diskaddr->block, number);
 
     if (res < 0) {
       HI(ax) = -res;
@@ -1982,8 +1982,8 @@ int int13(void)
     WRITE_P(diskaddr->blocks, res >> 9);
     HI(ax) = 0;
     REG(eflags) &= ~CF;
-    R_printf("DISK ext write LBA %"PRIu32" (%d) -> %#x OK.\n",
-	     diskaddr->block_lo, res >> 9, buffer);
+    R_printf("DISK ext write LBA %"PRIu64" (%d) -> %#x OK.\n",
+	     diskaddr->block, res >> 9, buffer);
     break;
   }
 

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1395,6 +1395,7 @@ static int checkdp(struct disk *disk)
 int int13(void)
 {
   unsigned int disk, head, sect, track, number;
+  uint64_t number_sectors;
   int res;
   off64_t  pos;
   unsigned buffer;
@@ -1761,9 +1762,17 @@ int int13(void)
       else {
 	d_printf("disk gettype: hard disk\n");
 	HI(ax) = 3;		/* fixed disk */
-	number = dp->tracks * dp->sectors * dp->heads;
-	LWORD(ecx) = number >> 16;
-	LWORD(edx) = number & 0xffff;
+	number = dp->tracks;
+	if (number > 0x3FF) number = 0x3FF;
+	number_sectors = (uint64_t)number * dp->sectors * dp->heads;
+	if (number_sectors <= 0xFFFFFFFF) {
+	  LWORD(ecx) = (number_sectors >> 16) & 0xFFFF;
+	  LWORD(edx) = number_sectors & 0xFFFF;
+	}
+	else {
+	  LWORD(ecx) = 0xFFFF;
+	  LWORD(edx) = 0xFFFF;
+	}
       }
       REG(eflags) &= ~CF;	/* no error */
     }

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -206,6 +206,12 @@ read_sectors(struct disk *dp, unsigned buffer, unsigned long sector,
   long already = 0;
   long tmpread;
 
+  if ( (sector + count - 1) >= dp->num_secs) {
+    d_printf("Sector not found, read_sectors!\n");
+    show_regs();
+    return -DERR_NOTFOUND;
+  }
+
   /* XXX - header hack. dp->header can be negative for type PARTITION */
   pos = sector * SECTOR_SIZE + dp->header;
   d_printf("DISK: %s: Trying to read %ld sectors at LBA %lu",
@@ -298,6 +304,12 @@ write_sectors(struct disk *dp, unsigned buffer, unsigned long sector,
 {
   off64_t  pos;
   long tmpwrite, already = 0;
+
+  if ( (sector + count - 1) >= dp->num_secs) {
+    error("Sector not found, write_sectors!\n");
+    show_regs();
+    return -DERR_NOTFOUND;
+  }
 
   if (dp->rdonly) {
     d_printf("ERROR: write to readonly disk %s\n", dp->dev_name);

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1460,7 +1460,7 @@ int int13(void)
 
     if (checkdp_val || head >= dp->heads ||
 	sect >= dp->sectors || track >= dp->tracks) {
-      d_printf("Sector not found 1!\n");
+      d_printf("Sector not found, ah=0x02!\n");
       d_printf("DISK %02x read [h:%d,s:%d,t:%d](%d)->%#x\n",
 	       disk, head, sect, track, number, buffer);
       if (dp) {
@@ -1520,7 +1520,7 @@ int int13(void)
 
     if (checkdp_val || head >= dp->heads ||
 	sect >= dp->sectors || track >= dp->tracks) {
-      error("Sector not found 3!\n");
+      error("Sector not found, ah=0x03!\n");
       show_regs();
       HI(ax) = DERR_NOTFOUND;
       REG(eflags) |= CF;

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -24,6 +24,7 @@
 #endif
 #include <sys/stat.h>
 #include <sys/time.h>
+#include <inttypes.h>
 
 #include "int.h"
 #include "port.h"
@@ -559,7 +560,7 @@ static void image_auto(struct disk *dp)
     leavedos(20);
   }
 
-  d_printf("IMAGE auto disk %s; num_secs=%lu, t=%d, h=%d, s=%d, off=%ld\n",
+  d_printf("IMAGE auto disk %s; num_secs=%"PRIu64", t=%d, h=%d, s=%d, off=%ld\n",
            dp->dev_name, dp->num_secs,
            dp->tracks, dp->heads, dp->sectors,
            (long) dp->header);
@@ -1879,12 +1880,12 @@ int int13(void)
     buffer = SEGOFF2LINEAR(diskaddr->buf_seg, diskaddr->buf_ofs);
     number = diskaddr->blocks;
     WRITE_P(diskaddr->blocks, 0);
-    d_printf("DISK %02x ext read [LBA %lu](%d)->%04x:%04x\n",
+    d_printf("DISK %02x ext read [LBA %"PRIu32"](%d)->%04x:%04x\n",
 	     disk, diskaddr->block_lo, number, diskaddr->buf_seg, diskaddr->buf_ofs);
 
     if (checkdp_val || diskaddr->block_hi != 0) {
       d_printf("Sector not found, AH=0x42!\n");
-      d_printf("DISK %02x ext read [LBA %lu<<32 + %lu](%d)->%#x\n",
+      d_printf("DISK %02x ext read [LBA %"PRIu32"<32 + %"PRIu32"](%d)->%#x\n",
 	       disk, diskaddr->block_hi, diskaddr->block_lo, number, buffer);
       if (dp) {
 	  d_printf("DISK dev %s GEOM %d heads %d sects %d trk\n",
@@ -1916,7 +1917,7 @@ int int13(void)
     WRITE_P(diskaddr->blocks, res >> 9);
     HI(ax) = 0;
     REG(eflags) &= ~CF;
-    R_printf("DISK ext read LBA %lu (%d) -> %#x OK.\n",
+    R_printf("DISK ext read LBA %"PRIu32" (%d) -> %#x OK.\n",
 	     diskaddr->block_lo, res >> 9, buffer);
     break;
   }
@@ -1931,12 +1932,12 @@ int int13(void)
     buffer = SEGOFF2LINEAR(diskaddr->buf_seg, diskaddr->buf_ofs);
     number = diskaddr->blocks;
     WRITE_P(diskaddr->blocks, 0);
-    d_printf("DISK %02x ext write [LBA %lu](%d)->%04x:%04x\n",
+    d_printf("DISK %02x ext write [LBA %"PRIu32"](%d)->%04x:%04x\n",
 	     disk, diskaddr->block_lo, number, diskaddr->buf_seg, diskaddr->buf_ofs);
 
     if (checkdp_val || diskaddr->block_hi != 0) {
       error("Sector not found, AH=0x43!\n");
-      d_printf("DISK %02x ext write [LBA %lu<<32 + %lu](%d)->%#x\n",
+      d_printf("DISK %02x ext write [LBA %"PRIu32"<<32 + %"PRIu32"](%d)->%#x\n",
 	       disk, diskaddr->block_hi, diskaddr->block_lo, number, buffer);
       if (dp) {
 	  d_printf("DISK dev %s GEOM %d heads %d sects %d trk\n",
@@ -1981,7 +1982,7 @@ int int13(void)
     WRITE_P(diskaddr->blocks, res >> 9);
     HI(ax) = 0;
     REG(eflags) &= ~CF;
-    R_printf("DISK ext write LBA %lu (%d) -> %#x OK.\n",
+    R_printf("DISK ext write LBA %"PRIu32" (%d) -> %#x OK.\n",
 	     diskaddr->block_lo, res >> 9, buffer);
     break;
   }

--- a/src/emu.c
+++ b/src/emu.c
@@ -206,7 +206,7 @@ void boot(void)
 	    leavedos(16);
 	}
     } else if (dp->floppy) {
-	if (read_sectors(dp, buffer, 0, 0, 0, 1) != SECTOR_SIZE) {
+	if (read_sectors(dp, buffer, 0, 1) != SECTOR_SIZE) {
 	    error("can't boot from %s, using harddisk\n", dp->dev_name);
 	    dp = hdisktab;
 	    goto mbr;

--- a/src/include/disks.h
+++ b/src/include/disks.h
@@ -114,7 +114,7 @@ struct disk {
   int dexeflags;		/* special flags for DEXE support */
   int sectors, heads, tracks;	/* geometry */
   unsigned long start;		/* geometry */
-  unsigned long long num_secs;	/* total sectors on disk */
+  uint64_t num_secs;		/* total sectors on disk */
   int hdtype;			/* 0 none, IBM Types 1, 2 and 9 */
   floppy_t default_cmos;	/* default CMOS floppy type */
   int drive_num;

--- a/src/include/disks.h
+++ b/src/include/disks.h
@@ -189,8 +189,8 @@ extern struct disk hdisktab[MAX_HDISKS];
 #endif
 
 int read_mbr(struct disk *dp, unsigned buffer);
-int read_sectors(struct disk *, unsigned, long, long, long, long);
-int write_sectors(struct disk *, unsigned, long, long, long, long);
+int read_sectors(struct disk *, unsigned, unsigned long, long);
+int write_sectors(struct disk *, unsigned, unsigned long, long);
 
 void disk_open(struct disk *dp);
 int disk_is_bootable(const struct disk *dp);

--- a/src/include/disks.h
+++ b/src/include/disks.h
@@ -189,8 +189,8 @@ extern struct disk hdisktab[MAX_HDISKS];
 #endif
 
 int read_mbr(struct disk *dp, unsigned buffer);
-int read_sectors(struct disk *, unsigned, unsigned long, long);
-int write_sectors(struct disk *, unsigned, unsigned long, long);
+int read_sectors(struct disk *, unsigned, uint64_t, long);
+int write_sectors(struct disk *, unsigned, uint64_t, long);
 
 void disk_open(struct disk *dp);
 int disk_is_bootable(const struct disk *dp);
@@ -230,8 +230,7 @@ struct ibm_ms_diskaddr_pkt {
   uint16_t blocks;     /* number of blocks to transfer */
   uint16_t buf_ofs;    /* offset of transfer buffer */
   uint16_t buf_seg;    /* segment of transfer buffer */
-  uint32_t block_lo;    /* starting block number, low dword */
-  uint32_t block_hi;    /* starting block, high dword */
+  uint64_t block;	/* starting block number */
 } __attribute__((packed));
 
 struct ibm_ms_drive_params {


### PR DESCRIPTION
Note that this doesn't yet correctly limit accesses to the num_secs value. That should probably be done in (read|write)_sectors.

See also discussion in https://github.com/stsp/dosemu2/issues/461