### PR TITLE
commands: change MaxCmd to AmountCmd, use jb conditional

### DIFF
--- a/src/env/commands/aspi.S
+++ b/src/env/commands/aspi.S
@@ -52,7 +52,7 @@ Dispatch:
 	.word	Dummy		# removeable media check
 Dispatch_End:
 
-MaxCmd = (Dispatch_End - Dispatch) / 2
+AmountCmd = (Dispatch_End - Dispatch) / 2
 
 Strat:
 	movw	%bx, %cs:RHPtr
@@ -77,8 +77,8 @@ Intr:
 
 	movb	%es:2(%di),%bl
 	xorb	%bh,%bh
-	cmpw	$MaxCmd, %bx
-	jle	Intr1
+	cmpw	$AmountCmd, %bx
+	jb	Intr1
 	call	Error
 	jmp	Intr2
 

--- a/src/env/commands/ems.S
+++ b/src/env/commands/ems.S
@@ -79,7 +79,7 @@ Dispatch:
 	.word	Dummy		# removeable media check
 Dispatch_End:
 
-MaxCmd = (Dispatch_End - Dispatch) / 2
+AmountCmd = (Dispatch_End - Dispatch) / 2
 
 Strat:
 	mov	%bx, %cs:RHPtr
@@ -97,8 +97,8 @@ Intr:
 
 	movzbw	%es:CMD(%di), %si
 	movw	%si, %bx
-	cmpw	$MaxCmd, %bx
-	jle	1f
+	cmpw	$AmountCmd, %bx
+	jb	1f
 	mov	$0x8003, %ax	# error
 	jmp	2f
 

--- a/src/env/commands/emufs.S
+++ b/src/env/commands/emufs.S
@@ -89,7 +89,7 @@ Dispatch:
 	.word	Dummy		# removeable media check
 Dispatch_End:
 
-MaxCmd = (Dispatch_End - Dispatch) / 2
+AmountCmd = (Dispatch_End - Dispatch) / 2
 
 Strat:
 	movw	%bx, %cs:RHPtr
@@ -108,8 +108,8 @@ Intr:
 
 	movb	%es:CMD(%di),%bl
 	xorb	%bh,%bh
-	cmpw	$MaxCmd,%bx
-	jle	1f
+	cmpw	$AmountCmd,%bx
+	jb	1f
 	movw	$0x8003,%ax		# Set error
 	jmp	2f
 

--- a/src/env/commands/umb.S
+++ b/src/env/commands/umb.S
@@ -70,7 +70,7 @@ Dispatch:
 	.word	Dummy		# removeable media check
 Dispatch_End:
 
-MaxCmd = (Dispatch_End - Dispatch) / 2
+AmountCmd = (Dispatch_End - Dispatch) / 2
 
 Strat:
 	mov	%bx, %cs:RHPtr
@@ -88,8 +88,8 @@ Intr:
 
 	movzbw	%es:CMD(%di), %si
 	movw	%si, %bx
-	cmpw	$MaxCmd, %bx
-	jle	1f
+	cmpw	$AmountCmd, %bx
+	jb	1f
 	mov	$0x8003, %ax	# error
 	jmp	2f
 


### PR DESCRIPTION
The first change is to rename the MaxCmd label to AmountCmd, because the
current way that this label is created actually calculates the *amount*
of table entries (ie commands), not the maximum command (one less).

The second change is to use an unsigned comparison conditional branch,
ie "jbe" instead of "jle". With "jle", values that in two's complement are
below zero would incorrectly try to dispatch through the table.

The third change is to use "jb" instead of "jbe", which relates to the
different sense of the calculation as already indicated by the first change.
A command index needs to be *below* the AmountCmd value, not below-or-equal.