### PR TITLE
Dpmi kvm streamline

### DIFF
--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -3331,7 +3331,8 @@ void dpmi_init(void)
 
     in_dpmi_irq = 0;
 
-    dpmi_tid = co_create(co_handle, dpmi_thr, NULL, NULL, SIGSTACK_SIZE);
+    if (config.cpu_vm_dpmi == CPUVM_NATIVE)
+      dpmi_tid = co_create(co_handle, dpmi_thr, NULL, NULL, SIGSTACK_SIZE);
   }
 
   dpmi_set_pm(1);

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -4318,9 +4318,6 @@ int dpmi_fault(sigcontext_t *scp)
   }
 
   dpmi_return(scp, -3);		// process the rest in dosemu context
-  if (!in_dpmi_pm())
-    return -1;
-
   /* return value only applies to non-modify_ldt case */
   return -3;
 }

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -509,7 +509,7 @@ static int _dpmi_control(void)
         ret = do_dpmi_control(scp);
       if (debug_level('M') > 5)
         D_printf("DPMI: switch to dosemu\n");
-      if (!ret)
+      if (ret == -3)
         ret = dpmi_fault1(scp);
       if (!in_dpmi && in_dpmi_thr) {
         ret = do_dpmi_exit(scp);
@@ -4317,7 +4317,7 @@ int dpmi_fault(sigcontext_t *scp)
     return 0;
   }
 
-  dpmi_return(scp, 0);		// process the rest in dosemu context
+  dpmi_return(scp, -3);		// process the rest in dosemu context
   if (!in_dpmi_pm())
     return -1;
 

--- a/src/dosext/dpmi/dpmi.h
+++ b/src/dosext/dpmi/dpmi.h
@@ -222,8 +222,9 @@ extern void dpmi_setup(void);
 extern void dpmi_reset(void);
 extern void dpmi_done(void);
 extern int get_ldt(void *buffer);
+void dpmi_return(sigcontext_t *scp, int retcode);
 void dpmi_return_request(void);
-int dpmi_check_return(sigcontext_t *scp);
+int dpmi_check_return(void);
 void dpmi_init(void);
 extern void copy_context(sigcontext_t *d,
     sigcontext_t *s, int copy_fpu);

--- a/src/dosext/dpmi/dpmi.h
+++ b/src/dosext/dpmi/dpmi.h
@@ -132,6 +132,10 @@ struct RSP_s {
   dpmi_pm_block_root *pm_block_root;
 };
 
+enum { DPMI_RET_FAULT=-3, DPMI_RET_EXIT=-2, DPMI_RET_DOSEMU=-1,
+       DPMI_RET_CLIENT=0, DPMI_RET_TRAP_DB=1, DPMI_RET_TRAP_BP=3,
+       DPMI_RET_INT=0x100 };
+
 extern unsigned char dpmi_mhp_intxxtab[256];
 
 extern unsigned long dpmi_total_memory; /* total memory  of this session */

--- a/src/emu-i386/kvm.c
+++ b/src/emu-i386/kvm.c
@@ -762,7 +762,7 @@ int kvm_dpmi(sigcontext_t *scp)
       _trapno = trapno;
       _err = regs->orig_eax & 0xffff;
       if (_trapno == 0x0e && vga_emu_fault(scp, 1) == True)
-	ret = dpmi_check_return(scp);
+	ret = dpmi_check_return();
       else
 	ret = dpmi_fault(scp);
     }

--- a/src/emu-i386/kvm.c
+++ b/src/emu-i386/kvm.c
@@ -767,6 +767,5 @@ int kvm_dpmi(sigcontext_t *scp)
 	ret = dpmi_fault(scp);
     }
   } while (!ret);
-  /* "-3" means to call dpmi_fault1 in dpmi.c:_dpmi_control */
-  return ret == -3 ? 0 : ret;
+  return ret;
 }

--- a/src/emu-i386/kvm.c
+++ b/src/emu-i386/kvm.c
@@ -756,7 +756,7 @@ int kvm_dpmi(sigcontext_t *scp)
 
     _eflags = regs->eflags;
 
-    ret = -1; /* mirroring sigio/sigalrm */
+    ret = DPMI_RET_DOSEMU; /* mirroring sigio/sigalrm */
     if (trapno != 0x20) {
       _cr2 = (uintptr_t)MEM_BASE32(monitor->cr2);
       _trapno = trapno;
@@ -766,6 +766,6 @@ int kvm_dpmi(sigcontext_t *scp)
       else
 	ret = dpmi_fault(scp);
     }
-  } while (!ret);
+  } while (ret == DPMI_RET_CLIENT);
   return ret;
 }

--- a/src/emu-i386/kvm.c
+++ b/src/emu-i386/kvm.c
@@ -363,7 +363,7 @@ void set_kvm_memory_regions(void)
     struct kvm_userspace_memory_region *p = &maps[slot];
     if (p->memory_size != 0) {
       if (config.cpu_vm_dpmi != CPUVM_KVM &&
-	  (void *)p->userspace_addr != monitor) {
+	  (void *)(uintptr_t)p->userspace_addr != monitor) {
 	if (p->guest_phys_addr > LOWMEM_SIZE + HMASIZE)
 	  p->memory_size = 0;
 	else if (p->guest_phys_addr + p->memory_size > LOWMEM_SIZE + HMASIZE)

--- a/src/emu-i386/simx86/cpu-emu.c
+++ b/src/emu-i386/simx86/cpu-emu.c
@@ -1337,9 +1337,9 @@ int e_dpmi(sigcontext_t *scp)
 	if (debug_level('e')) TotalTime += (GETTSC() - tt0);
 	emu_dpmi_retcode = dpmi_fault(scp);
 	if (debug_level('e')) tt0 = GETTSC();
-	if (emu_dpmi_retcode != 0) {
-	    retval=emu_dpmi_retcode; emu_dpmi_retcode = 0;
-	    if (retval == -1)
+	if (emu_dpmi_retcode != DPMI_RET_CLIENT) {
+	    retval=emu_dpmi_retcode; emu_dpmi_retcode = DPMI_RET_CLIENT;
+	    if (retval == DPMI_RET_DOSEMU)
 		retval = 0;
 	}
     }

--- a/src/emu-i386/simx86/cpu-emu.c
+++ b/src/emu-i386/simx86/cpu-emu.c
@@ -1331,7 +1331,7 @@ int e_dpmi(sigcontext_t *scp)
         retval = 0;
     }
     else if (xval == EXCP0E_PAGE && VGA_EMU_FAULT(scp,code,1)==True) {
-	retval = dpmi_check_return(scp);
+	retval = dpmi_check_return();
     } else {
 	int emu_dpmi_retcode;
 	if (debug_level('e')) TotalTime += (GETTSC() - tt0);


### PR DESCRIPTION
I managed to make DPMI+KVM behave more similar to native DPMI with respect to control flow.
This way dpmi_thr() is used in both cases, only signals are not used.

I assumed that it's ok to simply keep the FPU state inside KVM all the time with no explicit save and restore; as far as I can see DOSEMU does not attempt to keep a per-client FPU state. Let me know if I understood that wrongly.