### PR TITLE
fpstate-related cleanups and speedups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -160,8 +160,6 @@ AC_CHECK_LIB(pthread, pthread_create,,[
 )
 AC_CHECK_FUNCS([pthread_getname_np pthread_setname_np])
 
-AC_CHECK_TYPES([struct _libc_fpstate, struct _fpstate],,, [[#include <ucontext.h>]])
-
 dnl Check for the XKB extension to get reliable keyboard handling
 AC_CHECK_HEADER(X11/XKBlib.h, AC_DEFINE(HAVE_XKB,1))
 AC_CHECK_HEADERS([netipx/ipx.h linux/ipx.h])

--- a/src/arch/linux/async/sigsegv.c
+++ b/src/arch/linux/async/sigsegv.c
@@ -447,15 +447,13 @@ void print_exception_info(sigcontext_t *scp)
    case 0x10: {
       int i, n;
       unsigned short sw;
-#ifdef __x86_64__
-      fpregset_t p = ((mcontext_t *)scp)->fpregs;
+      fpregset_t p = __fpstate;
       error ("@Coprocessor Error:\n");
+#ifdef __x86_64__
       error ("@cwd=%04x swd=%04x ftw=%04x\n", p->cwd, p->swd, p->ftw);
       error ("@cs:rip=%04x:%08lx ds:data=%04x:%08lx\n",	_cs,p->rip,_ds,p->rdp);
       sw = p->swd;
 #else
-      ___fpstate *p = __fpstate;
-      error ("@Coprocessor Error:\n");
       error ("@cw=%04x sw=%04x tag=%04x\n",
 	     ((unsigned short)(p->cw)),((unsigned short)(p->sw)),
 	((unsigned short)(p->tag)));
@@ -487,15 +485,12 @@ void print_exception_info(sigcontext_t *scp)
    case 0x13: {
       int i;
       unsigned mxcsr;
-#ifdef __x86_64__
-      fpregset_t p = ((mcontext_t *)scp)->fpregs;
+      fpregset_t p = __fpstate;
       error ("@SIMD Floating-Point Exception:\n");
       mxcsr = p->mxcsr;
+#ifdef __x86_64__
       error ("@mxcsr=%08x, mxcr_mask=%08x\n",mxcsr,(unsigned)(p->mxcr_mask));
 #else
-      struct _fpstate *p = scp->fpstate;
-      error ("@SIMD Floating-Point Exception:\n");
-      mxcsr = p->mxcsr;
       error ("@mxcsr=%08x\n",mxcsr);
 #endif
       if (mxcsr&0x40) error("@Denormals are zero\n");

--- a/src/emu-i386/cpu.c
+++ b/src/emu-i386/cpu.c
@@ -94,7 +94,7 @@ static unsigned int TRs[2] =
 #endif
 
 /* fpu_state needs to be paragraph aligned for fxrstor/fxsave */
-___fpstate *vm86_fpu_state;
+fpregset_t vm86_fpu_state;
 fenv_t dosemu_fenv;
 
 /*

--- a/src/emu-i386/simx86/codegen-x86.c
+++ b/src/emu-i386/simx86/codegen-x86.c
@@ -3214,6 +3214,10 @@ unsigned int Exec_x86(TNode *G, int ln)
 	fprintf(aLog,"%p: exec\n",G->key);
 #endif
 	if (seqflg & F_FPOP) {
+		if (TheCPU.fpstate) {
+			loadfpstate(*TheCPU.fpstate);
+			TheCPU.fpstate = NULL;
+		}
 		/* mask exceptions in generated code */
 		unsigned short fpuc;
 		asm ("fstcw	%0" : "=m"(TheCPU.fpuc));

--- a/src/emu-i386/simx86/cpu-emu.c
+++ b/src/emu-i386/simx86/cpu-emu.c
@@ -128,7 +128,7 @@ FILE *aLog = NULL;
  * 16	unsigned long eflags;
  * 17	unsigned long esp_at_signal;
  * 18	unsigned short ss, __ssh;
- * 19	struct _fpstate * fpstate;
+ * 19	fpregset_t fpstate;
  * 20	unsigned long oldmask;
  * 21	unsigned long cr2;
  *

--- a/src/emu-i386/simx86/cpu-emu.c
+++ b/src/emu-i386/simx86/cpu-emu.c
@@ -609,9 +609,8 @@ static void Scp2Cpu (sigcontext_t *scp)
   TheCPU.ss = _ss;
   TheCPU.cr2 = _cr2;
 
-  /* Native FPU used for JIT, for simulator this is just to switch off
-     FPU exceptions */
-  loadfpstate(*__fpstate);
+  /* __fpstate is loaded later on demand for JIT, not used for simulator */
+  TheCPU.fpstate = __fpstate;
 }
 
 /*
@@ -650,15 +649,16 @@ static void Cpu2Scp (sigcontext_t *scp, int trapno)
    * (b0-b1 are currently unimplemented here)
    */
   if (!TheCPU.err) _err = 0;		//???
-  savefpstate(*__fpstate);
-#ifdef FE_NOMASK_ENV
-  /* there is no real need to save and restore the FPU state of the
-     emulator itself: savefpstate (fnsave) also resets the current FPU
-     state using fninit/ldmxcsr which is good enough for calling FPU-using
-     routines.
-  */
-  feenableexcept(FE_DIVBYZERO | FE_OVERFLOW);
-#endif
+  if (TheCPU.fpstate == NULL) {
+    if (!CONFIG_CPUSIM) savefpstate(*__fpstate);
+    /* there is no real need to save and restore the FPU state of the
+       emulator itself: savefpstate (fnsave) also resets the current FPU
+       state using fninit; fesetenv then restores trapping of division by
+       zero and overflow which is good enough for calling FPU-using
+       routines.
+    */
+    fesetenv(&dosemu_fenv);
+  }
 
   /* push running flags - same as eflags, RF is cosmetic */
   _eflags = (TheCPU.eflags & (eTSSMASK|0xfd5)) | 0x10002;
@@ -1114,6 +1114,8 @@ int e_vm86(void)
   e_sigpa_count = 0;
   mode = ADDR16|DATA16; TheCPU.StackMask = 0x0000ffff;
   TheCPU.mem_base = (uintptr_t)mem_base;
+  /* FPU state is loaded later on demand for JIT, not used for simulator */
+  TheCPU.fpstate = vm86_fpu_state;
   VgaAbsBankBase = TheCPU.mem_base + vga.mem.bank_base;
   if (eTimeCorrect >= 0) TheCPU.EMUtime = GETTSC();
 #ifdef SKIP_VM86_TRACE
@@ -1208,6 +1210,11 @@ int e_vm86(void)
   }
   while (retval < 0);
   /* ------ OUTER LOOP -- exit to user level ---------------------- */
+
+  if (TheCPU.fpstate == NULL) {
+    if (!CONFIG_CPUSIM) savefpstate(*vm86_fpu_state);
+    fesetenv(&dosemu_fenv);
+  }
 
   LastXNode = NULL;
   if (debug_level('e')>1)

--- a/src/emu-i386/simx86/interp.c
+++ b/src/emu-i386/simx86/interp.c
@@ -2315,6 +2315,16 @@ repag0:
 			}
 			b &= 7;
 			TheCPU.mode |= M_FPOP;
+			if (TheCPU.fpstate) {
+				/* For simulator, only need to mask all
+				   exceptions; for JIT, load emulated FPU state
+				   into real FPU */
+				if (CONFIG_CPUSIM)
+					fesetenv(FE_DFL_ENV);
+				else
+					loadfpstate(*TheCPU.fpstate);
+				TheCPU.fpstate = NULL;
+			}
 			if (sim) {
 			    if (Fp87_op(exop,b)) { TheCPU.err = -96; return P0; }
 			}

--- a/src/emu-i386/simx86/syncpu.h
+++ b/src/emu-i386/simx86/syncpu.h
@@ -153,6 +153,11 @@ typedef struct {
 	void (*stub_movsb)(void);
 	void (*stub_movsw)(void);
 	void (*stub_movsl)(void);
+
+	/* if not NULL, points to emulated FPU state
+	   if NULL, emulator uses FPU instructions, so flags that
+	   dosemu needs to restore its own FPU environment. */
+	fpregset_t fpstate;
 } SynCPU;
 
 union SynCPU {

--- a/src/include/cpu.h
+++ b/src/include/cpu.h
@@ -161,17 +161,7 @@ static inline void *FAR2PTR(FAR_PTR far_ptr) {
 
 #define peek(seg, off)	(READ_WORD(SEGOFF2LINEAR(seg, off)))
 
-#ifdef HAVE_STRUCT__LIBC_FPSTATE
-typedef struct _libc_fpstate ___fpstate;
-#else
-#ifdef HAVE_STRUCT__FPSTATE
-typedef struct _fpstate ___fpstate;
-#else
-#error struct for fpu state not detected
-#endif
-#endif
-
-extern ___fpstate *vm86_fpu_state;
+extern fpregset_t vm86_fpu_state;
 extern fenv_t dosemu_fenv;
 
 /*


### PR DESCRIPTION
Relates to #572.

I haven't submitted any of my proposed changes to dpmi.c yet, that needs some more testing. There is also still the issue that SSE state is not saved/restored on i386.
