### PR TITLE
MFS: Use the public interface to setup the FATFS drives

### DIFF
--- a/src/include/redirect.h
+++ b/src/include/redirect.h
@@ -26,8 +26,6 @@
 #define REDIR_PRINTER_TYPE    3
 #define REDIR_DISK_TYPE       4
 
-int RedirectDisk(int, char *, int);
-int RedirectPrinter(char *);
 int CancelDiskRedirection(int);
 int ResetRedirection(int);
 int GetRedirectionRoot(int,char **,int *);


### PR DESCRIPTION
Use the public interface to setup the FATFS drives, this reduces the
reliance on the LOL and global CDS array location.

Thanks to @stsp for a substantial simplification.