### PR TITLE
simx86: Fix offsetof calculation

### DIFF
--- a/src/emu-i386/simx86/codegen-x86.c
+++ b/src/emu-i386/simx86/codegen-x86.c
@@ -2737,7 +2737,7 @@ static void ProduceCode(unsigned int PC)
 	 *
 	 */
 	mall_req = GenBufSize + offsetof(CodeBuf, meta) +
-		sizeof(GenCodeBuf->meta) * nap + 32;// 32 for tail
+               sizeof(GenCodeBuf->meta[0]) * nap + 32;// 32 for tail
 	GenCodeBuf = dlmalloc(mall_req);
 	/* actual code buffer starts from here */
 	BaseGenBuf = CodePtr = (unsigned char *)&GenCodeBuf->meta[nap];


### PR DESCRIPTION
Need to get sizeof array element fixes OS crash mentioned in #691