### PR TITLE
Cleanup vm86_fault: pass trapno/err/cr2 instead of scp.

### DIFF
--- a/src/arch/linux/async/sigsegv.c
+++ b/src/arch/linux/async/sigsegv.c
@@ -104,7 +104,7 @@ static void dosemu_fault1(int signal, sigcontext_t *scp)
     /* cpu-emu may decide to call vm86_fault() later */
     if (!CONFIG_CPUSIM && config.cpuemu > 1 && e_handle_fault(scp))
       return;
-    vm86_fault(scp);
+    vm86_fault(_trapno, _err, DOSADDR_REL(LINP(_cr2)));
     return;
   }
 

--- a/src/emu-i386/kvm.c
+++ b/src/emu-i386/kvm.c
@@ -693,7 +693,7 @@ int kvm_vm86(struct vm86_struct *info)
     _err = regs->orig_eax & 0xffff;
     if (_trapno == 0x0e && VGA_EMU_FAULT(scp, code, 0) == True)
       return vm86_ret;
-    vm86_fault(scp);
+    vm86_fault(_trapno, _err, monitor->cr2);
   }
   return vm86_ret;
 }

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -28,7 +28,7 @@ struct eflags_fs_gs {
 extern struct eflags_fs_gs eflags_fs_gs;
 
 int vm86_init(void);
-int vm86_fault(sigcontext_t *scp);
+int vm86_fault(unsigned trapno, unsigned err, dosaddr_t cr2);
 
 #define BIT(x)  	(1<<x)
 


### PR DESCRIPTION
vm86_fault does not use most scp fields, but the vm86 registers instead.
Make this explicit by only passing those fields, and removing
unneeded code around vm86_fault, and disabled code inside vm86_fault
that uses scp. Make the cr2 passed to vm86_fault relative to mem_base.