### PR TITLE
config: Detect if running under valgrind

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -270,6 +270,10 @@ if test "$enable_debug" = "yes"; then
     fi
     AC_DEFINE(HAVE_BACKTRACE)
   ])
+
+  AC_CHECK_HEADER([valgrind/valgrind.h], [
+    AC_DEFINE([HAVE_VALGRIND], 1, [Define to 1 if you have valgrind installed])
+  ])
 else
   AC_MSG_NOTICE(Compiling without debug info...)
 fi

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -7,6 +7,9 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <sys/utsname.h>
+#ifdef HAVE_VALGRIND
+#include <valgrind/valgrind.h>
+#endif
 
 #include "version.h"
 #include "emu.h"
@@ -566,6 +569,13 @@ static void config_post_process(void)
 	config.cpuemu = 4;
 	c_printf("CONF: JIT CPUEMU set to 4 for %d86\n", (int)vm86s.cpu_type);
     }
+#ifdef HAVE_VALGRIND
+    if ((config.cpuemu != 3 || config.cpusim != 1) && RUNNING_ON_VALGRIND) {
+      config.cpuemu = 3;
+      config.cpusim = 1;
+      c_printf("CONF: Running under valgrind, forcing vm86sim\n");
+    }
+#endif
 #endif
     if (config.rdtsc) {
 	if (config.smp) {


### PR DESCRIPTION
Since running under valgrind currently requires cpu_emu == "vm86sim", if
we detect that we are running under it, force it without needing
dosemu.conf change. This doesn't add any extra library dependency, but
utilises a macro in the valgrind header file.
Tested on:
  32bit with valgrind
  64bit without valgrind