### PR TITLE
Disable the '.note.gnu.build-id' ELF note section explicitly.

### DIFF
--- a/src/env/commands/Makefile
+++ b/src/env/commands/Makefile
@@ -41,10 +41,10 @@ all: $(COM2) $(SYS)
 $(COM2) $(SYS): | $(top_builddir)/commands
 
 %.sys.elf: %.o
-	$(LD) $(AS_LDFLAGS) -static -Wl,--section-start=.text=0,-e,_start16 -nostdlib -o $@ $<
+	$(LD) $(AS_LDFLAGS) -static -Wl,--section-start=.text=0,-e,_start16,--build-id=none -nostdlib -o $@ $<
 
 %.com.elf: %.o
-	$(LD) $(AS_LDFLAGS) -static -Wl,--section-start=.text=0x100,-e,_start16 -nostdlib -o $@ $<
+	$(LD) $(AS_LDFLAGS) -static -Wl,--section-start=.text=0x100,-e,_start16,--build-id=none -nostdlib -o $@ $<
 
 $(D)/%: %.elf
 	objcopy -j .text -O binary $< $@


### PR DESCRIPTION
Some distributions (e.g. Debian 9.3) enable this by default, and
it messes up ems.sys and co because the origin is effectively changed
to 0x24 instead of 0. This may need a configure check too if
some supported ld's do not support --build-id=none.