### PR TITLE
build: Fix a syntax error in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -120,7 +120,7 @@ AC_CHECK_LIB(m, pow)
 
 DOSDEBUG_LIBS=""
 AC_CHECK_LIB(readline, main, [
-  DOSDEBUG_LIBS="$(DOSDEBUG_LIBS) -lreadline"
+  DOSDEBUG_LIBS="$DOSDEBUG_LIBS -lreadline"
   AC_DEFINE([HAVE_LIBREADLINE], 1, [Define to 1 if you have the readline library (-lreadline).])
 ], [
   AC_MSG_NOTICE(Please install libreadline-dev for readline support in dosdebug)


### PR DESCRIPTION
This is a mess up of mine, although it still did work by chance.