### PR TITLE
Allow to override build date

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -169,7 +169,9 @@ AC_CHECK_FUNCS([pthread_getname_np pthread_setname_np])
 dnl Check for the XKB extension to get reliable keyboard handling
 AC_CHECK_HEADER(X11/XKBlib.h, AC_DEFINE(HAVE_XKB,1))
 AC_CHECK_HEADERS([netipx/ipx.h linux/ipx.h])
-CONFIG_TIME=`date +"%F %T %z"`
+DATE_FMT="%F %T %z"
+test -n "$SOURCE_DATE_EPOCH" || SOURCE_DATE_EPOCH=`date +%s`
+CONFIG_TIME=`date -u -d "@$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u "+$DATE_FMT"`
 AC_DEFINE_UNQUOTED(CONFIG_HOST, "$CONFIG_HOST")
 AC_DEFINE_UNQUOTED(CONFIG_TIME, "$CONFIG_TIME")
 


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.
Also use UTC to be independent of timezone.

This date call is designed to work with all variants of 'date'

Without this patch, the dosemu package in openSUSE would differ for every build.