### PR TITLE
Fix those gcc 8 warnings that look like bugs - see Issue#613

### DIFF
--- a/src/base/kbd_unicode/keymaps.c
+++ b/src/base/kbd_unicode/keymaps.c
@@ -2427,7 +2427,7 @@ static int read_kbd_table(struct keytable_entry *kt,
 		altkt->shift_alt_map = kt->shift_map;
 	}
 	if (!altgr_present) {
-		for(i = 0; i < sizeof(kt->alt_map)/sizeof(kt->alt_map[0]); i++) {
+		for(i = 0; i < kt->sizemap; i++) {
 			kt->alt_map[i] = U_VOID;
 		}
 	}

--- a/src/base/sound/sndpcm.c
+++ b/src/base/sound/sndpcm.c
@@ -219,12 +219,12 @@ int pcm_init(void)
     pthread_mutex_init(&pcm.time_mtx, NULL);
 
 #ifdef USE_DL_PLUGINS
-#define LOAD_PLUGIN_C(x, c) \
+#define LOAD_PLUGIN_C(x, c) { \
     dl_handles[num_dl_handles] = load_plugin(x); \
     if (dl_handles[num_dl_handles]) { \
 	num_dl_handles++; \
 	c \
-    }
+    } }
 #define LOAD_PLUGIN(x) LOAD_PLUGIN_C(x,)
 #ifdef USE_LIBAO
     LOAD_PLUGIN_C("libao", { ca = pcm_get_cfg("ao"); } );

--- a/src/emu-i386/simx86/interp.c
+++ b/src/emu-i386/simx86/interp.c
@@ -83,11 +83,11 @@ static __inline__ void SetCPU_WL(int m, char o, unsigned long v)
  *	from P0, abort the current instruction and resume the parsing
  *	loop at P2.
  */
-#define	CODE_FLUSH() 	if (CONFIG_CPUSIM || CurrIMeta>0) {\
+#define	CODE_FLUSH() 	{ if (CONFIG_CPUSIM || CurrIMeta>0) {\
 			  unsigned int P2 = CloseAndExec(P0, mode, __LINE__);\
 			  if (TheCPU.err) return P2;\
 			  if (!CONFIG_CPUSIM && P2 != P0) { PC=P2; continue; }\
-			} NewNode=0
+			} NewNode=0; }
 
 #define UNPREFIX(m)	((m)&~(DATA16|ADDR16))|(basemode&(DATA16|ADDR16))
 


### PR DESCRIPTION
In the case of the loop the compiler is correct - the loop as written would always execute once and not for the number of entries the map.  I got the sizemap field as the size by looking at other code that manipluates these.

For the macros I have added braces to make them a compound statement.  Another possibility is to add braces in the conditionals where they are called.