### PR TITLE
debian/*: explicitly building a -dbg package is no longer necessary

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -40,11 +40,3 @@ Recommends: ladspa-sdk, ${shlibs-:Recommends}
 Suggests: fluid-soundfont-gm, vde2
 Description: DOS Emulator for Linux
  dosemu2 is a virtual machine that allows you to run DOS programs under linux.
-
-Package: dosemu2-dbg
-Architecture: i386 amd64
-Section: debug
-Priority: optional
-Depends: dosemu2 (= ${binary:Version}), ${misc:Depends}
-Description: debugging symbols for dosemu2
- This package contains the debugging symbols for dosemu2.

--- a/debian/install
+++ b/debian/install
@@ -1,3 +1,2 @@
-debian/tmp/* .
 debian/dosemu.desktop usr/share/applications/
 etc/dosemu2.alias etc/X11/fonts/misc/

--- a/debian/rules
+++ b/debian/rules
@@ -14,9 +14,6 @@ override_dh_auto_configure:
 		--with-fdtarball=`pwd`/dosemu-freedos-1.0-bin.tgz \
 		--enable-plugins=+vde
 
-override_dh_strip:
-	dh_strip --dbg-package=dosemu2-dbg
-
 override_dh_shlibdeps:
 	dh_shlibdeps -X.so
 	dh_shlibdeps -- -dRecommends -pshlibs-


### PR DESCRIPTION
Current Debian build tools are capable of generating debug packages (`-dbgsym`) without explicit instructions in control files. I believe build instructions for `dosemu2-dbg` can be removed now.