### PR TITLE
MFS: Reinstate FAT32 disk space function [#544]

### DIFF
--- a/src/dosext/mfs/lfn.c
+++ b/src/dosext/mfs/lfn.c
@@ -921,30 +921,6 @@ static int mfs_lfn_(void)
 			return 1;
 		}
 		return 1;
-	} else if (_AH == 0x73) {
-		unsigned int spc, bps, free, tot;
-
-		if (_AL != 3) return 0;
-
-		d_printf("LFN: Get disk space %s\n", src);
-		drive = build_posix_path(fpath, src, 0);
-		if (drive < 0)
-			return drive + 2;
-		if (!find_file(fpath, &st, drive, NULL)|| !S_ISDIR(st.st_mode))
-			return lfn_error(PATH_NOT_FOUND);
-		if (!dos_get_disk_space(fpath, &free, &tot, &spc, &bps))
-			return lfn_error(PATH_NOT_FOUND);
-
-		WRITE_DWORD(dest, 0x24);
-		WRITE_DWORD(dest + 0x4, spc);
-		WRITE_DWORD(dest + 0x8, bps);
-		WRITE_DWORD(dest + 0xc, free);
-		WRITE_DWORD(dest + 0x10, tot);
-		WRITE_DWORD(dest + 0x14, free * spc);
-		WRITE_DWORD(dest + 0x18, tot * spc);
-		WRITE_DWORD(dest + 0x1c, free);
-		WRITE_DWORD(dest + 0x20, tot);
-		return 1;
 	}
 	/* else _AH == 0x71 */
 	switch (_AL) {

--- a/src/dosext/mfs/mfs.h
+++ b/src/dosext/mfs/mfs.h
@@ -356,8 +356,6 @@ extern void get_volume_label(char *fname, char *fext, char *lfn, int drive);
 extern int dos_rename(const char *filename1, const char *filename2, int drive, int lfn);
 extern int dos_mkdir(const char *filename, int drive, int lfn);
 extern int dos_rmdir(const char *filename, int drive, int lfn);
-extern int dos_get_disk_space(const char *cwd, unsigned int *free, unsigned int *total,
-			      unsigned int *spc, unsigned int *bps);
 extern char *sft_to_filename(const unsigned char *sft, int *fd);
 
 extern void register_cdrom(int drive, int device);

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -352,6 +352,7 @@ extern void real_run_int(int);
 #define run_int real_run_int
 extern void mfs_reset(void);
 extern int mfs_redirector(void);
+extern int mfs_fat32(void);
 extern int mfs_lfn(void);
 extern int int10(void);
 extern int int13(void);


### PR DESCRIPTION
This is mostly working(all FreeDOS and MS-DOS 7.1 work with native 0x7303, MS-DOS 6.22 works with dosemu 0x7303 implementation), but I have problems on PC-DOS 7.1 and MS-DOS 7.0. See the log

PC-DOS 7.1
~~~
C:\>dir
 
 Volume in drive C is ir/dXXXXs/c
 Directory of C:\
 
AUTOEXEC BAT            76  12-21-17  5:52p
IBMBIO   COM        44,656  06-28-05 11:03p
VERSION  BAT            14  12-21-17  5:52p
IBMDOS   COM        42,566  06-28-05 11:03p
LFNVINFO EXE       180,527  12-21-17  5:52p
CONFIG   SYS            43  12-21-17  5:52p
TEST_MFS BAT            26  12-21-17  5:52p
LFNVINFO C             708  12-21-17  5:52p
COMMAND  COM        53,802  06-28-05 11:02p
DOSEMU         <DIR>        12-21-17  3:52p
        10 file(s)        322,418 bytes
~~~

~~~
int 0x21, ax=0x7303                                                             
int 0xe6, ax=0x2142                                                             
int_rvc 0x21 setup                                                              
int 0x21, ax=0x7303                                                             
int 0xe6, ax=0x2f42                                                             
INT2F at fc00:01e9: AX=110c, BX=0000, CX=002c, DX=3a03, DS=0125, ES=0f11        
MFS: Entering dos_fs_redirect, FN=0C                                            
MFS: selecting drive fn=c sda_cds=0xb22eb1c0                                    
MFS: no drive selected fn=c                                                     
int 0x2f, ax=0x110c                                                             
int 0xe6, ax=0x2142                                                             
int_rvc 0x21, doing second revect call                                          
int_rvc 0x21 call for ax=0x000f 7303                                            
int 0x21, ax=0x3600                                                             
int 0xe6, ax=0x2142                                                             
INT21 (0) at fc00:01e9: AX=3600, BX=0000, CX=000f, DX=0000, DS=9556, ES=9556    
int 0x21, ax=0x3600                                                             
int 0xe6, ax=0x2f42                                                             
INT2F at fc00:01e9: AX=110c, BX=0000, CX=000f, DX=0000, DS=0125, ES=0f11        
MFS: Entering dos_fs_redirect, FN=0C                                            
MFS: selecting drive fn=c sda_cds=0xb22eb1c0                                    
MFS: no drive selected fn=c                                                     
int 0x2f, ax=0x110c                                                             
~~~

Seems like something wrong with the second revect code I added?
