### PR TITLE
Disks boundary

### DIFF
--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1561,8 +1561,8 @@ int int13(void)
       track |= (HI(dx) & 0xc0) << 4;
     buffer = SEGOFF2LINEAR(SREG(es), LWORD(ebx));
     number = LO(ax);
-    W_printf("DISK write [h:%d,s:%d,t:%d](%d)->%#x (%04x:%04x)\n",
-	     head, sect, track, number, buffer, SREG(es), LWORD(ebx));
+    W_printf("DISK %02x write [h:%d,s:%d,t:%d](%d)->%#x (%04x:%04x)\n",
+	     disk, head, sect, track, number, buffer, SREG(es), LWORD(ebx));
 
     if (number > I13_MAX_ACCESS) {
       error("Too large write, ah=0x03!\n");

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1889,7 +1889,7 @@ int int13(void)
     break;
 
   case 0x20:			/* ??? */
-    d_printf("weird int13, ah=0x%x\n", LWORD(eax));
+    d_printf("weird int13, ax=0x%04x\n", LWORD(eax));
     break;
   case 0x28:			/* DRDOS 6.0 call ??? */
     d_printf("int 13h, ax=%04x...DRDOS call\n", LWORD(eax));
@@ -2105,7 +2105,7 @@ int int13(void)
     NOCARRY;
     break;
   default:
-    d_printf("disk error, unknown command: int13, ax=0x%x\n",
+    d_printf("disk error, unknown command: int13, ax=0x%04x\n",
 	  LWORD(eax));
     show_regs();
     CARRY;

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1576,6 +1576,14 @@ int int13(void)
     if (checkdp_val || head >= dp->heads ||
 	sect >= dp->sectors || track >= dp->tracks) {
       error("Sector not found, ah=0x03!\n");
+      error("DISK %02x write [h:%d,s:%d,t:%d](%d)->%#x (%04x:%04x)\n",
+	    disk, head, sect, track, number, buffer, SREG(es), LWORD(ebx));
+      if (dp) {
+	  error("DISK dev %s GEOM %d heads %d sects %d trk\n",
+		dp->dev_name, dp->heads, dp->sectors, dp->tracks);
+      } else {
+	  error("DISK %02x undefined.\n", disk);
+      }
       show_regs();
       HI(ax) = DERR_NOTFOUND;
       REG(eflags) |= CF;

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1495,6 +1495,15 @@ int int13(void)
     d_printf("DISK %02x read [h:%d,s:%d,t:%d](%d)->%04x:%04x\n",
 	     disk, head, sect, track, number, SREG(es), LWORD(ebx));
 
+    if (number > I13_MAX_ACCESS) {
+      error("Too large read, ah=0x02!\n");
+      error("DISK %02x read [h:%d,s:%d,t:%d](%d)->%#x\n",
+	    disk, head, sect, track, number, buffer);
+      HI(ax) = DERR_BOUNDARY;
+      CARRY;
+      break;
+    }
+
     if (checkdp_val || head >= dp->heads ||
 	sect >= dp->sectors || track >= dp->tracks) {
       d_printf("Sector not found, ah=0x02!\n");
@@ -1554,6 +1563,15 @@ int int13(void)
     number = LO(ax);
     W_printf("DISK write [h:%d,s:%d,t:%d](%d)->%#x\n",
 	     head, sect, track, number, buffer);
+
+    if (number > I13_MAX_ACCESS) {
+      error("Too large write, ah=0x03!\n");
+      error("DISK %02x write [h:%d,s:%d,t:%d](%d)->%#x\n",
+	    disk, head, sect, track, number, buffer);
+      HI(ax) = DERR_BOUNDARY;
+      CARRY;
+      break;
+    }
 
     if (checkdp_val || head >= dp->heads ||
 	sect >= dp->sectors || track >= dp->tracks) {
@@ -1890,6 +1908,15 @@ int int13(void)
     d_printf("DISK %02x ext read [LBA %"PRIu64"](%d)->%04x:%04x\n",
 	     disk, diskaddr->block, number, diskaddr->buf_seg, diskaddr->buf_ofs);
 
+    if (number > I13_MAX_ACCESS) {
+      error("Too large read, ah=0x42!\n");
+      error("DISK %02x ext read [LBA %"PRIu64"](%d)->%#x\n",
+	    disk, diskaddr->block, number, buffer);
+      HI(ax) = DERR_BOUNDARY;
+      CARRY;
+      break;
+    }
+
     if (checkdp_val) {
       d_printf("Sector not found, AH=0x42!\n");
       d_printf("DISK %02x ext read [LBA %"PRIu64"](%d)->%#x\n",
@@ -1941,6 +1968,15 @@ int int13(void)
     WRITE_P(diskaddr->blocks, 0);
     d_printf("DISK %02x ext write [LBA %"PRIu64"](%d)->%04x:%04x\n",
 	     disk, diskaddr->block, number, diskaddr->buf_seg, diskaddr->buf_ofs);
+
+    if (number > I13_MAX_ACCESS) {
+      error("Too large write, ah=0x43!\n");
+      error("DISK %02x ext write [LBA %"PRIu64"](%d)->%#x\n",
+	    disk, diskaddr->block, number, buffer);
+      HI(ax) = DERR_BOUNDARY;
+      CARRY;
+      break;
+    }
 
     if (checkdp_val) {
       error("Sector not found, AH=0x43!\n");

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1492,13 +1492,13 @@ int int13(void)
       track |= (HI(dx) & 0xc0) << 4;
     buffer = SEGOFF2LINEAR(SREG(es), LWORD(ebx));
     number = LO(ax);
-    d_printf("DISK %02x read [h:%d,s:%d,t:%d](%d)->%04x:%04x\n",
-	     disk, head, sect, track, number, SREG(es), LWORD(ebx));
+    d_printf("DISK %02x read [h:%d,s:%d,t:%d](%d)->%#x (%04x:%04x)\n",
+	     disk, head, sect, track, number, buffer, SREG(es), LWORD(ebx));
 
     if (number > I13_MAX_ACCESS) {
       error("Too large read, ah=0x02!\n");
-      error("DISK %02x read [h:%d,s:%d,t:%d](%d)->%#x\n",
-	    disk, head, sect, track, number, buffer);
+      error("DISK %02x read [h:%d,s:%d,t:%d](%d)->%#x (%04x:%04x)\n",
+	    disk, head, sect, track, number, buffer, SREG(es), LWORD(ebx));
       HI(ax) = DERR_BOUNDARY;
       CARRY;
       break;
@@ -1507,8 +1507,8 @@ int int13(void)
     if (checkdp_val || head >= dp->heads ||
 	sect >= dp->sectors || track >= dp->tracks) {
       d_printf("Sector not found, ah=0x02!\n");
-      d_printf("DISK %02x read [h:%d,s:%d,t:%d](%d)->%#x\n",
-	       disk, head, sect, track, number, buffer);
+      d_printf("DISK %02x read [h:%d,s:%d,t:%d](%d)->%#x (%04x:%04x)\n",
+	       disk, head, sect, track, number, buffer, SREG(es), LWORD(ebx));
       if (dp) {
 	  d_printf("DISK dev %s GEOM %d heads %d sects %d trk\n",
 		   dp->dev_name, dp->heads, dp->sectors, dp->tracks);
@@ -1561,13 +1561,13 @@ int int13(void)
       track |= (HI(dx) & 0xc0) << 4;
     buffer = SEGOFF2LINEAR(SREG(es), LWORD(ebx));
     number = LO(ax);
-    W_printf("DISK write [h:%d,s:%d,t:%d](%d)->%#x\n",
-	     head, sect, track, number, buffer);
+    W_printf("DISK write [h:%d,s:%d,t:%d](%d)->%#x (%04x:%04x)\n",
+	     head, sect, track, number, buffer, SREG(es), LWORD(ebx));
 
     if (number > I13_MAX_ACCESS) {
       error("Too large write, ah=0x03!\n");
-      error("DISK %02x write [h:%d,s:%d,t:%d](%d)->%#x\n",
-	    disk, head, sect, track, number, buffer);
+      error("DISK %02x write [h:%d,s:%d,t:%d](%d)->%#x (%04x:%04x)\n",
+	    disk, head, sect, track, number, buffer, SREG(es), LWORD(ebx));
       HI(ax) = DERR_BOUNDARY;
       CARRY;
       break;
@@ -1905,13 +1905,15 @@ int int13(void)
     buffer = SEGOFF2LINEAR(diskaddr->buf_seg, diskaddr->buf_ofs);
     number = diskaddr->blocks;
     WRITE_P(diskaddr->blocks, 0);
-    d_printf("DISK %02x ext read [LBA %"PRIu64"](%d)->%04x:%04x\n",
-	     disk, diskaddr->block, number, diskaddr->buf_seg, diskaddr->buf_ofs);
+    d_printf("DISK %02x ext read [LBA %"PRIu64"](%d)->%#x (%04x:%04x)\n",
+	     disk, diskaddr->block, number,
+	     buffer, diskaddr->buf_seg, diskaddr->buf_ofs);
 
     if (number > I13_MAX_ACCESS) {
       error("Too large read, ah=0x42!\n");
-      error("DISK %02x ext read [LBA %"PRIu64"](%d)->%#x\n",
-	    disk, diskaddr->block, number, buffer);
+      error("DISK %02x ext read [LBA %"PRIu64"](%d)->%#x (%04x:%04x)\n",
+	    disk, diskaddr->block, number,
+	    buffer, diskaddr->buf_seg, diskaddr->buf_ofs);
       HI(ax) = DERR_BOUNDARY;
       CARRY;
       break;
@@ -1919,8 +1921,9 @@ int int13(void)
 
     if (checkdp_val) {
       d_printf("Sector not found, AH=0x42!\n");
-      d_printf("DISK %02x ext read [LBA %"PRIu64"](%d)->%#x\n",
-	       disk, diskaddr->block, number, buffer);
+      d_printf("DISK %02x ext read [LBA %"PRIu64"](%d)->%#x (%04x:%04x)\n",
+	       disk, diskaddr->block, number,
+	       buffer, diskaddr->buf_seg, diskaddr->buf_ofs);
       if (dp) {
 	  d_printf("DISK dev %s GEOM %d heads %d sects %d trk\n",
 		   dp->dev_name, dp->heads, dp->sectors, dp->tracks);
@@ -1966,13 +1969,15 @@ int int13(void)
     buffer = SEGOFF2LINEAR(diskaddr->buf_seg, diskaddr->buf_ofs);
     number = diskaddr->blocks;
     WRITE_P(diskaddr->blocks, 0);
-    d_printf("DISK %02x ext write [LBA %"PRIu64"](%d)->%04x:%04x\n",
-	     disk, diskaddr->block, number, diskaddr->buf_seg, diskaddr->buf_ofs);
+    d_printf("DISK %02x ext write [LBA %"PRIu64"](%d)->%#x (%04x:%04x)\n",
+	     disk, diskaddr->block, number,
+	     buffer, diskaddr->buf_seg, diskaddr->buf_ofs);
 
     if (number > I13_MAX_ACCESS) {
       error("Too large write, ah=0x43!\n");
-      error("DISK %02x ext write [LBA %"PRIu64"](%d)->%#x\n",
-	    disk, diskaddr->block, number, buffer);
+      error("DISK %02x ext write [LBA %"PRIu64"](%d)->%#x (%04x:%04x)\n",
+	    disk, diskaddr->block, number,
+	    buffer, diskaddr->buf_seg, diskaddr->buf_ofs);
       HI(ax) = DERR_BOUNDARY;
       CARRY;
       break;
@@ -1980,8 +1985,9 @@ int int13(void)
 
     if (checkdp_val) {
       error("Sector not found, AH=0x43!\n");
-      d_printf("DISK %02x ext write [LBA %"PRIu64"](%d)->%#x\n",
-	       disk, diskaddr->block, number, buffer);
+      d_printf("DISK %02x ext write [LBA %"PRIu64"](%d)->%#x (%04x:%04x)\n",
+	       disk, diskaddr->block, number,
+	       buffer, diskaddr->buf_seg, diskaddr->buf_ofs);
       if (dp) {
 	  d_printf("DISK dev %s GEOM %d heads %d sects %d trk\n",
 		   dp->dev_name, dp->heads, dp->sectors, dp->tracks);

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1515,10 +1515,9 @@ int int13(void)
       } else {
 	  d_printf("DISK %02x undefined.\n", disk);
       }
-
+      show_regs();
       HI(ax) = DERR_NOTFOUND;
       REG(eflags) |= CF;
-      show_regs();
       break;
     }
 
@@ -1938,10 +1937,9 @@ int int13(void)
       } else {
 	  d_printf("DISK %02x undefined.\n", disk);
       }
-
+      show_regs();
       HI(ax) = DERR_NOTFOUND;
       REG(eflags) |= CF;
-      show_regs();
       break;
     }
 
@@ -2002,10 +2000,9 @@ int int13(void)
       } else {
 	  error("DISK %02x undefined.\n", disk);
       }
-
+      show_regs();
       HI(ax) = DERR_NOTFOUND;
       REG(eflags) |= CF;
-      show_regs();
       break;
     }
 
@@ -2070,10 +2067,9 @@ int int13(void)
       } else {
 	  d_printf("DISK %02x undefined.\n", disk);
       }
-
+      show_regs();
       HI(ax) = DERR_NOTFOUND;
       REG(eflags) |= CF;
-      show_regs();
       break;
     }
 

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1993,14 +1993,14 @@ int int13(void)
 
     if (checkdp_val) {
       error("Sector not found, AH=0x43!\n");
-      d_printf("DISK %02x ext write [LBA %"PRIu64"](%d)->%#x (%04x:%04x)\n",
-	       disk, diskaddr->block, number,
-	       buffer, diskaddr->buf_seg, diskaddr->buf_ofs);
+      error("DISK %02x ext write [LBA %"PRIu64"](%d)->%#x (%04x:%04x)\n",
+	    disk, diskaddr->block, number,
+	    buffer, diskaddr->buf_seg, diskaddr->buf_ofs);
       if (dp) {
-	  d_printf("DISK dev %s GEOM %d heads %d sects %d trk\n",
-		   dp->dev_name, dp->heads, dp->sectors, dp->tracks);
+	  error("DISK dev %s GEOM %d heads %d sects %d trk\n",
+		dp->dev_name, dp->heads, dp->sectors, dp->tracks);
       } else {
-	  d_printf("DISK %02x undefined.\n", disk);
+	  error("DISK %02x undefined.\n", disk);
       }
 
       HI(ax) = DERR_NOTFOUND;

--- a/src/include/disks.h
+++ b/src/include/disks.h
@@ -214,11 +214,26 @@ fatfs_t *get_fat_fs_by_drive(unsigned char drv_num);
 #define DERR_WP 	3
 #define DERR_NOTFOUND 	4
 #define DERR_CHANGE 	6
+#define DERR_BOUNDARY	9
 #define DERR_ECCERR 	0x10
 #define DERR_CONTROLLER	0x20
 #define DERR_SEEK	0x40
 #define DERR_NOTREADY	0x80
 #define DERR_WRITEFLT	0xcc
+
+/* Int13 maximum amount of sectors to access.
+ *
+ * Mentioned in RBIL 61 Int 1301 Table 00234,
+ *  which lists error code 09 as follows:
+ *
+ * 09h	data boundary error (attempted DMA across 64K boundary or >80h sectors)
+ *
+ * Note that > 80h sectors with 512 bytes per sector always crosses a 64 KiB
+ *  boundary, so it may be the error code is only meant for that crossing.
+ *  But in Int 1342 Table 00272, it is also mentioned that the maximum amount
+ *  of blocks may be 7Fh (for LBA), and we use the same error code then.
+ */
+#define I13_MAX_ACCESS	0x80
 
 /* IBM/MS Extensions */
 #define IMEXT_MAGIC                 0xaa55


### PR DESCRIPTION
As requested in https://github.com/stsp/dosemu2/issues/461#issuecomment-398392842 based on the patch I provided in https://github.com/stsp/dosemu2/issues/461#issuecomment-331267480 (but defining the I13_MAX_ACCESS constant in the header (needs to be modified to hold DERR_BOUNDARY already), and for all of CHS read and write and LBA read and write).

I also took on a number of minor changes to unify and improve some of the logging.

Not addressed by this pull request (yet):

* Floppy units may (should) fail accesses with buffers crossing a 64 KiB boundary, to imitate the floppy DMA restriction.
* CHS accesses may fail if a track boundary is crossed; but some ROM-BIOSes are known to support "multi-track" access.
* LBA accesses should check the length of the packet provided by the caller.
* LBA accesses could be extended to work with 64-bit linear buffer address.
* Accesses could be failed if the offset plus buffer length exceed 64 KiB (> 1_0000h).
* Accesses could be failed if the buffer extends past 1088 KiB - 16 byte (past the HMA). (Not the ones with linear buffer address of course.)
* 13.20 and 13.28 probably should return errors, like the 13.unknown handler?

Are any of these desired?
