### PR TITLE
cpuemu bug fixes

### DIFF
--- a/src/emu-i386/simx86/codegen-x86.c
+++ b/src/emu-i386/simx86/codegen-x86.c
@@ -2870,6 +2870,7 @@ static void _nodelinker2(TNode *LG, TNode *G)
 			    G,G->key,G->addr,
 			    ra, L->t_undo, T->nrefs, L->t_ref, *L->t_ref);
 		    }
+		    LG->flags |= G->flags;
 		    if (debug_level('e')>8) { backref *bk = T->bkr.next;
 #ifdef DEBUG_LINKER
 			if (bk==NULL) { dbug_printf("bkr null\n"); leavedos_main(0x8108); }
@@ -2925,6 +2926,7 @@ static void _nodelinker2(TNode *LG, TNode *G)
 				G,G->key,G->addr,
 				ra, L->nt_undo, T->nrefs, L->nt_ref, *L->nt_ref);
 			}
+			LG->flags |= G->flags;
 			if (debug_level('e')>8) { backref *bk = T->bkr.next;
 #ifdef DEBUG_LINKER
 			    if (bk==NULL) { dbug_printf("bkr null\n"); leavedos_main(0x8109); }

--- a/src/emu-i386/simx86/fp87-sim.c
+++ b/src/emu-i386/simx86/fp87-sim.c
@@ -120,7 +120,7 @@ static inline void round_double(void)
 	case 0x000: WFR0 = rintl(WFR0); break;
 	case 0x400: WFR0 = floorl(WFR0); break;
 	case 0x800: WFR0 = ceill(WFR0); break;
-	default:    WFR0 = floorl(WFR0); if (WFR0<0) WFR0++; break;
+	default:    WFR0 = truncl(WFR0); break;
 	}
 }
 

--- a/src/emu-i386/simx86/interp.c
+++ b/src/emu-i386/simx86/interp.c
@@ -594,8 +594,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    /* virtual-8086 monitor */
 			    temp = EFLAGS & 0xdff;
 			    if (eVEFLAGS & VIF) temp |= EFLAGS_IF;
-			    temp |= (((IOPL_MASK|eVEFLAGS) & (eTSSMASK|VIF)) |
-				(vm86s.regs.eflags&VIP));  // this one FYI
+			    temp |= (IOPL_MASK|eVEFLAGS) & eTSSMASK;
 			    PUSH(mode, &temp);
 			    if (debug_level('e')>1)
 				e_printf("Pushed flags %08x fl=%08x vf=%08x\n",


### PR DESCRIPTION
These make the output of the QEMU tests in src/tests identical for JIT, sim, KVM and native, and prepare for on-demand FP state saving.