### PR TITLE
Fix cpuemu for DPMI

### DIFF
--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -1023,17 +1023,18 @@ int vga_emu_fault(sigcontext_t *scp, int pmode)
   );
 
   if(pmode) {
-    dosaddr_t daddr = GetSegmentBase(_cs) + _eip;
-    cs_ip = SEL_ADR_CLNT(_cs, _eip, dpmi_segment_is32(_cs));
-    if (debug_level('v') && (
-	  (cs_ip >= &mem_base[0] && cs_ip < &mem_base[0x110000]) ||
-	   dpmi_is_valid_range(daddr, 15)))
+    dosaddr_t daddr;
+    if (debug_level('v') && DPMIValidSelector(_cs) &&
+	  (((daddr = GetSegmentBase(_cs) + _eip) < 0x110000) ||
+	   dpmi_is_valid_range(daddr, 15))) {
+     cs_ip = MEM_BASE32(daddr);
      vga_deb_map(
       "vga_emu_fault: cs:eip = %04x:%04x, instr: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x\n",
       (unsigned) _cs, (unsigned) _eip,
       cs_ip[ 0], cs_ip[ 1], cs_ip[ 2], cs_ip[ 3], cs_ip[ 4], cs_ip[ 5], cs_ip[ 6], cs_ip[ 7],
       cs_ip[ 8], cs_ip[ 9], cs_ip[10], cs_ip[11], cs_ip[12], cs_ip[13], cs_ip[14], cs_ip[15]
     );
+    }
   }
   else {
     cs_ip = SEG_ADR((unsigned char *), cs, ip);

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -504,6 +504,10 @@ static int _dpmi_control(void)
       }
       if (config.cpu_vm_dpmi == CPUVM_KVM)
         ret = kvm_dpmi(scp);
+#ifdef X86_EMULATOR
+      else if (config.cpu_vm_dpmi == CPUVM_EMU)
+        ret = e_dpmi(scp);
+#endif
       else
         ret = do_dpmi_control(scp);
       if (debug_level('M') > 5)
@@ -2970,12 +2974,7 @@ static void run_dpmi_thr(void *arg)
       continue;
     }
 #endif
-    retcode = (
-#ifdef X86_EMULATOR
-	config.cpuemu>3?
-	e_dpmi(&DPMI_CLIENT.stack_frame) :
-#endif
-	dpmi_control());
+    retcode = dpmi_control();
 #ifdef USE_MHPDBG
     if (retcode > DPMI_RET_CLIENT && mhpdbg.active) {
       if ((retcode == DPMI_RET_TRAP_DB) || (retcode == DPMI_RET_TRAP_BP))

--- a/src/emu-i386/simx86/cpu-emu.c
+++ b/src/emu-i386/simx86/cpu-emu.c
@@ -682,10 +682,16 @@ static void Cpu2Scp (sigcontext_t *scp, int trapno)
 #endif
 
   /* rebuild running flags */
-  mask = VIF | eTSSMASK;
-  REG(eflags) = (REG(eflags) & VIP) |
+  if (V86MODE()) {
+    mask = VIF | eTSSMASK;
+    REG(eflags) = (REG(eflags) & VIP) |
   			(eVEFLAGS & mask) | (TheCPU.eflags & ~(mask|VIP));
-  _eflags = REG(eflags) & ~VM;
+    _eflags = REG(eflags) & ~VM;
+  }
+  else {
+    /* push running flags - same as eflags, RF is cosmetic */
+    _eflags = (TheCPU.eflags & (eTSSMASK|0xfd5)) | 0x10002;
+  }
   if (debug_level('e')>1) e_printf("Cpu2Scp< scp=%08x vm86=%08x dpm=%08x fl=%08x vf=%08x\n",
 	_eflags,REG(eflags),get_FLAGS(TheCPU.eflags),TheCPU.eflags,eVEFLAGS);
 }

--- a/src/emu-i386/simx86/cpu-emu.c
+++ b/src/emu-i386/simx86/cpu-emu.c
@@ -1318,33 +1318,27 @@ int e_dpmi(sigcontext_t *scp)
 
     Cpu2Scp (scp, xval-1);
 
-    retval = -1;
+    retval = DPMI_RET_CLIENT;
     E_TIME_STRETCH;
 
     if ((xval==EXCP_SIGNAL) || (xval==EXCP_PICSIGNAL) || (xval==EXCP_STISIGNAL)) {
 	if (debug_level('e')>2) e_printf("DPMI sigpending = %d\n",signal_pending());
 	if (signal_pending()) {
-	    retval=0;
+	    retval = DPMI_RET_DOSEMU;
 	}
     }
     else if (xval==EXCP_GOBACK) {
-        retval = 0;
+        retval = DPMI_RET_DOSEMU;
     }
     else if (xval == EXCP0E_PAGE && VGA_EMU_FAULT(scp,code,1)==True) {
 	retval = dpmi_check_return();
     } else {
-	int emu_dpmi_retcode;
 	if (debug_level('e')) TotalTime += (GETTSC() - tt0);
-	emu_dpmi_retcode = dpmi_fault(scp);
+	retval = dpmi_fault(scp);
 	if (debug_level('e')) tt0 = GETTSC();
-	if (emu_dpmi_retcode != DPMI_RET_CLIENT) {
-	    retval=emu_dpmi_retcode; emu_dpmi_retcode = DPMI_RET_CLIENT;
-	    if (retval == DPMI_RET_DOSEMU)
-		retval = 0;
-	}
     }
   }
-  while (retval < 0);
+  while (retval == DPMI_RET_CLIENT);
   /* ------ OUTER LOOP -- exit to user level ---------------------- */
 
   LastXNode = NULL;


### PR DESCRIPTION
These are minimal patches to fix $_cpu_emu="full" and "fullsim" (or the newer $_cpu_vm_dpmi = "emulated" -- a patch to cleanup the old syntax will come later).
