### PR TITLE
dosdebug: Match the whole command for kill

### DIFF
--- a/src/tools/debugger/dosdebug.c
+++ b/src/tools/debugger/dosdebug.c
@@ -170,7 +170,7 @@ static void handle_console_input(void)
         return;
       }
 #endif
-      if (!strncmp(buf,"kill",4)) {
+      if (!strcmp(buf, "kill\n")) {
         kill_timeout=KILL_TIMEOUT;
       }
       write(fdout, buf, n);


### PR DESCRIPTION
Previously the dosdebug client was matching only the first 4 characters
of the command for 'kill' which meant that 'killeverything' also
matched but the 'unknown command' message was displayed anyway. Tighten
the matching to look for whole string and terminating EOL character.

Fixes [#509]

Note: that the issue reports that there's a difference in the kill
behaviour, that's because the mhp dosdebug side never sent the
termination command due to 'unknown command'. Subsequently the dosdebug
client side timed out and followed up with the signal sequence of TERM
then KILL.