### PR TITLE
Adding includes to improve musl libc compatibility

### DIFF
--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -59,6 +59,7 @@
 #include <sys/stat.h>
 #include <errno.h>
 #include <assert.h>
+#include <limits.h>
 
 #include "disks.h"
 #include "fatfs.h"

--- a/src/include/disks.h
+++ b/src/include/disks.h
@@ -21,6 +21,7 @@
 
 #include <stdint.h>
 #include <sys/types.h>
+#include <fcntl.h>
 
 /* disk file types */
 typedef enum {


### PR DESCRIPTION
Musl defines `loff_t` in `fcntl.h` and `PATH_MAX` in `limits.h`.