### PR TITLE
dosdebug: Set normalised seg:ofs on linear addr

### DIFF
--- a/src/tools/debugger/mhpdbgc.c
+++ b/src/tools/debugger/mhpdbgc.c
@@ -1026,8 +1026,8 @@ static unsigned int mhp_getadr(char * a1, unsigned int * s1, unsigned int *o1, u
        }
        if (!(srchp = strchr(a1, ':'))) {
           sscanf(a1, "%lx", &ul1);
-          *s1 = 0;
-          *o1 = 0;
+          *s1 = (ul1 >> 4);
+          *o1 = (ul1 & 0b00001111);
           return ul1;
        }
        if ( (seg1 = mhp_getreg(a1)) == -1) {


### PR DESCRIPTION
If for example a linear address is specified in 'u' unassemble, but
current address mode is 'dos', unassembly is incorrectly done from
0000:0000. Since there is a one to many relationship of linear to
seg:ofs addresses, set a normalised seg:ofs so that unassembly will be
correct and subsequent 'u' commands will be sequential.

Fixes strangeness with [#494], but doesn't alter the addr (no colon)
behaviour to match the reporter's expectation that it should represent
the offset part of a seg:off address and the segment part be defaulted
to current CS.

Note: The same problem as in #494 occurs with unix addresses found via the symbol file.