### PR TITLE
Makefile: plugin_config.h is under git control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,6 @@ pristine distclean mrproper:  Makefile.conf docsclean
 	rm -f src/include/stamp-h1
 	rm -f src/include/config.hh.in
 	rm -f src/include/version.hh
-	rm -f src/include/plugin_*.h
 	rm -f `find . -name '*~'`
 	rm -f `find . -name '*[\.]o'`
 	rm -f `find . -name '*.d'`


### PR DESCRIPTION
Now that src/include/plugin_config.h is a static stub file, don't remove
it on make clean.

Fixes #629