### PR TITLE
dosdebug: Don't repeat '[ud]` xxxx:xxxx' commands

### DIFF
--- a/src/tools/debugger/dosdebug.c
+++ b/src/tools/debugger/dosdebug.c
@@ -27,6 +27,8 @@
 
 #include <sys/ioctl.h>
 
+#include "utilities.h"
+
 #define    TMPFILE_VAR		"/var/run/dosemu."
 #define    TMPFILE_HOME		".dosemu/run/dosemu."
 
@@ -172,8 +174,14 @@ static void handle_console_input(void)
         kill_timeout=KILL_TIMEOUT;
       }
       write(fdout, buf, n);
-      memcpy(sbuf, buf, n);
-      sn=n;
+
+      if (strncmp(buf, "d ", 2) == 0)
+        sn = snprintf(sbuf, sizeof sbuf, "d\n");
+      else if (strncmp(buf, "u ", 2) == 0)
+        sn = snprintf(sbuf, sizeof sbuf, "u\n");
+      else
+        sn = snprintf(sbuf, min(sizeof sbuf, n + 1), "%s", buf);
+
       if (buf[0] == 'q') exit(1);
     }
   }


### PR DESCRIPTION
Repeating 'd' dump memory or 'u' unassemble commands with a fixed address
makes no sense, so translate those into a plain 'd/u' before saving in the
command history. Subsequent repeats will increment the address.

e.g.

d cs:0010
PRINTS 0070:0010 > 0070:0080
<enter>
PRINTS 0070:0090 > 0070:0100
<enter>
PRINTS 0070:0110 > 0070:0180

fixes #482 