### PR TITLE
utilities.c: use va_copy instead of __va_copy

### DIFF
--- a/src/base/misc/utilities.c
+++ b/src/base/misc/utilities.c
@@ -270,7 +270,7 @@ void verror(const char *fmt, va_list args)
 {
 	char fmtbuf[1025];
 	va_list orig_args;
-	__va_copy(orig_args, args);
+	va_copy(orig_args, args);
 
 	if (fmt[0] == '@') {
 		pthread_mutex_lock(&log_mtx);


### PR DESCRIPTION
resolves #533 