### PR TITLE
bios.S: Avoid copying over text font [fixes #552]

### DIFF
--- a/src/base/bios/bios.S
+++ b/src/base/bios/bios.S
@@ -922,9 +922,6 @@ int_rvc_cs_\inum:
 	.org	((INT_RVC_SEG - BIOSSEG) << 4) + INT_RVC_2f_OFF
 	int_rvc 2f
 
-	.globl  bios_f000_endpart1
-bios_f000_endpart1:
-
 /* COMPAS FF841		jmp to INT12 */
 /* COMPAS FF844-FF84C	reserved */
 /* COMPAS FF84D		jmp to INT11 */
@@ -938,9 +935,6 @@ bios_f000_endpart1:
 bios_text_font:
          /* there's no need to allocate the space just move over */
 	.org . + (128 * 8) // uint8_t text_font[128*8]
-
-	.globl	bios_f000_part2
-bios_f000_part2:
 
 /* COMPAS FFE6E		jmp to INT1A */
 /* COMPAS FFE71-FFEA4	reserved */

--- a/src/base/bios/bios.S
+++ b/src/base/bios/bios.S
@@ -931,12 +931,19 @@ bios_f000_endpart1:
 /* COMPAS FF850-FF858	reserved */
 /* COMPAS FF859		jmp to INT15 */
 /* COMPAS FF85C-FFA6D	reserved */
+
 /* COMPAS FFA6E		font tables */
-/* COMPAS FFE6E		jmp to INT1A */
-/* COMPAS FFE71-FFEA4	reserved */
+	.org 0xfa6e
+	.globl	bios_text_font
+bios_text_font:
+         /* there's no need to allocate the space just move over */
+	.org . + (128 * 8) // uint8_t text_font[128*8]
 
 	.globl	bios_f000_part2
 bios_f000_part2:
+
+/* COMPAS FFE6E		jmp to INT1A */
+/* COMPAS FFE71-FFEA4	reserved */
 
 /* ----------------------------------------------------------------- */
 	.org    ((INT75_SEG-BIOSSEG) << 4)+INT75_OFF

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -1702,10 +1702,6 @@ static int vga_emu_post_init(void)
 
   vgaemu_register_ports();
 
-  /*
-   * init the ROM-BIOS font (the VGA fonts are added in vbe_init())
-   */
-  MEMCPY_2DOS(GFX_CHARS, vga_rom_08, 128 * 8);
   SETIVEC(0x42, INT42HOOK_SEG, INT42HOOK_OFF);
   vbe_pre_init();
 

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -41,6 +41,8 @@
 #include "mapping.h"
 #include "vgaemu.h"
 
+#define GFX_CHARS       0xffa6e
+
 #if 0
 static inline void dbug_dumpivec(void)
 {
@@ -168,7 +170,7 @@ void map_video_bios(void)
     }
 
     /* copy graphics characters from system BIOS */
-    load_file("/dev/mem", GFX_CHARS, LINEAR2UNIX(GFX_CHARS), GFXCHAR_SIZE);
+    load_file("/dev/mem", GFX_CHARS, vga_rom_08, 128 * 8);
 
     memcheck_addtype('V', "Video BIOS");
     memcheck_reserve('V', VBIOS_START, VBIOS_SIZE);

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -39,6 +39,7 @@
 #include "cpu-emu.h"
 #include "kvm.h"
 #include "mapping.h"
+#include "vgaemu.h"
 
 #if 0
 static inline void dbug_dumpivec(void)
@@ -181,7 +182,7 @@ void map_video_bios(void)
  *
  * description:
  *  Setup the dosemu amazing custom BIOS, quietly overwriting anything
- *  was copied there before. Do not overwrite graphic fonts!
+ *  was copied there before.
  *
  * DANG_END_FUNCTION
  */
@@ -190,14 +191,14 @@ void map_custom_bios(void)
   unsigned int ptr;
   u_long n;
 
-  n = (u_long)bios_f000_endpart1 - (u_long)bios_f000;
+  /* Copy the BIOS into DOS memory */
+  n = (u_long)bios_f000_end - (u_long)bios_f000;
   ptr = SEGOFF2LINEAR(BIOSSEG, 0);
   e_invalidate(ptr, n);
   MEMCPY_2DOS(ptr, bios_f000, n);
 
-  n = (u_long)bios_f000_end - (u_long)bios_f000_part2;
-  ptr = SEGOFF2LINEAR(BIOSSEG, ((u_long)bios_f000_part2 - (u_long)bios_f000));
-  MEMCPY_2DOS(ptr, bios_f000_part2, n);
+  /* Initialise the ROM-BIOS graphic font (lower half only) */
+  MEMCPY_2DOS(GFX_CHARS, vga_rom_08, 128 * 8);
 }
 
 /*

--- a/src/include/bios.h
+++ b/src/include/bios.h
@@ -5,10 +5,6 @@
 
 
 extern void bios_f000(void);		/* BIOS start at 0xf0000 */
-/* these two addresses are needed to avoid overwriting e.g. font
- * tables copied from VBIOS */
-extern void bios_f000_endpart1(void);
-extern void bios_f000_part2(void);
 extern void bios_f000_end(void);	/* BIOS end at 0xfffff */
 extern void bios_f000_int10ptr(void);
 extern void bios_f000_bootdrive(void);

--- a/src/include/memory.h
+++ b/src/include/memory.h
@@ -148,8 +148,6 @@
 #define VBIOS_START	(SEGOFF2LINEAR(config.vbios_seg,0))
 /*#define VBIOS_SIZE	(64*1024)*/
 #define VBIOS_SIZE	(config.vbios_size)
-#define GFX_CHARS	0xffa6e
-#define GFXCHAR_SIZE	1400
 
 /* Memory adresses for all common video adapters */
 


### PR DESCRIPTION
The lower 128 characters of text font are kept in the bios at f000:fa6e
and we copy the bios in two chunks to seemingly avoid overwriting this.
However at present the bios_f000_endpart1 and bios_f000_part2 symbols are
pointing to the same address so rendering the two part copy ineffective.

>>> Existing bios.o objdump
0000f5d8 g       .text	00000000 bios_f000_endpart1
0000f5d8 g       .text	00000000 bios_f000_part2

This patch defines the bios_text_font symbol, positions it at the 0xfa6e
offset and advances the origin to avoid overwriting the text font that
may already be defined in the bios.

>>> New bios.o objdump
0000f5d8 g       .text	00000000 bios_f000_endpart1
0000fa6e g       .text	00000000 bios_text_font
0000fe6e g       .text	00000000 bios_f000_part2