### PR TITLE
Replace canonicalize_file_name with realpath in dos2linux.c

### DIFF
--- a/src/base/misc/dos2linux.c
+++ b/src/base/misc/dos2linux.c
@@ -203,7 +203,7 @@ int find_drive (char **plinux_path_resolved)
     char *drive_linux_root_resolved;
 
     if (GetRedirectionRoot (drive, &drive_linux_root, &drive_ro) == 0/*success*/) {
-      drive_linux_root_resolved = canonicalize_file_name(drive_linux_root);
+      drive_linux_root_resolved = realpath(drive_linux_root, NULL);
       if (!drive_linux_root_resolved) {
         com_fprintf (com_stderr,
                      "ERROR: %s.  Cannot canonicalize drive root path.\n",


### PR DESCRIPTION
Fixes following error when linking against the musl libc:

```
lib/libbase_misc.a(dos2linux.o): In function `find_drive':
dos2linux.c:(.text+0x1514): undefined reference to `canonicalize_file_name'
```

Found a bug report where this is discussed:
https://sourceware.org/bugzilla/show_bug.cgi?id=21009