### PR TITLE
lfn: Fix LFN file creation

### DIFF
--- a/src/base/bios/bios.S
+++ b/src/base/bios/bios.S
@@ -165,6 +165,10 @@ PKTDRV_stats:
 LFN_short_name:
 	.space 128
 
+	.globl	LFN_long_name
+LFN_long_name:
+	.space 128
+
 /******************************************************************
  * BIOS CODE BLOCK						  *
  ******************************************************************/
@@ -696,30 +700,23 @@ PKTDRV_driver_entry_cs:
 /* ===== LFN helper f000:f230 */
 	.org	((LFN_HELPER_SEG-BIOSSEG) << 4)+LFN_HELPER_OFF
 	pushw	%ds
-        pushw	%dx
-        pushw	%si
-        movw    %cs, %si
-        movw	%si, %ds
-        movw	$LFN_short_name-bios_f000, %si
+	pushw	%dx
+	pushw	%si
+
+	pushw	%cs
+	popw	%ds
+	movw	$LFN_short_name-bios_f000, %si
 	cmpb	$0x6c, %ah
-        je	do_6c
-        movw	%si, %dx
-        jmp     do_int21
-do_6c:
-        cmpb    $1, %al        /* ax=6c01 means created by lfn.c */
-        movb    $0, %al
-        jnz     do_int21
-        movb    $1, %dl        /* then transform to open (dl=1) */
-        int	$0x21
-        movw    $2, %cx        /* flag creation */
-        jmp     after_int21
-do_int21:
-        int	$0x21
-after_int21:
-        popw	%si
-        popw	%dx
-        popw	%ds
-        lret
+	je	1f
+	movw	%si, %dx	/* 0x3b chdir needs path in DS:DX */
+1:
+	movb	$0x00, %al
+	int	$0x21
+
+	popw	%si
+	popw	%dx
+	popw	%ds
+	lret
 
 /* ----------------------------------------------------------------- */
 

--- a/src/include/bios.h
+++ b/src/include/bios.h
@@ -16,6 +16,7 @@ extern void bios_f000_int10_old(void);
 extern char bios_in_int10_callback;
 
 extern char LFN_short_name[];
+extern char LFN_long_name[];
 
 #define INT2F_IDLE_MAGIC	0x1680
 


### PR DESCRIPTION
**NOT** ready for inclusion yet, but here for discussion

1/ Remove the new file creation from lfn.c
2/ Pass both long and short filenames via bios.S
3/ Simplify bios.S LFN helper
4/ In mfs.c Multipurpose open use LFN long name if LFN short name
matches the filename passed in via SDA.

Note: This is a work in progress, but does work for MS-DOS 6.22 etc
   1/ I dislike the jumping between cases in mfs.c, and subseqently
      the selected_name crap.
   2/ Device opening needs to be checked
   3/ Doesn't seem to work for older DOSes(tested MS-DOS 3.31) that
      don't have int21/6c. Perhaps int21/3c/3d enter the redirector
      via an entry point other than Multipurpose open.