### PR TITLE
MFS: Reinstate FAT32 disk space function [#544]

### DIFF
--- a/src/base/async/int.c
+++ b/src/base/async/int.c
@@ -1517,7 +1517,14 @@ static int msdos(void)
 	    can_change_title = 0;
 	    return 0;
 	}
+
+    case 0x73:
+        /* Call our FAT32 handler before DOS's to ensure we can provide
+	 * proper (>2GB) free disk space values on our MFS drives regardless
+	 * of whether the DOS actually implements this call */
+        return mfs_fat32();
     }
+
     return 0;
 }
 

--- a/src/dosext/mfs/lfn.c
+++ b/src/dosext/mfs/lfn.c
@@ -921,30 +921,6 @@ static int mfs_lfn_(void)
 			return 1;
 		}
 		return 1;
-	} else if (_AH == 0x73) {
-		unsigned int spc, bps, free, tot;
-
-		if (_AL != 3) return 0;
-
-		d_printf("LFN: Get disk space %s\n", src);
-		drive = build_posix_path(fpath, src, 0);
-		if (drive < 0)
-			return drive + 2;
-		if (!find_file(fpath, &st, drive, NULL)|| !S_ISDIR(st.st_mode))
-			return lfn_error(PATH_NOT_FOUND);
-		if (!dos_get_disk_space(fpath, &free, &tot, &spc, &bps))
-			return lfn_error(PATH_NOT_FOUND);
-
-		WRITE_DWORD(dest, 0x24);
-		WRITE_DWORD(dest + 0x4, spc);
-		WRITE_DWORD(dest + 0x8, bps);
-		WRITE_DWORD(dest + 0xc, free);
-		WRITE_DWORD(dest + 0x10, tot);
-		WRITE_DWORD(dest + 0x14, free * spc);
-		WRITE_DWORD(dest + 0x18, tot * spc);
-		WRITE_DWORD(dest + 0x1c, free);
-		WRITE_DWORD(dest + 0x20, tot);
-		return 1;
 	}
 	/* else _AH == 0x71 */
 	switch (_AL) {
@@ -1339,4 +1315,58 @@ int mfs_lfn(void)
 	if (ret == 0 && carry)
 		CARRY;
 	return ret;
+}
+
+/*
+ * This is called before DOS gets a chance to call its own implementation. It
+ * is necessary to do this so we can be sure that our own function is called
+ * even if the DOS does provide FAT32 support. We need to be very careful
+ * about what functions we shield here. At present only the int21/7303
+ * function is implemented so that we can provide the caller with > 2GB free
+ * space values.
+ */
+int mfs_fat32(void)
+{
+  char *src = MK_FP32(_DS, _DX);
+  unsigned int dest = SEGOFF2LINEAR(_ES, _DI);
+  int carry = isset_CF();
+  char fpath[PATH_MAX];
+  unsigned int spc, bps, free, tot;
+  int drive;
+  struct stat st;
+
+  NOCARRY;
+
+  if (!mfs_enabled)
+    goto donthandle;
+
+  if (_AX != 0x7303)
+    goto donthandle;
+
+  d_printf("LFN: Get disk space (FAT32) '%s'\n", src);
+  drive = build_posix_path(fpath, src, 0);
+  if (drive < 0)
+    goto donthandle;
+
+  if (!find_file(fpath, &st, drive, NULL) || !S_ISDIR(st.st_mode))
+    goto donthandle;
+
+  if (!dos_get_disk_space(fpath, &free, &tot, &spc, &bps))
+    goto donthandle;
+
+  WRITE_DWORD(dest, 0x24);
+  WRITE_DWORD(dest + 0x4, spc);
+  WRITE_DWORD(dest + 0x8, bps);
+  WRITE_DWORD(dest + 0xc, free);
+  WRITE_DWORD(dest + 0x10, tot);
+  WRITE_DWORD(dest + 0x14, free * spc);
+  WRITE_DWORD(dest + 0x18, tot * spc);
+  WRITE_DWORD(dest + 0x1c, free);
+  WRITE_DWORD(dest + 0x20, tot);
+  return 1;
+
+donthandle:
+  if (carry)
+    CARRY;
+  return 0;
 }

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -352,6 +352,7 @@ extern void real_run_int(int);
 #define run_int real_run_int
 extern void mfs_reset(void);
 extern int mfs_redirector(void);
+extern int mfs_fat32(void);
 extern int mfs_lfn(void);
 extern int int10(void);
 extern int int13(void);


### PR DESCRIPTION
This disappeared during the second_revect rework at commit
33da1edecfa9f9450a328f24a8d28f04073e9f01

Allows MS-DOS 7.10 to report > 2GB free space on dir listing of MFS drive
Allows FR-DOS 1.20 to report > 2GB free space on dir listing of MFS drive
Allows NDN to show real free space on all versions of DOS

Fixes #544