### PR TITLE
Kvm dpmi4

### DIFF
--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -48,6 +48,14 @@
 
 # $_cpu_vm = "auto"
 
+# Select cpu virtualization mode for DPMI.
+# "native" - use native LDT via modify_ldt() syscall.
+# "kvm" - use KVM, hardware-assisted in-kernel virtual machine.
+# "emulated" - use CPU emulator
+# "auto" - select whatever works
+
+# $_cpu_vm_dpmi = "auto"
+
 # if possible use Pentium cycle counter for timing. Default: off
 
 # $_rdtsc = (off)

--- a/etc/global.conf
+++ b/etc/global.conf
@@ -149,8 +149,8 @@ else
     checkuservar $_debug, $_trace_ports,
       $_features, $_mapping, $_hogthreshold, $_cli_timeout,
       $_timemode,
-      $_mathco, $_cpu, $_cpu_vm, $_cpu_emu, $_rdtsc, $_cpuspeed, $_xms, $_ems,
-      $_ems_frame, $_ems_uma_pages, $_ems_conv_pages,
+      $_mathco, $_cpu, $_cpu_vm, $_cpu_vm_dpmi, $_cpu_emu, $_rdtsc, $_cpuspeed,
+      $_xms, $_ems, $_ems_frame, $_ems_uma_pages, $_ems_conv_pages,
       $_ext_mem, $_dpmi, $_dpmi_lin_rsv_base, $_ignore_djgpp_null_derefs,
       $_dpmi_lin_rsv_size, $_emusys,
       $_dosmem, $_full_file_locks, $_lfn_support
@@ -220,6 +220,8 @@ else
     cpuemu off
   endif
   $xxx = "cpu_vm ", $_cpu_vm;
+  $$xxx
+  $xxx = "cpu_vm_dpmi ", $_cpu_vm_dpmi;
   $$xxx
   $_pm_dos_api = $_ems;		# disabling EMS disables also the translator
   if ($_ems || ($_dpmi && $_pm_dos_api))

--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -195,7 +195,10 @@ void *alias_mapping_high(int cap, size_t mapsize, int protect, void *source)
   }
 #endif
 
-  return mappingdriver->alias(cap, target, mapsize, protect, source);
+  target = mappingdriver->alias(cap, target, mapsize, protect, source);
+  if (config.cpu_vm_dpmi == CPUVM_KVM)
+    mmap_kvm(cap, target, mapsize, protect);
+  return target;
 }
 
 int alias_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect, void *source)

--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -218,7 +218,7 @@ int alias_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect, void *so
   if (targ != (dosaddr_t)-1)
     update_aliasmap(targ, mapsize, source);
   if (config.cpu_vm == CPUVM_KVM)
-    mprotect_kvm(addr, mapsize, protect);
+    mprotect_kvm(cap, targ, mapsize, protect);
   Q__printf("MAPPING: %s alias created at %p\n", cap, addr);
 
   return 0;
@@ -311,7 +311,8 @@ static void *do_mmap_mapping(int cap, void *target, size_t mapsize, int protect)
   }
   if (target == (void *)-1) target = NULL;
 #ifdef __x86_64__
-  if (flags == 0 && (cap & (MAPPING_DPMI|MAPPING_VGAEMU|MAPPING_INIT_LOWRAM)))
+  if (flags == 0 &&
+      (cap & (MAPPING_DPMI|MAPPING_VGAEMU|MAPPING_INIT_LOWRAM|MAPPING_KVM)))
     flags = MAP_32BIT;
 #endif
   addr = mmap(target, mapsize, protect,
@@ -322,6 +323,10 @@ static void *do_mmap_mapping(int cap, void *target, size_t mapsize, int protect)
     munmap(addr, mapsize);
     return MAP_FAILED;
   }
+
+  if (config.cpu_vm == CPUVM_KVM)
+    /* Map guest memory in KVM */
+    mmap_kvm(cap, addr, mapsize, protect);
 
   return addr;
 }
@@ -353,8 +358,6 @@ void *mmap_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect)
   if (targ != (dosaddr_t)-1)
     update_aliasmap(targ, mapsize, addr);
   Q__printf("MAPPING: map success, cap=%s, addr=%p\n", cap, addr);
-  if (config.cpu_vm == CPUVM_KVM)
-    mprotect_kvm(addr, mapsize, protect);
   return addr;
 }
 
@@ -378,7 +381,7 @@ int mprotect_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect)
        - if permissions are insufficient, reflect the fault back to the guest)
   */
   if (config.cpu_vm == CPUVM_KVM)
-    mprotect_kvm(addr, mapsize, protect);
+    mprotect_kvm(cap, targ, mapsize, protect);
   ret = mprotect(addr, mapsize, protect);
   if (ret)
     error("mprotect() failed: %s\n", strerror(errno));
@@ -457,6 +460,7 @@ char *decode_mapping_cap(int cap)
     if (cap & MAPPING_INIT_HWRAM) p += sprintf(p, " INIT_HWRAM");
     if (cap & MAPPING_INIT_LOWRAM) p += sprintf(p, " INIT_LOWRAM");
     if (cap & MAPPING_EXTMEM) p += sprintf(p, " EXTMEM");
+    if (cap & MAPPING_KVM) p += sprintf(p, " KVM");
   }
   if (cap & MAPPING_KMEM) p += sprintf(p, " KMEM");
   if (cap & MAPPING_LOWMEM) p += sprintf(p, " LOWMEM");

--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -196,7 +196,7 @@ void *alias_mapping_high(int cap, size_t mapsize, int protect, void *source)
 #endif
 
   target = mappingdriver->alias(cap, target, mapsize, protect, source);
-  if (config.cpu_vm_dpmi == CPUVM_KVM)
+  if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
     mmap_kvm(cap, target, mapsize, protect);
   return target;
 }
@@ -220,7 +220,7 @@ int alias_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect, void *so
     return -1;
   if (targ != (dosaddr_t)-1)
     update_aliasmap(targ, mapsize, source);
-  if (config.cpu_vm == CPUVM_KVM)
+  if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
     mprotect_kvm(cap, targ, mapsize, protect);
   Q__printf("MAPPING: %s alias created at %p\n", cap, addr);
 
@@ -327,7 +327,7 @@ static void *do_mmap_mapping(int cap, void *target, size_t mapsize, int protect)
     return MAP_FAILED;
   }
 
-  if (config.cpu_vm == CPUVM_KVM)
+  if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
     /* Map guest memory in KVM */
     mmap_kvm(cap, addr, mapsize, protect);
 
@@ -383,7 +383,7 @@ int mprotect_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect)
        (gva->gpa or ngpa->gpa)
        - if permissions are insufficient, reflect the fault back to the guest)
   */
-  if (config.cpu_vm == CPUVM_KVM)
+  if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
     mprotect_kvm(cap, targ, mapsize, protect);
   ret = mprotect(addr, mapsize, protect);
   if (ret)

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -1196,7 +1196,7 @@ int vga_emu_protect_page(unsigned page, int prot)
     page < vga.mem.lfb_base_page + vga.mem.pages) {
     unsigned char *p;
     p = &vga.mem.lfb_base[(page - vga.mem.lfb_base_page) << 12];
-    i = mprotect(p, 1 << 12, sys_prot);
+    i = mprotect_mapping(MAPPING_VGAEMU, DOSADDR_REL(p), 1 << 12, sys_prot);
   }
   else {
     i = mprotect_mapping(MAPPING_VGAEMU, page << 12, 1 << 12, sys_prot);
@@ -1406,7 +1406,7 @@ static int vga_emu_map(unsigned mapping, unsigned first_page)
       vmt->base_page << 12, vmt->pages << 12,
       prot, vga.mem.base + (first_page << 12));
   else /* LFB: mapped at init, just need to set protection */
-    i = mprotect(MEM_BASE32(vmt->base_page << 12),
+    i = mprotect_mapping(MAPPING_VGAEMU, vmt->base_page << 12,
 			 vmt->pages << 12, prot);
 
   if(i == -1) {

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -559,6 +559,12 @@ static void config_post_process(void)
 	config.cpuemu = 3;
 	c_printf("CONF: JIT CPUEMU set to 3 for %d86\n", (int)vm86s.cpu_type);
     }
+    if (config.cpu_vm_dpmi != CPUVM_EMU) {
+      if (config.cpuemu > 3 && config.cpu_vm_dpmi != -1) config.cpuemu = 3;
+    } else if (config.cpuemu < 4) {
+	config.cpuemu = 4;
+	c_printf("CONF: JIT CPUEMU set to 4 for %d86\n", (int)vm86s.cpu_type);
+    }
     if (config.rdtsc) {
 	if (config.smp) {
 		c_printf("CONF: Denying use of pentium timer on SMP machine\n");

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -388,7 +388,7 @@ void low_mem_init(void)
   }
 
   mem_base = mem_reserve(&base2, &dpmi_base);
-  if (config.cpu_vm == CPUVM_KVM)
+  if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
     init_kvm_monitor();
   result = alias_mapping(MAPPING_INIT_LOWRAM, 0, LOWMEM_SIZE + HMASIZE,
 			 PROT_READ | PROT_WRITE | PROT_EXEC, lowmem);

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -388,6 +388,8 @@ void low_mem_init(void)
   }
 
   mem_base = mem_reserve(&base2, &dpmi_base);
+  if (config.cpu_vm == CPUVM_KVM)
+    init_kvm_monitor();
   result = alias_mapping(MAPPING_INIT_LOWRAM, 0, LOWMEM_SIZE + HMASIZE,
 			 PROT_READ | PROT_WRITE | PROT_EXEC, lowmem);
   if (result == -1) {
@@ -396,9 +398,6 @@ void low_mem_init(void)
   }
   c_printf("Conventional memory mapped from %p to %p\n", lowmem, mem_base);
   dpmi_set_mem_bases(base2, dpmi_base);
-
-  if (config.cpu_vm == CPUVM_KVM)
-    init_kvm_monitor();
 
   /* keep conventional memory protected as long as possible to protect
      NULL pointer dereferences */

--- a/src/base/init/lexer.l
+++ b/src/base/init/lexer.l
@@ -419,6 +419,7 @@ vm86sim			RETURN(VM86SIM);
 fullsim			RETURN(FULLSIM);
 
 cpu_vm			RETURN(CPU_VM);
+cpu_vm_dpmi		RETURN(CPU_VM_DPMI);
 kvm			RETURN(KVM);
 
 	/* disk keywords */

--- a/src/base/init/parser.y
+++ b/src/base/init/parser.y
@@ -274,7 +274,7 @@ static void set_external_charset(char *charset_name);
 	/* speaker */
 %token EMULATED NATIVE
 	/* cpuemu */
-%token CPUEMU CPU_VM VM86 FULL VM86SIM FULLSIM KVM
+%token CPUEMU CPU_VM CPU_VM_DPMI VM86 FULL VM86SIM FULLSIM KVM
 	/* keyboard */
 %token RAWKEYBOARD
 %token PRESTROKE
@@ -340,7 +340,7 @@ static void set_external_charset(char *charset_name);
 	/* %expect 1 */
 
 %type <i_value> int_bool irq_bool bool speaker floppy_bool cpuemu
-%type <i_value> cpu_vm
+%type <i_value> cpu_vm cpu_vm_dpmi
 
 	/* special bison declaration */
 %token <i_value> UNICODE
@@ -493,6 +493,12 @@ line:		CHARSET '{' charset_flags '}' {}
 			{
 			config.cpu_vm = $2;
 			c_printf("CONF: CPU VM set to %d\n", config.cpu_vm);
+			}
+		| CPU_VM_DPMI cpu_vm_dpmi
+			{
+			config.cpu_vm_dpmi = $2;
+			c_printf("CONF: CPU VM set to %d for DPMI\n",
+				 config.cpu_vm_dpmi);
 			}
 		| CPUEMU cpuemu
 			{
@@ -1805,6 +1811,14 @@ cpu_vm		: L_AUTO	{ $$ = -1; }
 				  free($1); }
 		| error         { yyerror("bad value for cpu_vm"); }
 		;
+
+cpu_vm_dpmi	: L_AUTO	{ $$ = -1; }
+		| NATIVE	{ $$ = CPUVM_NATIVE; }
+		| KVM		{ $$ = CPUVM_KVM; }
+		| EMULATED	{ $$ = CPUVM_EMU; }
+		| STRING        { yyerror("got '%s' for cpu_vm_dpmi", $1);
+				  free($1); }
+		| error         { yyerror("bad value for cpu_vm_dpmi"); }
 
 charset_flags	: charset_flag
 		| charset_flags charset_flag

--- a/src/dosext/dpmi/dpmi.h
+++ b/src/dosext/dpmi/dpmi.h
@@ -138,6 +138,7 @@ extern unsigned long dpmi_total_memory; /* total memory  of this session */
 extern unsigned long dpmi_free_memory; /* how many bytes memory client */
 				       /* can allocate */
 extern unsigned long pm_block_handle_used;       /* tracking handle */
+extern unsigned char *ldt_buffer;
 
 void dpmi_get_entry_point(void);
 #ifdef __x86_64__

--- a/src/dosext/dpmi/memory.c
+++ b/src/dosext/dpmi/memory.c
@@ -128,7 +128,7 @@ dpmi_pm_block *lookup_pm_block_by_addr(dpmi_pm_block_root *root,
 
 static int commit(void *ptr, size_t size)
 {
-  if (mprotect(ptr, size,
+  if (mprotect_mapping(MAPPING_DPMI, DOSADDR_REL(ptr), size,
 	PROT_READ | PROT_WRITE | PROT_EXEC) == -1)
     return 0;
   return 1;
@@ -238,7 +238,7 @@ static int SetAttribsForPage(unsigned int ptr, us attr, us old_attr)
 
     if (change) {
       if (com) {
-        if (mprotect(MEM_BASE32(ptr), PAGE_SIZE, prot) == -1) {
+        if (mprotect_mapping(MAPPING_DPMI, ptr, PAGE_SIZE, prot) == -1) {
           D_printf("mprotect() failed: %s\n", strerror(errno));
           return 0;
         }
@@ -417,7 +417,7 @@ dpmi_pm_block * DPMI_realloc(dpmi_pm_block_root *root,
     }
 
     /* realloc needs full access to the old block */
-    mprotect(MEM_BASE32(block->base), block->size,
+    mprotect_mapping(MAPPING_DPMI, block->base, block->size,
         PROT_READ | PROT_WRITE | PROT_EXEC);
     if (!(ptr = smrealloc(&mem_pool, MEM_BASE32(block->base), newsize)))
 	return NULL;
@@ -459,7 +459,7 @@ dpmi_pm_block * DPMI_reallocLinear(dpmi_pm_block_root *root,
     * We have to make sure the whole region have the same protection, so that
     * it can be merged into a single VMA. Otherwise mremap() will fail!
     */
-    mprotect(MEM_BASE32(block->base), block->size,
+    mprotect_mapping(MAPPING_DPMI, block->base, block->size,
       PROT_READ | PROT_WRITE | PROT_EXEC);
     ptr = mremap(MEM_BASE32(block->base), block->size, newsize,
       MREMAP_MAYMOVE);

--- a/src/emu-i386/cpu.c
+++ b/src/emu-i386/cpu.c
@@ -331,6 +331,13 @@ void cpu_setup(void)
 	;
   }
 
+  if (config.cpu_vm_dpmi == -1) {
+    if (config.cpuemu > 3)
+      config.cpu_vm_dpmi = CPUVM_EMU;
+    else
+      config.cpu_vm_dpmi = CPUVM_NATIVE;
+  }
+
   if (config.cpu_vm == CPUVM_KVM && !init_kvm_cpu()) {
     if (orig_cpu_vm == -1) {
       warn("KVM not available: %s\n", strerror(errno));

--- a/src/emu-i386/cpu.c
+++ b/src/emu-i386/cpu.c
@@ -296,7 +296,6 @@ void cpu_setup(void)
 {
   emu_iodev_t io_dev;
   int orig_cpu_vm = config.cpu_vm;
-  int orig_cpu_vm_dpmi = config.cpu_vm_dpmi;
   io_dev.read_portb = fpu_io_read;
   io_dev.write_portb = fpu_io_write;
   io_dev.read_portw = NULL;
@@ -330,25 +329,6 @@ void cpu_setup(void)
 	CPUVM_VM86
 #endif
 	;
-  }
-
-  if (config.cpu_vm_dpmi == -1) {
-    if (config.cpuemu > 3)
-      config.cpu_vm_dpmi = CPUVM_EMU;
-    else
-      config.cpu_vm_dpmi = CPUVM_NATIVE;
-  }
-
-  if (config.cpu_vm_dpmi == CPUVM_NATIVE) {
-    unsigned char buf[LDT_ENTRY_SIZE];
-    if (modify_ldt(0, buf, LDT_ENTRY_SIZE) != 0)
-    {
-      if (orig_cpu_vm_dpmi == -1)
-        warn("modify_ldt service not available in your kernel, %s\n", strerror(errno));
-      else
-        error("modify_ldt service not available in your kernel, %s\n", strerror(errno));
-      config.cpu_vm_dpmi = CPUVM_KVM;
-    }
   }
 
   if ((config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM) &&

--- a/src/emu-i386/kvm.c
+++ b/src/emu-i386/kvm.c
@@ -260,7 +260,10 @@ void init_kvm_monitor(void)
     leavedos(99);
   }
 
-  warn("Using V86 mode inside KVM\n");
+  if (config.cpu_vm == CPUVM_KVM)
+    warn("Using V86 mode inside KVM\n");
+  if (config.cpu_vm_dpmi == CPUVM_KVM)
+    warn("Using DPMI inside KVM\n");
 }
 
 /* Initialize KVM and memory mappings */
@@ -714,7 +717,6 @@ int kvm_dpmi(sigcontext_t *scp)
     regs->eflags &= (SAFE_MASK | X86_EFLAGS_VIF | X86_EFLAGS_VIP);
     regs->eflags |= X86_EFLAGS_FIXED | X86_EFLAGS_IF;
 
-    D_printf("cs=%x, ds=%x\n", _cs, _ds);
     kvm_run(regs);
 
     /* orig_eax >> 16 = exception number */

--- a/src/emu-i386/kvmmon.S
+++ b/src/emu-i386/kvmmon.S
@@ -43,7 +43,10 @@ kvm_mon_start:
         .endr
 
 kvm_mon_main:
-        sub $0x10,%esp
+        push %gs
+        push %fs
+        push %es
+        push %ds
         push %eax
         push %ebp
         push %edi
@@ -64,7 +67,11 @@ kvm_mon_hlt:
         pop %edi
         pop %ebp
         pop %eax
-        add $0x14,%esp
+        pop %ds
+        pop %es
+        pop %fs
+        pop %gs
+        add $0x4,%esp
         iret
 
 	.globl kvm_mon_end

--- a/src/emu-i386/kvmmon.S
+++ b/src/emu-i386/kvmmon.S
@@ -36,14 +36,14 @@ kvm_mon_start:
         /* push fake error code for consistent stack */
         pushl $0
         .endif
-        pushl $i
+        movw $i,2(%esp)
         jmp kvm_mon_main
         i = i + 1
-        .fill kvm_mon_start+10*i-., 1, 0x90
+        .fill kvm_mon_start+16*i-., 1, 0x90
         .endr
 
 kvm_mon_main:
-        sub $0xc,%esp
+        sub $0x10,%esp
         push %eax
         push %ebp
         push %edi

--- a/src/emu.c
+++ b/src/emu.c
@@ -97,6 +97,7 @@
 #ifdef X86_EMULATOR
 #include "cpu-emu.h"
 #endif
+#include "kvm.h"
 
 static int ld_tid;
 static int can_leavedos;
@@ -399,7 +400,9 @@ int main(int argc, char **argv)
 #endif
     timer_interrupt_init();	/* start sending int 8h int signals */
 
-    /* unprotect conventional memory just before booting */
+    /* map KVM memory and unprotect conventional memory just before booting */
+    if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
+      set_kvm_memory_regions();
     mprotect_mapping(MAPPING_LOWMEM, 0, config.mem_size * 1024,
 		     PROT_READ | PROT_WRITE | PROT_EXEC);
 

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -152,6 +152,7 @@ typedef struct config_info {
        boolean cpusim;
 #endif
        int cpu_vm;
+       int cpu_vm_dpmi;
        int CPUSpeedInMhz;
        /* for video */
        int console_video;
@@ -329,7 +330,7 @@ typedef struct config_info {
 
 
 enum { SPKR_OFF, SPKR_NATIVE, SPKR_EMULATED };
-enum { CPUVM_VM86, CPUVM_KVM, CPUVM_EMU };
+enum { CPUVM_VM86, CPUVM_KVM, CPUVM_EMU, CPUVM_NATIVE };
 
 /*
  * Right now, dosemu only supports two serial ports.

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -26,5 +26,6 @@ int kvm_vm86(struct vm86_struct *info);
 int kvm_dpmi(sigcontext_t *scp);
 void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect);
 void mmap_kvm(int cap, void *addr, size_t mapsize, int protect);
+void set_kvm_memory_regions(void);
 
 #endif

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -23,6 +23,7 @@
 int init_kvm_cpu(void);
 void init_kvm_monitor(void);
 int kvm_vm86(struct vm86_struct *info);
+int kvm_dpmi(sigcontext_t *scp);
 void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect);
 void mmap_kvm(int cap, void *addr, size_t mapsize, int protect);
 

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -23,7 +23,7 @@
 int init_kvm_cpu(void);
 void init_kvm_monitor(void);
 int kvm_vm86(struct vm86_struct *info);
-void mprotect_kvm(void *addr, size_t mapsize, int protect);
-void mmap_kvm(unsigned targ, void *addr, size_t mapsize);
+void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect);
+void mmap_kvm(int cap, void *addr, size_t mapsize, int protect);
 
 #endif

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -42,6 +42,7 @@
 #define MAPPING_INIT_HWRAM	0x000100
 #define MAPPING_INIT_LOWRAM	0x000200
 #define MAPPING_EXTMEM		0x000400
+#define MAPPING_KVM		0x000800
 
 /* usage as: (kind of mapping required) */
 #define MAPPING_KMEM		0x010000


### PR DESCRIPTION
Third try (fourth local) to have a working
$_kvm_mode = "vm86_dpmi"

The interface with dpmi.c is at a different place than before (do_dpmi_control() instead of dpmi_control()) since dpmi_fault no longer calls dpmi_fault1 (which likely broke full and fullsim, i.e. e_dpmi(), as well). It's not necessary to use co_call etc. for KVM. But perhaps the interface between kvm.c and dpmi.c could be cleaned up a bit more.

In any case this works. Tested with DOOM and Duke3D, and compiling FreeCOM with DOS watcom compiler