### PR TITLE
KVM: fix int 3 and int 4 handling: fixes bp in dosdebug.

### DIFF
--- a/src/emu-i386/kvm.c
+++ b/src/emu-i386/kvm.c
@@ -211,8 +211,10 @@ void init_kvm_monitor(void)
     monitor->idt[i].offs_hi = offs >> 16;
     monitor->idt[i].seg = 0x8; // FLAT_CODE_SEL
     monitor->idt[i].type = 0xe;
-    /* DPL must be 0 so that software ints from DPMI clients will GPF */
-    monitor->idt[i].DPL = 0;
+    /* DPL must be 0 so that software ints from DPMI clients will GPF.
+       Exceptions are int3 (BP) and into (OF): matching the Linux kernel
+       they must generate traps 3 and 4, and not GPF */
+    monitor->idt[i].DPL = (i == 3 || i == 4) ? 3 : 0;
     monitor->idt[i].present = 1;
   }
   memcpy(monitor->code, kvm_mon_start, kvm_mon_end - kvm_mon_start);


### PR DESCRIPTION
DPL is set to 0 in most IDT entries so that software interrupts in DPMI
GPF (which matches Linux kernel handling in native mode). However int3
and int4 (and only those) must have DPL 3 as in the Linux kernel so
they generate traps 3 and 4 instead of GPFs for INT3 and INTO instructions.