### PR TITLE
MFS/LFN: Fix LFN file creation for r/o files.

### DIFF
--- a/src/base/bios/bios.S
+++ b/src/base/bios/bios.S
@@ -702,20 +702,10 @@ PKTDRV_driver_entry_cs:
         movw	%si, %ds
         movw	$LFN_short_name-bios_f000, %si
 	cmpb	$0x6c, %ah
-        je	do_6c
+        je	do_int21
         movw	%si, %dx
-        jmp     do_int21
-do_6c:
-        cmpb    $1, %al        /* ax=6c01 means created by lfn.c */
-        movb    $0, %al
-        jnz     do_int21
-        movb    $1, %dl        /* then transform to open (dl=1) */
-        int	$0x21
-        movw    $2, %cx        /* flag creation */
-        jmp     after_int21
 do_int21:
         int	$0x21
-after_int21:
         popw	%si
         popw	%dx
         popw	%ds

--- a/src/dosext/mfs/lfn.c
+++ b/src/dosext/mfs/lfn.c
@@ -43,6 +43,8 @@ struct lfndir {
 #define MAX_OPEN_DIRS 20
 struct lfndir *lfndirs[MAX_OPEN_DIRS];
 
+char lfn_create_fpath[PATH_MAX];
+
 static unsigned long long unix_to_win_time(time_t ut)
 {
 	return ((unsigned long long)ut + (369 * 365 + 89)*24*60*60ULL) *
@@ -1224,27 +1226,13 @@ static int mfs_lfn_(void)
 			strcat(fpath, fpath2);
 			if (!find_file(fpath, &st, drive, NULL) &&
 			    (_DX & 0x10)) {
-				int fd;
 				if (drives[drive].read_only)
 					return lfn_error(ACCESS_DENIED);
-				fd = open(fpath, (O_RDWR | O_CREAT),
-					  get_unix_attr(0664, _CL |
-							ARCHIVE_NEEDED));
-				if (fd < 0) {
-					d_printf("LFN: creat problem: %o %s %s\n",
-						 get_unix_attr(0644, _CX),
-						 fpath, strerror(errno));
-					return lfn_error(ACCESS_DENIED);
-				}
-				set_fat_attr(fd, _CL | ARCHIVE_NEEDED);
-				d_printf("LFN: open: created %s\n", fpath);
-				close(fd);
-				_AL = 1; /* flags creation to DOS helper */
-			} else {
-				_AL = 0;
+				strcpy(lfn_create_fpath, fpath);
 			}
 			make_unmake_dos_mangled_path(d, fpath, drive, 1);
 		}
+		_AL = 0;
 		call_dos_helper(0x6c);
 		break;
 	}

--- a/src/dosext/mfs/lfn.h
+++ b/src/dosext/mfs/lfn.h
@@ -5,6 +5,9 @@
  * for details see file COPYING in the DOSEMU distribution
  */
 
+#include <limits.h>
+extern char lfn_create_fpath[PATH_MAX];
+
 int make_unmake_dos_mangled_path(char *dest, const char *fpath,
                                          int current_drive, int alias);
 void close_dirhandles(unsigned psp);

--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -4259,6 +4259,12 @@ dos_fs_redirect(struct vm86_regs *state)
       }
 
       if (((action & 0x10) != 0) && !file_exists) {
+	u_short *userStack = (u_short *) sda_user_stack(sda);
+	if (userStack[7] == BIOSSEG &&
+	    userStack[4] == LFN_short_name - (char *)bios_f000)
+	  /* special case: creation of LFN's using saved path
+	     if original DS:SI points to BIOSSEG:LFN_short_name */
+	  strcpy(fpath, lfn_create_fpath);
 	/* Replace if file exists */
 	SETWORD(&(state->ecx), 0x2);
 	goto do_create_truncate;


### PR DESCRIPTION
Do a single open for creating LFN files by storing the Unix filename
in a global variable, which is then used by MFS to open the file.
MFS uses sda_user_stack to detect if the passed SFN comes from lfn.c
(DS:SI=BIOSSEG:LFN_short_name).