### PR TITLE
Mimic boot blk improvements

### DIFF
--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -1641,6 +1641,10 @@ void mimic_boot_blk(void)
       SREG(es)  = loadaddress >> 4;
       SREG(ss)  = 0x1FE0;
       LWORD(esp) = 0x7c00;  /* temp stack */
+      LWORD(ebp) = 0x7C00;
+
+      /* load boot sector to stack */
+      read_boot(f, LINEAR2UNIX(SEGOFF2LINEAR(0x1FE0, 0x7C00)));
 
 #ifdef USE_FDPP
       void *handle = load_plugin("fdpp");

--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -1646,6 +1646,12 @@ void mimic_boot_blk(void)
       /* load boot sector to stack */
       read_boot(f, LINEAR2UNIX(SEGOFF2LINEAR(0x1FE0, 0x7C00)));
 
+      if ( (loadaddress + size) > SEGOFF2LINEAR(0x1FE0, 0x7C00 - 8192) ) {
+	/* loadaddress + size -> after end of load, -8192: stack reservation */
+	error("too large DOS system file %s\n", f->obj[1].full_name);
+	leavedos(99);
+      }
+
 #ifdef USE_FDPP
       void *handle = load_plugin("fdpp");
       if (handle)


### PR DESCRIPTION
**fatfs.c: load boot sector to 1FE0h:7C00h for loading FreeDOS kernel**

When booting, the boot sector is loaded to 0:7C00h, which is
overwritten by a FreeDOS KERNEL.SYS (that is fully loaded
starting at 60h:0). Original FreeDOS boot sector loaders cope
with this by relocating to 1FE0h:7C00h, allowing the kernel to
grow to below 1FE00h+7C00h-600h = 27400h (ca. 156 KiB).

The BPB is still pointed to by ss:bp when passing control to
the kernel's entry point. This allows users of this boot load
protocol to learn what unit and what partition they're booted
from. The current FreeDOS kernel does not utilise this yet,
only noting the boot unit as passed in bl.
    
Similarly as for the case MOS_D, this commit loads the boot
sector to the relocated position to provide it to the loaded
kernel. This allows to load kernels which expect the boot
sector with BPB there.

Refer to https://github.com/stsp/dosemu2/issues/581


**fatfs.c: check file size of FreeDOS kernel to load**
    
As the boot sector with BPB is located at 1FE0h:7C00h,
the kernel must be smaller than 1FE00h+7C00h-600h
= 27400h (ca. 156 KiB), to avoid overwriting the BPB.
(The BPB can be located elsewhere, and its actual
address is passed to the kernel in ss:bp, but we use
the default address as implemented by their loaders.)

This commit makes the handler check for the load address
plus size being below 1FE0h:7C00h - 8192, where the -8192
is a stack reservation to insure the stack doesn't overwrite
the end of the kernel. A file larger than this is rejected.

This is equivalent to the check I added to grub2's FreeDOS
direct loading support, which implements the FreeDOS load
protocol too.
Refer to http://git.savannah.gnu.org/cgit/grub.git/commit/?id=08bcec502084e322318ecad1bc4c04d3ddc10d32
    
The original FreeDOS boot sectors do not check the size of
the kernel they're loading, but this must be so only because
there is no space in a boot sector to check for that. Refer
to https://github.com/PerditionC/fdkernel/tree/master/boot


**fatfs.c: pass boot load unit to FreeDOS kernel in dl as well**

This possibly improves compatibility with EDR-DOS kernels,
it's not entirely clear. In any case, it does no harm.