### PR TITLE
 Rearrange / cleanup the order of the remapper definitions and functions #2

### DIFF
--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1576,7 +1576,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
     MODE_VGA_4,
     MODE_TRUE_8,
     gen_4to8_all,
@@ -1584,7 +1584,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
     MODE_VGA_4,
     MODE_PSEUDO_8,
     gen_4to8p_all,
@@ -1592,7 +1592,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
     MODE_VGA_4,
     MODE_TRUE_15 | MODE_TRUE_16,
     gen_4to16_all,
@@ -1600,7 +1600,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
     MODE_VGA_4,
     MODE_TRUE_24,
     gen_4to24_all,
@@ -1608,7 +1608,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
     MODE_VGA_4,
     MODE_TRUE_32,
     gen_4to32_all,
@@ -1616,7 +1616,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
     MODE_VGA_X | MODE_PSEUDO_8,
     MODE_TRUE_8,
     gen_8to8_all,
@@ -1624,7 +1624,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_1  | RFF_REMAP_RECT,
+    RFF_SCALE_1 | RFF_REMAP_RECT,
     MODE_PSEUDO_8,
     MODE_TRUE_8,
     gen_8to8_1,
@@ -1632,7 +1632,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
     MODE_VGA_X | MODE_PSEUDO_8,
     MODE_PSEUDO_8,
     gen_8to8p_all,
@@ -1640,7 +1640,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_1  | RFF_REMAP_LINES,
+    RFF_SCALE_1 | RFF_REMAP_LINES,
     MODE_PSEUDO_8,
     MODE_PSEUDO_8,
     gen_8to8p_1,
@@ -1648,7 +1648,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
     MODE_VGA_X | MODE_PSEUDO_8,
     MODE_TRUE_15 | MODE_TRUE_16,
     gen_8to16_all,
@@ -1656,7 +1656,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES | RFF_LIN_FILT,
+    RFF_SCALE_ALL | RFF_REMAP_LINES | RFF_LIN_FILT,
     MODE_PSEUDO_8,
     MODE_TRUE_15 | MODE_TRUE_16,
     gen_8to16_lin,
@@ -1664,7 +1664,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES | RFF_BILIN_FILT,
+    RFF_SCALE_ALL | RFF_REMAP_LINES | RFF_BILIN_FILT,
     MODE_PSEUDO_8,
     MODE_TRUE_15 | MODE_TRUE_16,
     gen_8to16_bilin,
@@ -1672,7 +1672,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
     MODE_VGA_X | MODE_PSEUDO_8,
     MODE_TRUE_24,
     gen_8to24_all,
@@ -1680,7 +1680,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
     MODE_VGA_X | MODE_PSEUDO_8,
     MODE_TRUE_32,
     gen_8to32_all,
@@ -1688,7 +1688,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_1  | RFF_REMAP_RECT,
+    RFF_SCALE_1 | RFF_REMAP_RECT,
     MODE_PSEUDO_8,
     MODE_TRUE_32,
     gen_8to32_1,
@@ -1696,7 +1696,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES | RFF_LIN_FILT,
+    RFF_SCALE_ALL | RFF_REMAP_LINES | RFF_LIN_FILT,
     MODE_PSEUDO_8,
     MODE_TRUE_32,
     gen_8to32_lin,
@@ -1704,7 +1704,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES | RFF_BILIN_FILT,
+    RFF_SCALE_ALL | RFF_REMAP_LINES | RFF_BILIN_FILT,
     MODE_PSEUDO_8,
     MODE_TRUE_32,
     gen_8to32_bilin,
@@ -1720,7 +1720,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_1  | RFF_REMAP_LINES,
+    RFF_SCALE_1 | RFF_REMAP_LINES,
     MODE_TRUE_15,
     MODE_TRUE_32,
     gen_15to32_1,
@@ -1728,7 +1728,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_1  | RFF_REMAP_LINES,
+    RFF_SCALE_1 | RFF_REMAP_LINES,
     MODE_TRUE_15,
     MODE_TRUE_15,
     gen_16to16_1,
@@ -1736,7 +1736,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_1  | RFF_REMAP_LINES,
+    RFF_SCALE_1 | RFF_REMAP_LINES,
     MODE_TRUE_16,
     MODE_TRUE_16,
     gen_16to16_1,
@@ -1752,7 +1752,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_1  | RFF_REMAP_LINES,
+    RFF_SCALE_1 | RFF_REMAP_LINES,
     MODE_TRUE_16,
     MODE_TRUE_32,
     gen_16to32_1,
@@ -1760,7 +1760,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_1  | RFF_REMAP_LINES,
+    RFF_SCALE_1 | RFF_REMAP_LINES,
     MODE_TRUE_24,
     MODE_TRUE_24,
     gen_24to24_1,
@@ -1768,7 +1768,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
     MODE_TRUE_24,
     MODE_TRUE_32,
     gen_24to32_all,
@@ -1776,7 +1776,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_1  | RFF_REMAP_LINES,
+    RFF_SCALE_1 | RFF_REMAP_LINES,
     MODE_TRUE_24,
     MODE_TRUE_32,
     gen_24to32_1,
@@ -1784,7 +1784,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
     MODE_TRUE_32,
     MODE_TRUE_32,
     gen_32to32_all,
@@ -1792,7 +1792,7 @@ static RemapFuncDesc remap_gen_list[] = {
   ),
 
   REMAP_DESC(
-    RFF_SCALE_1  | RFF_REMAP_LINES,
+    RFF_SCALE_1 | RFF_REMAP_LINES,
     MODE_TRUE_32,
     MODE_TRUE_32,
     gen_32to32_1,

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1783,21 +1783,19 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
-  // sort position (temporary comment)
+  REMAP_DESC(
+    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    MODE_TRUE_32,
+    MODE_TRUE_32,
+    gen_32to32_all,
+    NULL
+  ),
 
   REMAP_DESC(
     RFF_SCALE_1  | RFF_REMAP_LINES,
     MODE_TRUE_32,
     MODE_TRUE_32,
     gen_32to32_1,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
-    MODE_TRUE_32,
-    MODE_TRUE_32,
-    gen_32to32_all,
     NULL
   ),
 
@@ -2766,6 +2764,7 @@ void gen_8to16_all(RemapObject *ro)
     }
   }
 }
+
 /*
  * 8 bit pseudo color --> 15/16 bit true color
  * supports arbitrary scaling
@@ -3350,29 +3349,6 @@ void gen_24to32_1(RemapObject *ro)
   }
 }
 
-// sort position (temporary comment)
-
-/*
- * 32 bit true color --> 32 bit true color
- * Source format is BGR (see vesa.c:vbe_mode_info() )
- * *** ingnores color space description ***
- */
-void gen_32to32_1(RemapObject *ro)
-{
-  int i;
-  const unsigned char *src;
-  unsigned char *dst;
-
-  src = ro->src_image + ro->src_start + ro->src_offset;
-  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
-
-  for(i = ro->src_y0; i < ro->src_y1; i++) {
-    memcpy(dst, src, ro->src_width << 2);
-    src += ro->src_scan_len;
-    dst += ro->dst_scan_len;
-  }
-}
-
 /*
  * 32 bit true color --> 32 bit true color
  * supports arbitrary scaling
@@ -3401,6 +3377,27 @@ void gen_32to32_all(RemapObject *ro)
       dst_4[d_x++] = rgb_color_2int(ro->dst_color_space, 8, 8, 8, c);
       s_x += *(bre_x++);
     }
+  }
+}
+
+/*
+ * 32 bit true color --> 32 bit true color
+ * Source format is BGR (see vesa.c:vbe_mode_info() )
+ * *** ignores color space description ***
+ */
+void gen_32to32_1(RemapObject *ro)
+{
+  int i;
+  const unsigned char *src;
+  unsigned char *dst;
+
+  src = ro->src_image + ro->src_start + ro->src_offset;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+
+  for(i = ro->src_y0; i < ro->src_y1; i++) {
+    memcpy(dst, src, ro->src_width << 2);
+    src += ro->src_scan_len;
+    dst += ro->dst_scan_len;
   }
 }
 

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1599,6 +1599,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    MODE_VGA_4,
+    MODE_TRUE_24,
+    gen_4to24_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1694,14 +1702,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_PSEUDO_8,
     MODE_TRUE_15 | MODE_TRUE_16,
     gen_8to16_lin,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
-    MODE_VGA_4,
-    MODE_TRUE_24,
-    gen_4to24_all,
     NULL
   ),
 
@@ -2536,6 +2536,58 @@ void gen_4to16_all(RemapObject *ro)
   }
 }
 
+/*
+ * 4 bit pseudo color --> 24 bit true color
+ * supports arbitrary scaling
+ *
+ */
+void gen_4to24_all(RemapObject *ro)
+{
+  int d_x_len, s_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+
+  unsigned *dst1, *lut;
+  const unsigned char *src, *src0, *src_last;
+  unsigned char *dst, *src1;
+  unsigned color;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = (ro->dst_image + ro->dst_start + ro->dst_offset);
+  d_x_len = ro->dst_width *3;
+  s_x_len = ro->src_width >> 3;
+  src1 = ro->src_tmp_line;
+  dst1 = (unsigned *) src1;
+  lut = ro->bit_lut;
+  src_last = NULL;
+
+  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    if(src != src_last) {
+      src_last = src;
+      for(s_x = d_x = 0; s_x < s_x_len; s_x++, d_x += 2) {
+        dst1[d_x    ]  = lut[2 * src[s_x          ]            ] |
+                         lut[2 * src[s_x + 0x10000]     + 0x200] |
+                         lut[2 * src[s_x + 0x20000]     + 0x400] |
+                         lut[2 * src[s_x + 0x30000]     + 0x600];
+        dst1[d_x + 1]  = lut[2 * src[s_x          ] + 1        ] |
+                         lut[2 * src[s_x + 0x10000] + 1 + 0x200] |
+                         lut[2 * src[s_x + 0x20000] + 1 + 0x400] |
+                         lut[2 * src[s_x + 0x30000] + 1 + 0x600];
+      }
+    }
+    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
+      color = ro->true_color_lut[src1[s_x]];
+      dst[d_x++] = color & 0xFF;
+      dst[d_x++] = (color >> 8) & 0xFF;
+      dst[d_x++] = (color >> 16) & 0xFF;
+      s_x += *(bre_x++);
+    }
+  }
+}
+
 // sort position (temporary comment)
 
 
@@ -3031,60 +3083,6 @@ void gen_8to16_lin(RemapObject *ro)
     }
   }
 }
-
-/*
- * 4 bit pseudo color --> 24 bit true color
- * supports arbitrary scaling
- *
- */
-void gen_4to24_all(RemapObject *ro)
-{
-  int d_x_len, s_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-
-  unsigned *dst1, *lut;
-  const unsigned char *src, *src0, *src_last;
-  unsigned char *dst, *src1;
-  unsigned color;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = (ro->dst_image + ro->dst_start + ro->dst_offset);
-  d_x_len = ro->dst_width *3;
-  s_x_len = ro->src_width >> 3;
-  src1 = ro->src_tmp_line;
-  dst1 = (unsigned *) src1;
-  lut = ro->bit_lut;
-  src_last = NULL;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    if(src != src_last) {
-      src_last = src;
-      for(s_x = d_x = 0; s_x < s_x_len; s_x++, d_x += 2) {
-        dst1[d_x    ]  = lut[2 * src[s_x          ]            ] |
-                         lut[2 * src[s_x + 0x10000]     + 0x200] |
-                         lut[2 * src[s_x + 0x20000]     + 0x400] |
-                         lut[2 * src[s_x + 0x30000]     + 0x600];
-        dst1[d_x + 1]  = lut[2 * src[s_x          ] + 1        ] |
-                         lut[2 * src[s_x + 0x10000] + 1 + 0x200] |
-                         lut[2 * src[s_x + 0x20000] + 1 + 0x400] |
-                         lut[2 * src[s_x + 0x30000] + 1 + 0x600];
-      }
-    }
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      color = ro->true_color_lut[src1[s_x]];
-      dst[d_x++] = color & 0xFF;
-      dst[d_x++] = (color >> 8) & 0xFF;
-      dst[d_x++] = (color >> 16) & 0xFF;
-      s_x += *(bre_x++);
-    }
-  }
-}
-
-
 
 /*
  * 4 bit pseudo color --> 32 bit true color

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1727,23 +1727,23 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_1  | RFF_REMAP_LINES,
+    MODE_TRUE_15,
+    MODE_TRUE_15,
+    gen_16to16_1,
+    NULL
+  ),
+
+  REMAP_DESC(
+    RFF_SCALE_1  | RFF_REMAP_LINES,
+    MODE_TRUE_16,
+    MODE_TRUE_16,
+    gen_16to16_1,
+    NULL
+  ),
+
   // sort position (temporary comment)
-
-  REMAP_DESC(
-    RFF_SCALE_1  | RFF_REMAP_LINES,
-    MODE_TRUE_15,
-    MODE_TRUE_15,
-    gen_16to16_1,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_1  | RFF_REMAP_LINES,
-    MODE_TRUE_16,
-    MODE_TRUE_16,
-    gen_16to16_1,
-    NULL
-  ),
 
   REMAP_DESC(
     RFF_SCALE_1  | RFF_REMAP_LINES,
@@ -3182,13 +3182,11 @@ void gen_15to32_1(RemapObject *ro)
   }
 }
 
-// sort position (temporary comment)
-
 /*
  * 16 bit true color --> 16 bit true color
  * 15 bit true color --> 15 bit true color
  * Source format is BGR (see vesa.c:vbe_mode_info() )
- * *** ingnores color space description ***
+ * *** ignores color space description ***
  */
 void gen_16to16_1(RemapObject *ro)
 {
@@ -3206,6 +3204,7 @@ void gen_16to16_1(RemapObject *ro)
   }
 }
 
+// sort position (temporary comment)
 
 /*
  * 24 bit true color --> 24 bit true color

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1396,54 +1396,62 @@ static int _find_supported_modes(unsigned dst_mode)
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  */
 
-void gen_8to8p_1(RemapObject *);
-void gen_8to8p_all(RemapObject *);
-void gen_8to8_1(RemapObject *);
-void gen_8to8_all(RemapObject *);
-void gen_8to16_all(RemapObject *);
-void gen_8to24_all(RemapObject *);
-void gen_8to32_1(RemapObject *);
-void gen_8to32_all(RemapObject *);
-void gen_8to32_bilin(RemapObject *);
-void gen_8to16_bilin(RemapObject *);
-void gen_8to32_lin(RemapObject *);
-void gen_8to16_lin(RemapObject *);
-
-void gen_4to8p_all(RemapObject *);
-void gen_4to8_all(RemapObject *);
-void gen_4to16_all(RemapObject *);
-void gen_4to24_all(RemapObject *);
-void gen_4to32_all(RemapObject *);
-
-void gen_16to16_1(RemapObject *);
-void gen_24to24_1(RemapObject *);
-void gen_32to32_1(RemapObject *);
-void gen_32to32_all(RemapObject *);
-void gen_24to32_1(RemapObject *);
-void gen_24to32_all(RemapObject *);
-
-void gen_15to32_1(RemapObject *);
-void gen_15to32_all(RemapObject *);
-void gen_16to32_1(RemapObject *);
-void gen_16to32_all(RemapObject *);
-
-void gen_1to8p_all(RemapObject *);
 void gen_1to8_all(RemapObject *);
+void gen_1to8p_all(RemapObject *);
 void gen_1to16_all(RemapObject *);
 void gen_1to24_all(RemapObject *);
 void gen_1to32_all(RemapObject *);
 
-void gen_2to8p_all(RemapObject *);
 void gen_2to8_all(RemapObject *);
+void gen_2to8p_all(RemapObject *);
 void gen_2to16_all(RemapObject *);
 void gen_2to24_all(RemapObject *);
 void gen_2to32_all(RemapObject *);
 
-void gen_c2to8p_all(RemapObject *);
 void gen_c2to8_all(RemapObject *);
+void gen_c2to8p_all(RemapObject *);
 void gen_c2to16_all(RemapObject *);
 void gen_c2to24_all(RemapObject *);
 void gen_c2to32_all(RemapObject *);
+
+void gen_4to8_all(RemapObject *);
+void gen_4to8p_all(RemapObject *);
+void gen_4to16_all(RemapObject *);
+void gen_4to24_all(RemapObject *);
+void gen_4to32_all(RemapObject *);
+
+void gen_8to8_all(RemapObject *);
+void gen_8to8_1(RemapObject *);
+void gen_8to8p_all(RemapObject *);
+void gen_8to8p_1(RemapObject *);
+void gen_8to16_all(RemapObject *);
+void gen_8to16_lin(RemapObject *);
+void gen_8to16_bilin(RemapObject *);
+void gen_8to24_all(RemapObject *);
+void gen_8to32_all(RemapObject *);
+void gen_8to32_1(RemapObject *);
+void gen_8to32_lin(RemapObject *);
+void gen_8to32_bilin(RemapObject *);
+
+//void gen_15to16_all(RemapObject *);
+//void gen_15to24_all(RemapObject *);
+void gen_15to32_all(RemapObject *);
+void gen_15to32_1(RemapObject *);
+
+//void gen_16to16_all(RemapObject *);
+void gen_16to16_1(RemapObject *);
+//void gen_16to24_all(RemapObject *);
+void gen_16to32_all(RemapObject *);
+void gen_16to32_1(RemapObject *);
+
+//void gen_24to24_all(RemapObject *);
+void gen_24to24_1(RemapObject *);
+void gen_24to32_all(RemapObject *);
+void gen_24to32_1(RemapObject *);
+
+void gen_32to32_all(RemapObject *);
+void gen_32to32_1(RemapObject *);
+
 
 static RemapFuncDesc remap_gen_list[] = {
 

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1575,6 +1575,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    MODE_VGA_4,
+    MODE_TRUE_8,
+    gen_4to8_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1678,14 +1686,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_VGA_4,
     MODE_PSEUDO_8,
     gen_4to8p_all,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
-    MODE_VGA_4,
-    MODE_TRUE_8,
-    gen_4to8_all,
     NULL
   ),
 
@@ -2389,6 +2389,57 @@ void gen_c2to32_all(RemapObject *ro)
   }
 }
 
+/*
+ * 4 bit pseudo color --> 8 bit true color (shared color map)
+ * supports arbitrary scaling
+ *
+ */
+void gen_4to8_all(RemapObject *ro)
+{
+  int k;
+  int d_x_len, s_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+
+  const unsigned char *src, *src0, *src_last;
+  unsigned char *clut = (unsigned char*) ro->true_color_lut, *dst, *src1;
+  unsigned *dst1, *lut;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+  d_x_len = ro->dst_width;
+  s_x_len = ro->src_width >> 3;
+  src1 = ro->src_tmp_line;
+  dst1 = (unsigned *) src1;
+  lut = ro->bit_lut;
+  src_last = NULL;
+
+  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    k = (d_y & 1) << 1;
+    if(src != src_last) {
+      src_last = src;
+      for(s_x = d_x = 0; s_x < s_x_len; s_x++, d_x += 2) {
+        dst1[d_x    ]  = lut[2 * src[s_x          ]            ] |
+                         lut[2 * src[s_x + 0x10000]     + 0x200] |
+                         lut[2 * src[s_x + 0x20000]     + 0x400] |
+                         lut[2 * src[s_x + 0x30000]     + 0x600];
+        dst1[d_x + 1]  = lut[2 * src[s_x          ] + 1        ] |
+                         lut[2 * src[s_x + 0x10000] + 1 + 0x200] |
+                         lut[2 * src[s_x + 0x20000] + 1 + 0x400] |
+                         lut[2 * src[s_x + 0x30000] + 1 + 0x600];
+      }
+    }
+    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
+      dst[d_x++] = clut[4 * src1[s_x] + (k ^= 1)];
+      s_x += *(bre_x++);
+    }
+  }
+}
+
+
 // sort position (temporary comment)
 
 
@@ -2929,57 +2980,6 @@ void gen_4to8p_all(RemapObject *ro)
     }
     for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
       dst[d_x++] = src1[s_x];
-      s_x += *(bre_x++);
-    }
-  }
-}
-
-
-/*
- * 4 bit pseudo color --> 8 bit true color (shared color map)
- * supports arbitrary scaling
- *
- */
-void gen_4to8_all(RemapObject *ro)
-{
-  int k;
-  int d_x_len, s_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-
-  const unsigned char *src, *src0, *src_last;
-  unsigned char *clut = (unsigned char*) ro->true_color_lut, *dst, *src1;
-  unsigned *dst1, *lut;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
-  d_x_len = ro->dst_width;
-  s_x_len = ro->src_width >> 3;
-  src1 = ro->src_tmp_line;
-  dst1 = (unsigned *) src1;
-  lut = ro->bit_lut;
-  src_last = NULL;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    k = (d_y & 1) << 1;
-    if(src != src_last) {
-      src_last = src;
-      for(s_x = d_x = 0; s_x < s_x_len; s_x++, d_x += 2) {
-        dst1[d_x    ]  = lut[2 * src[s_x          ]            ] |
-                         lut[2 * src[s_x + 0x10000]     + 0x200] |
-                         lut[2 * src[s_x + 0x20000]     + 0x400] |
-                         lut[2 * src[s_x + 0x30000]     + 0x600];
-        dst1[d_x + 1]  = lut[2 * src[s_x          ] + 1        ] |
-                         lut[2 * src[s_x + 0x10000] + 1 + 0x200] |
-                         lut[2 * src[s_x + 0x20000] + 1 + 0x400] |
-                         lut[2 * src[s_x + 0x30000] + 1 + 0x600];
-      }
-    }
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      dst[d_x++] = clut[4 * src1[s_x] + (k ^= 1)];
       s_x += *(bre_x++);
     }
   }

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1551,6 +1551,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
+    MODE_CGA_2,
+    MODE_TRUE_15 | MODE_TRUE_16,
+    gen_c2to16_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1774,14 +1782,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_TRUE_16,
     MODE_TRUE_32,
     gen_16to32_all,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL | RFF_REMAP_LINES,
-    MODE_CGA_2,
-    MODE_TRUE_15 | MODE_TRUE_16,
-    gen_c2to16_all,
     NULL
   ),
 
@@ -2284,6 +2284,38 @@ void gen_c2to8p_all(RemapObject *ro)
       c0 >>= i;
       c0 &= 3;
       dst[d_x++] = c0;
+      s_x += *(bre_x++);
+    }
+  }
+}
+
+/*
+ * 2 bit CGA pseudo color --> 15/16 bit true color
+ * supports arbitrary scaling
+ *
+ * -- very basic and slow --
+ */
+void gen_c2to16_all(RemapObject *ro)
+{
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len >> 1;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+  unsigned char c0;
+
+  const unsigned char *src, *src0;
+  unsigned short *dst;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = (unsigned short *)(ro->dst_image + ro->dst_start + ro->dst_offset);
+  d_x_len = ro->dst_width;
+
+  for (d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    for (s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len;) {
+      c0 = (src[s_x >> 2] >> (2 * ((s_x & 3) ^ 3))) & 3;
+      dst[d_x++] = ro->true_color_lut[c0];
       s_x += *(bre_x++);
     }
   }
@@ -3326,39 +3358,6 @@ void gen_16to32_all(RemapObject *ro)
     }
   }
 }
-
-/*
- * 2 bit CGA pseudo color --> 15/16 bit true color
- * supports arbitrary scaling
- *
- * -- very basic and slow --
- */
-void gen_c2to16_all(RemapObject *ro)
-{
-  int d_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len >> 1;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-  unsigned char c0;
-
-  const unsigned char *src, *src0;
-  unsigned short *dst;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = (unsigned short *) (ro->dst_image + ro->dst_start + ro->dst_offset);
-  d_x_len = ro->dst_width;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      c0 = (src[s_x >> 2] >> (2 * ((s_x & 3) ^ 3))) & 3;
-      dst[d_x++] = ro->true_color_lut[c0];
-      s_x += *(bre_x++);
-    }
-  }
-}
-
 
 /*
  * 2 bit CGA pseudo color --> 24 bit true color

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1711,6 +1711,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
+    MODE_TRUE_15,
+    MODE_TRUE_32,
+    gen_15to32_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1774,14 +1782,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_TRUE_15,
     MODE_TRUE_32,
     gen_15to32_1,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL | RFF_REMAP_LINES,
-    MODE_TRUE_15,
-    MODE_TRUE_32,
-    gen_15to32_all,
     NULL
   ),
 
@@ -3118,6 +3118,38 @@ void gen_8to32_bilin(RemapObject *ro)
   }
 }
 
+/*
+ * 15 bit true color --> 32 bit true color
+ * supports arbitrary scaling
+ */
+void gen_15to32_all(RemapObject *ro)
+{
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+
+  const unsigned char *src, *src0;
+  unsigned char *dst;
+  const unsigned short *src_2;
+  unsigned *dst_4;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+  d_x_len = ro->dst_width;
+
+  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    src_2 = (const unsigned short *) src;
+    dst_4 = (unsigned *) dst;
+    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
+      dst_4[d_x++] = bgr_2int(ro->dst_color_space, 5, 5, 5, src_2[s_x]);
+      s_x += *(bre_x++);
+    }
+  }
+}
+
 // sort position (temporary comment)
 
 /*
@@ -3309,38 +3341,6 @@ void gen_15to32_1(RemapObject *ro)
 
     src += ro->src_scan_len;
     dst += ro->dst_scan_len;
-  }
-}
-
-/*
- * 15 bit true color --> 32 bit true color
- * supports arbitrary scaling
- */
-void gen_15to32_all(RemapObject *ro)
-{
-  int d_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-
-  const unsigned char *src, *src0;
-  unsigned char *dst;
-  const unsigned short *src_2;
-  unsigned *dst_4;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
-  d_x_len = ro->dst_width;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    src_2 = (const unsigned short *) src;
-    dst_4 = (unsigned *) dst;
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      dst_4[d_x++] = bgr_2int(ro->dst_color_space, 5, 5, 5, src_2[s_x]);
-      s_x += *(bre_x++);
-    }
   }
 }
 

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1527,6 +1527,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
+    MODE_VGA_2,
+    MODE_TRUE_32,
+    gen_2to32_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1750,14 +1758,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_TRUE_16,
     MODE_TRUE_32,
     gen_16to32_all,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL | RFF_REMAP_LINES,
-    MODE_VGA_2,
-    MODE_TRUE_32,
-    gen_2to32_all,
     NULL
   ),
 
@@ -2167,6 +2167,47 @@ void gen_2to24_all(RemapObject *ro)
       dst[d_x++] = color & 0xFF;
       dst[d_x++] = (color >> 8) & 0xFF;
       dst[d_x++] = (color >> 16) & 0xFF;
+      s_x += *(bre_x++);
+    }
+  }
+}
+
+/*
+ * 2 bit VGA pseudo color --> 32 bit true color
+ * supports arbitrary scaling
+ *
+ * -- very basic and slow --
+ */
+void gen_2to32_all(RemapObject *ro)
+{
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len >> 2;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+  unsigned char c0, c1;
+  int i;
+
+  const unsigned char *src, *src0;
+  unsigned *dst;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = (unsigned *)(ro->dst_image + ro->dst_start + ro->dst_offset);
+  d_x_len = ro->dst_width;
+
+  for (d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    for (s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len;) {
+      i = s_x >> 3;
+      c0 = src[i];
+      c1 = src[i + 0x20000];
+      i = (s_x & 7) ^ 7;
+      c0 >>= i;
+      c1 >>= i;
+      c0 &= 1;
+      c1 &= 1;
+      c0 |= c1 << 1;
+      dst[d_x++] = ro->true_color_lut[c0];
       s_x += *(bre_x++);
     }
   }
@@ -3209,46 +3250,6 @@ void gen_16to32_all(RemapObject *ro)
     }
   }
 }
-
-/*
- * 2 bit VGA pseudo color --> 32 bit true color
- * supports arbitrary scaling
- *
- * -- very basic and slow --
- */
-void gen_2to32_all(RemapObject *ro)
-{
-  int d_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len >> 2;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-  unsigned char c0, c1;
-  int i;
-
-
-  const unsigned char *src, *src0;
-  unsigned *dst;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = (unsigned *) (ro->dst_image + ro->dst_start + ro->dst_offset);
-  d_x_len = ro->dst_width;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      i = s_x >> 3;
-      c0 = src[i]; c1 = src[i + 0x20000];
-      i = (s_x & 7) ^ 7;
-      c0 >>= i; c1 >>= i;
-      c0 &= 1; c1 &= 1;;
-      c0 |= c1 << 1;
-      dst[d_x++] = ro->true_color_lut[c0];
-      s_x += *(bre_x++);
-    }
-  }
-}
-
 
 /*
  * 2 bit CGA pseudo color --> 8 bit pseudo color (private color map)

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1567,6 +1567,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
+    MODE_CGA_2,
+    MODE_TRUE_32,
+    gen_c2to32_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1790,14 +1798,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_TRUE_16,
     MODE_TRUE_32,
     gen_16to32_all,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL | RFF_REMAP_LINES,
-    MODE_CGA_2,
-    MODE_TRUE_32,
-    gen_c2to32_all,
     NULL
   ),
 
@@ -2352,6 +2352,38 @@ void gen_c2to24_all(RemapObject *ro)
       dst[d_x++] = color & 0xFF;
       dst[d_x++] = (color >> 8) & 0xFF;
       dst[d_x++] = (color >> 16) & 0xFF;
+      s_x += *(bre_x++);
+    }
+  }
+}
+
+/*
+ * 2 bit CGA pseudo color --> 32 bit true color
+ * supports arbitrary scaling
+ *
+ * -- very basic and slow --
+ */
+void gen_c2to32_all(RemapObject *ro)
+{
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len >> 2;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+  unsigned char c0;
+
+  const unsigned char *src, *src0;
+  unsigned *dst;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = (unsigned *)(ro->dst_image + ro->dst_start + ro->dst_offset);
+  d_x_len = ro->dst_width;
+
+  for (d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    for (s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len;) {
+      c0 = (src[s_x >> 2] >> (2 * ((s_x & 3) ^ 3))) & 3;
+      dst[d_x++] = ro->true_color_lut[c0];
       s_x += *(bre_x++);
     }
   }
@@ -3394,39 +3426,6 @@ void gen_16to32_all(RemapObject *ro)
     }
   }
 }
-
-/*
- * 2 bit CGA pseudo color --> 32 bit true color
- * supports arbitrary scaling
- *
- * -- very basic and slow --
- */
-void gen_c2to32_all(RemapObject *ro)
-{
-  int d_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len >> 2;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-  unsigned char c0;
-
-  const unsigned char *src, *src0;
-  unsigned *dst;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = (unsigned *) (ro->dst_image + ro->dst_start + ro->dst_offset);
-  d_x_len = ro->dst_width;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      c0 = (src[s_x >> 2] >> (2 * ((s_x & 3) ^ 3))) & 3;
-      dst[d_x++] = ro->true_color_lut[c0];
-      s_x += *(bre_x++);
-    }
-  }
-}
-
 
 #define RO(p) (*(RemapObject **)p)
 

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1671,8 +1671,6 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
-  // sort position (temporary comment)
-
   REMAP_DESC(
     RFF_SCALE_ALL  | RFF_REMAP_LINES,
     MODE_VGA_X | MODE_PSEUDO_8,
@@ -1680,6 +1678,8 @@ static RemapFuncDesc remap_gen_list[] = {
     gen_8to24_all,
     NULL
   ),
+
+  // sort position (temporary comment)
 
   REMAP_DESC(
     RFF_SCALE_1  | RFF_REMAP_RECT,
@@ -2901,9 +2901,6 @@ void gen_8to16_bilin(RemapObject *ro)
   }
 }
 
-// sort position (temporary comment)
-
-
 /*
  * 8 bit pseudo color --> 24 bit true color
  * supports arbitrary scaling
@@ -2936,6 +2933,7 @@ void gen_8to24_all(RemapObject *ro)
   }
 }
 
+// sort position (temporary comment)
 
 /*
  * 8 bit pseudo color --> 32 bit true color

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1767,6 +1767,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    MODE_TRUE_24,
+    MODE_TRUE_32,
+    gen_24to32_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1790,14 +1798,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_TRUE_24,
     MODE_TRUE_32,
     gen_24to32_1,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
-    MODE_TRUE_24,
-    MODE_TRUE_32,
-    gen_24to32_all,
     NULL
   ),
 
@@ -3289,6 +3289,37 @@ void gen_24to24_1(RemapObject *ro)
   }
 }
 
+/*
+ * 24 bit true color --> 32 bit true color
+ * supports arbitrary scaling
+ */
+void gen_24to32_all(RemapObject *ro)
+{
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+
+  const unsigned char *src, *src0;
+  unsigned char *dst;
+  unsigned *dst_4;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+  d_x_len = ro->dst_width;
+
+  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    dst_4 = (unsigned *) dst;
+    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
+      RGBColor c = { src[s_x * 3 + 2], src[s_x * 3 + 1], src[s_x * 3] };
+      dst_4[d_x++] = rgb_color_2int(ro->dst_color_space, 8, 8, 8, c);
+      s_x += *(bre_x++);
+    }
+  }
+}
+
 // sort position (temporary comment)
 
 /*
@@ -3371,37 +3402,6 @@ void gen_24to32_1(RemapObject *ro)
 
     src += ro->src_scan_len;
     dst += ro->dst_scan_len;
-  }
-}
-
-/*
- * 24 bit true color --> 32 bit true color
- * supports arbitrary scaling
- */
-void gen_24to32_all(RemapObject *ro)
-{
-  int d_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-
-  const unsigned char *src, *src0;
-  unsigned char *dst;
-  unsigned *dst_4;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
-  d_x_len = ro->dst_width;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    dst_4 = (unsigned *) dst;
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      RGBColor c = { src[s_x * 3 + 2], src[s_x * 3 + 1], src[s_x * 3] };
-      dst_4[d_x++] = rgb_color_2int(ro->dst_color_space, 8, 8, 8, c);
-      s_x += *(bre_x++);
-    }
   }
 }
 

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1511,6 +1511,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
+    MODE_VGA_2,
+    MODE_TRUE_15 | MODE_TRUE_16,
+    gen_2to16_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1734,14 +1742,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_TRUE_16,
     MODE_TRUE_32,
     gen_16to32_all,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL | RFF_REMAP_LINES,
-    MODE_VGA_2,
-    MODE_TRUE_15 | MODE_TRUE_16,
-    gen_2to16_all,
     NULL
   ),
 
@@ -2081,6 +2081,47 @@ void gen_2to8p_all(RemapObject *ro)
       c1 &= 1;
       c0 |= c1 << 1;
       dst[d_x++] = c0;
+      s_x += *(bre_x++);
+    }
+  }
+}
+
+/*
+ * 2 bit VGA pseudo color --> 15/16 bit true color
+ * supports arbitrary scaling
+ *
+ * -- very basic and slow --
+ */
+void gen_2to16_all(RemapObject *ro)
+{
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len >> 1;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+  unsigned char c0, c1;
+  int i;
+
+  const unsigned char *src, *src0;
+  unsigned short *dst;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = (unsigned short *)(ro->dst_image + ro->dst_start + ro->dst_offset);
+  d_x_len = ro->dst_width;
+
+  for (d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    for (s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len;) {
+      i = s_x >> 3;
+      c0 = src[i];
+      c1 = src[i + 0x20000];
+      i = (s_x & 7) ^ 7;
+      c0 >>= i;
+      c1 >>= i;
+      c0 &= 1;
+      c1 &= 1;
+      c0 |= (c1 << 1);
+      dst[d_x++] = ro->true_color_lut[c0];
       s_x += *(bre_x++);
     }
   }
@@ -3123,45 +3164,6 @@ void gen_16to32_all(RemapObject *ro)
     }
   }
 }
-
-/*
- * 2 bit VGA pseudo color --> 15/16 bit true color
- * supports arbitrary scaling
- *
- * -- very basic and slow --
- */
-void gen_2to16_all(RemapObject *ro)
-{
-  int d_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len >> 1;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-  unsigned char c0, c1;
-  int i;
-
-  const unsigned char *src, *src0;
-  unsigned short *dst;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = (unsigned short *) (ro->dst_image + ro->dst_start + ro->dst_offset);
-  d_x_len = ro->dst_width;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      i = s_x >> 3;
-      c0 = src[i]; c1 = src[i + 0x20000];
-      i = (s_x & 7) ^ 7;
-      c0 >>= i; c1 >>= i;
-      c0 &= 1; c1 &= 1;
-      c0 |= (c1 << 1);
-      dst[d_x++] = ro->true_color_lut[c0];
-      s_x += *(bre_x++);
-    }
-  }
-}
-
 
 /*
  * 2 bit VGA pseudo color --> 24 bit true color

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1591,6 +1591,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    MODE_VGA_4,
+    MODE_TRUE_15 | MODE_TRUE_16,
+    gen_4to16_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1686,14 +1694,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_PSEUDO_8,
     MODE_TRUE_15 | MODE_TRUE_16,
     gen_8to16_lin,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
-    MODE_VGA_4,
-    MODE_TRUE_15 | MODE_TRUE_16,
-    gen_4to16_all,
     NULL
   ),
 
@@ -2487,6 +2487,55 @@ void gen_4to8p_all(RemapObject *ro)
   }
 }
 
+/*
+ * 4 bit pseudo color --> 15/16 bit true color
+ * supports arbitrary scaling
+ *
+ */
+void gen_4to16_all(RemapObject *ro)
+{
+  int d_x_len, s_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len >> 1;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+
+  const unsigned char *src, *src0, *src_last;
+  unsigned char *src1;
+  unsigned short *dst;
+  unsigned *dst1, *lut;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = (unsigned short *) (ro->dst_image + ro->dst_start + ro->dst_offset);
+  d_x_len = ro->dst_width;
+  s_x_len = ro->src_width >> 3;
+  src1 = ro->src_tmp_line;
+  dst1 = (unsigned *) src1;
+  lut = ro->bit_lut;
+  src_last = NULL;
+
+  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    if(src != src_last) {
+      src_last = src;
+      for(s_x = d_x = 0; s_x < s_x_len; s_x++, d_x += 2) {
+        dst1[d_x    ]  = lut[2 * src[s_x          ]            ] |
+                         lut[2 * src[s_x + 0x10000]     + 0x200] |
+                         lut[2 * src[s_x + 0x20000]     + 0x400] |
+                         lut[2 * src[s_x + 0x30000]     + 0x600];
+        dst1[d_x + 1]  = lut[2 * src[s_x          ] + 1        ] |
+                         lut[2 * src[s_x + 0x10000] + 1 + 0x200] |
+                         lut[2 * src[s_x + 0x20000] + 1 + 0x400] |
+                         lut[2 * src[s_x + 0x30000] + 1 + 0x600];
+      }
+    }
+    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
+      dst[d_x++] = ro->true_color_lut[src1[s_x]];
+      s_x += *(bre_x++);
+    }
+  }
+}
+
 // sort position (temporary comment)
 
 
@@ -2978,56 +3027,6 @@ void gen_8to16_lin(RemapObject *ro)
         default:
           fprintf(stderr, "***** oops\n");
       }
-      s_x += *(bre_x++);
-    }
-  }
-}
-
-
-/*
- * 4 bit pseudo color --> 15/16 bit true color
- * supports arbitrary scaling
- *
- */
-void gen_4to16_all(RemapObject *ro)
-{
-  int d_x_len, s_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len >> 1;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-
-  const unsigned char *src, *src0, *src_last;
-  unsigned char *src1;
-  unsigned short *dst;
-  unsigned *dst1, *lut;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = (unsigned short *) (ro->dst_image + ro->dst_start + ro->dst_offset);
-  d_x_len = ro->dst_width;
-  s_x_len = ro->src_width >> 3;
-  src1 = ro->src_tmp_line;
-  dst1 = (unsigned *) src1;
-  lut = ro->bit_lut;
-  src_last = NULL;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    if(src != src_last) {
-      src_last = src;
-      for(s_x = d_x = 0; s_x < s_x_len; s_x++, d_x += 2) {
-        dst1[d_x    ]  = lut[2 * src[s_x          ]            ] |
-                         lut[2 * src[s_x + 0x10000]     + 0x200] |
-                         lut[2 * src[s_x + 0x20000]     + 0x400] |
-                         lut[2 * src[s_x + 0x30000]     + 0x600];
-        dst1[d_x + 1]  = lut[2 * src[s_x          ] + 1        ] |
-                         lut[2 * src[s_x + 0x10000] + 1 + 0x200] |
-                         lut[2 * src[s_x + 0x20000] + 1 + 0x400] |
-                         lut[2 * src[s_x + 0x30000] + 1 + 0x600];
-      }
-    }
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      dst[d_x++] = ro->true_color_lut[src1[s_x]];
       s_x += *(bre_x++);
     }
   }

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1639,8 +1639,6 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
-  // sort position (temporary comment)
-
   REMAP_DESC(
     RFF_SCALE_1  | RFF_REMAP_LINES,
     MODE_PSEUDO_8,
@@ -1648,6 +1646,8 @@ static RemapFuncDesc remap_gen_list[] = {
     gen_8to8p_1,
     NULL
   ),
+
+  // sort position (temporary comment)
 
   REMAP_DESC(
     RFF_SCALE_ALL  | RFF_REMAP_LINES,
@@ -2720,9 +2720,6 @@ void gen_8to8p_all(RemapObject *ro)
   }
 }
 
-// sort position (temporary comment)
-
-
 /*
  * 8 bit pseudo color --> 8 bit pseudo color (private color map)
  */
@@ -2741,6 +2738,9 @@ void gen_8to8p_1(RemapObject *ro)
     dst += ro->dst_scan_len;
   }
 }
+
+// sort position (temporary comment)
+
 
 /*
  * 8 bit pseudo color --> 15/16 bit true color

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1647,8 +1647,6 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
-  // sort position (temporary comment)
-
   REMAP_DESC(
     RFF_SCALE_ALL  | RFF_REMAP_LINES,
     MODE_VGA_X | MODE_PSEUDO_8,
@@ -1656,6 +1654,8 @@ static RemapFuncDesc remap_gen_list[] = {
     gen_8to16_all,
     NULL
   ),
+
+  // sort position (temporary comment)
 
   REMAP_DESC(
     RFF_SCALE_ALL  | RFF_REMAP_LINES,
@@ -2739,9 +2739,6 @@ void gen_8to8p_1(RemapObject *ro)
   }
 }
 
-// sort position (temporary comment)
-
-
 /*
  * 8 bit pseudo color --> 15/16 bit true color
  * supports arbitrary scaling
@@ -2769,6 +2766,8 @@ void gen_8to16_all(RemapObject *ro)
     }
   }
 }
+
+// sort position (temporary comment)
 
 
 /*

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1703,8 +1703,6 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
-  // sort position (temporary comment)
-
   REMAP_DESC(
     RFF_SCALE_ALL  | RFF_REMAP_LINES | RFF_BILIN_FILT,
     MODE_PSEUDO_8,
@@ -1712,6 +1710,8 @@ static RemapFuncDesc remap_gen_list[] = {
     gen_8to32_bilin,
     NULL
   ),
+
+  // sort position (temporary comment)
 
   REMAP_DESC(
     RFF_SCALE_1  | RFF_REMAP_LINES,
@@ -3023,8 +3023,6 @@ void gen_8to32_lin(RemapObject *ro)
   }
 }
 
-// sort position (temporary comment)
-
 /*
  * 8 bit pseudo color --> 32 bit true color
  * supports arbitrary scaling
@@ -3119,6 +3117,8 @@ void gen_8to32_bilin(RemapObject *ro)
 
   }
 }
+
+// sort position (temporary comment)
 
 /*
  * 16 bit true color --> 16 bit true color

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1543,6 +1543,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
+    MODE_CGA_2,
+    MODE_PSEUDO_8,
+    gen_c2to8p_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1766,14 +1774,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_TRUE_16,
     MODE_TRUE_32,
     gen_16to32_all,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL | RFF_REMAP_LINES,
-    MODE_CGA_2,
-    MODE_PSEUDO_8,
-    gen_c2to8p_all,
     NULL
   ),
 
@@ -2247,6 +2247,43 @@ void gen_c2to8_all(RemapObject *ro)
       c0 >>= i;
       c0 &= 3;
       dst[d_x++] = lut[4 * c0 + (k ^= 1)];
+      s_x += *(bre_x++);
+    }
+  }
+}
+
+/*
+ * 2 bit CGA pseudo color --> 8 bit pseudo color (private color map)
+ * supports arbitrary scaling
+ *
+ * -- very basic and slow --
+ */
+void gen_c2to8p_all(RemapObject *ro)
+{
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+  unsigned char c0;
+  int i;
+
+  const unsigned char *src, *src0;
+  unsigned char *dst;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+  d_x_len = ro->dst_width;
+
+  for (d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    for (s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len;) {
+      i = s_x >> 2;
+      c0 = src[i];
+      i = 2 * ((s_x & 3) ^ 3);
+      c0 >>= i;
+      c0 &= 3;
+      dst[d_x++] = c0;
       s_x += *(bre_x++);
     }
   }
@@ -3289,42 +3326,6 @@ void gen_16to32_all(RemapObject *ro)
     }
   }
 }
-
-/*
- * 2 bit CGA pseudo color --> 8 bit pseudo color (private color map)
- * supports arbitrary scaling
- *
- * -- very basic and slow --
- */
-void gen_c2to8p_all(RemapObject *ro)
-{
-  int d_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-  unsigned char c0;
-  int i;
-
-  const unsigned char *src, *src0;
-  unsigned char *dst;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
-  d_x_len = ro->dst_width;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      i = s_x >> 2;
-      c0 = src[i];
-      i = 2 * ((s_x & 3) ^ 3); c0 >>= i; c0 &= 3;
-      dst[d_x++] = c0;
-      s_x += *(bre_x++);
-    }
-  }
-}
-
 
 /*
  * 2 bit CGA pseudo color --> 15/16 bit true color

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1487,6 +1487,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
+    MODE_VGA_1 | MODE_CGA_1 | MODE_HERC,
+    MODE_TRUE_32,
+    gen_1to32_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1710,14 +1718,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_TRUE_16,
     MODE_TRUE_32,
     gen_16to32_all,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL | RFF_REMAP_LINES,
-    MODE_VGA_1 | MODE_CGA_1 | MODE_HERC,
-    MODE_TRUE_32,
-    gen_1to32_all,
     NULL
   ),
 
@@ -1965,6 +1965,38 @@ void gen_1to24_all(RemapObject *ro)
       dst[d_x++] = color & 0xFF;
       dst[d_x++] = (color >> 8) & 0xFF;
       dst[d_x++] = (color >> 16) & 0xFF;
+      s_x += *(bre_x++);
+    }
+  }
+}
+
+/*
+ * 1 bit pseudo color --> 32 bit true color
+ * supports arbitrary scaling
+ *
+ * -- very basic and slow --
+ */
+void gen_1to32_all(RemapObject *ro)
+{
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len >> 2;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+  unsigned char c0;
+
+  const unsigned char *src, *src0;
+  unsigned *dst;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = (unsigned *)(ro->dst_image + ro->dst_start + ro->dst_offset);
+  d_x_len = ro->dst_width;
+
+  for (d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    for (s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len;) {
+      c0 = (src[s_x >> 3] >> ((s_x & 7) ^ 7)) & 1;
+      dst[d_x++] = ro->true_color_lut[c0];
       s_x += *(bre_x++);
     }
   }
@@ -3007,40 +3039,6 @@ void gen_16to32_all(RemapObject *ro)
     }
   }
 }
-
-/*
- * 1 bit pseudo color --> 32 bit true color
- * supports arbitrary scaling
- *
- * -- very basic and slow --
- */
-void gen_1to32_all(RemapObject *ro)
-{
-  int d_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len >> 2;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-  unsigned char c0;
-
-  const unsigned char *src, *src0;
-  unsigned *dst;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = (unsigned *) (ro->dst_image + ro->dst_start + ro->dst_offset);
-  d_x_len = ro->dst_width;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      c0 = (src[s_x >> 3] >> ((s_x & 7) ^ 7)) & 1;
-      dst[d_x++] = ro->true_color_lut[c0];
-      s_x += *(bre_x++);
-    }
-  }
-}
-
-
 
 /*
  * 2 bit VGA pseudo color --> 8 bit pseudo color (private color map)

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1631,6 +1631,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    MODE_VGA_X | MODE_PSEUDO_8,
+    MODE_PSEUDO_8,
+    gen_8to8p_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1638,14 +1646,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_PSEUDO_8,
     MODE_PSEUDO_8,
     gen_8to8p_1,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
-    MODE_VGA_X | MODE_PSEUDO_8,
-    MODE_PSEUDO_8,
-    gen_8to8p_all,
     NULL
   ),
 
@@ -2692,29 +2692,6 @@ void gen_8to8_1(RemapObject *ro)
   }
 }
 
-// sort position (temporary comment)
-
-
-/*
- * 8 bit pseudo color --> 8 bit pseudo color (private color map)
- */
-void gen_8to8p_1(RemapObject *ro)
-{
-  int i;
-  const unsigned char *src;
-  unsigned char *dst;
-
-  src = ro->src_image + ro->src_start + ro->src_offset;
-  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
-
-  for(i = ro->src_y0; i < ro->src_y1; i++) {
-    memcpy(dst, src, ro->src_width);
-    src += ro->src_scan_len;
-    dst += ro->dst_scan_len;
-  }
-}
-
-
 /*
  * 8 bit pseudo color --> 8 bit pseudo color (private color map)
  * supports arbitrary scaling
@@ -2740,6 +2717,28 @@ void gen_8to8p_all(RemapObject *ro)
       dst[d_x++] = src[s_x];
       s_x += *(bre_x++);
     }
+  }
+}
+
+// sort position (temporary comment)
+
+
+/*
+ * 8 bit pseudo color --> 8 bit pseudo color (private color map)
+ */
+void gen_8to8p_1(RemapObject *ro)
+{
+  int i;
+  const unsigned char *src;
+  unsigned char *dst;
+
+  src = ro->src_image + ro->src_start + ro->src_offset;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+
+  for(i = ro->src_y0; i < ro->src_y1; i++) {
+    memcpy(dst, src, ro->src_width);
+    src += ro->src_scan_len;
+    dst += ro->dst_scan_len;
   }
 }
 

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1623,6 +1623,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_1  | RFF_REMAP_RECT,
+    MODE_PSEUDO_8,
+    MODE_TRUE_8,
+    gen_8to8_1,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1638,14 +1646,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_VGA_X | MODE_PSEUDO_8,
     MODE_PSEUDO_8,
     gen_8to8p_all,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_1  | RFF_REMAP_RECT,
-    MODE_PSEUDO_8,
-    MODE_TRUE_8,
-    gen_8to8_1,
     NULL
   ),
 
@@ -2667,6 +2667,31 @@ void gen_8to8_all(RemapObject *ro)
   }
 }
 
+/*
+ * 8 bit pseudo color --> 8 bit true color (shared color map)
+ */
+void gen_8to8_1(RemapObject *ro)
+{
+  int i, j, l, k;
+  const unsigned char *src;
+  unsigned char *dst;
+  unsigned char *lut = (unsigned char *)ro->true_color_lut;
+
+  src = ro->src_image + ro->src_start + ro->src_offset;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+
+  l = ro->src_x1 - ro->src_x0;
+
+  for (j = ro->src_y0; j < ro->src_y1; j++) {
+    k = (j & 1) << 1;
+    for (i = 0; i < l; i++) {
+      dst[i] = lut[4 * src[i] + (k ^= 1)];
+    }
+    dst += ro->dst_scan_len;
+    src += ro->src_scan_len;
+  }
+}
+
 // sort position (temporary comment)
 
 
@@ -2715,32 +2740,6 @@ void gen_8to8p_all(RemapObject *ro)
       dst[d_x++] = src[s_x];
       s_x += *(bre_x++);
     }
-  }
-}
-
-
-/*
- * 8 bit pseudo color --> 8 bit true color (shared color map)
- */
-void gen_8to8_1(RemapObject *ro)
-{
-  int i, j, l, k;
-  const unsigned char *src;
-  unsigned char *dst;
-  unsigned char *lut = (unsigned char*) ro->true_color_lut;
-
-  src = ro->src_image + ro->src_start + ro->src_offset;
-  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
-
-  l = ro->src_x1 - ro->src_x0;
-
-  for(j = ro->src_y0; j < ro->src_y1; j++) {
-    k = (j & 1) << 1;
-    for(i = 0; i < l; i++) {
-      dst[i] = lut[4 * src[i] + (k ^= 1)];
-    }
-    dst += ro->dst_scan_len;
-    src += ro->src_scan_len;
   }
 }
 

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1759,8 +1759,6 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
-  // sort position (temporary comment)
-
   REMAP_DESC(
     RFF_SCALE_1  | RFF_REMAP_LINES,
     MODE_TRUE_24,
@@ -1768,6 +1766,8 @@ static RemapFuncDesc remap_gen_list[] = {
     gen_24to24_1,
     NULL
   ),
+
+  // sort position (temporary comment)
 
   REMAP_DESC(
     RFF_SCALE_1  | RFF_REMAP_LINES,
@@ -3268,12 +3268,10 @@ void gen_16to32_1(RemapObject *ro)
   }
 }
 
-// sort position (temporary comment)
-
 /*
  * 24 bit true color --> 24 bit true color
  * Source format is BGR (see vesa.c:vbe_mode_info() )
- * *** ingnores color space description ***
+ * *** ignores color space description ***
  */
 void gen_24to24_1(RemapObject *ro)
 {
@@ -3291,6 +3289,7 @@ void gen_24to24_1(RemapObject *ro)
   }
 }
 
+// sort position (temporary comment)
 
 /*
  * 32 bit true color --> 32 bit true color

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1679,6 +1679,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    MODE_VGA_X | MODE_PSEUDO_8,
+    MODE_TRUE_32,
+    gen_8to32_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1686,14 +1694,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_PSEUDO_8,
     MODE_TRUE_32,
     gen_8to32_1,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
-    MODE_VGA_X | MODE_PSEUDO_8,
-    MODE_TRUE_32,
-    gen_8to32_all,
     NULL
   ),
 
@@ -2933,31 +2933,6 @@ void gen_8to24_all(RemapObject *ro)
   }
 }
 
-// sort position (temporary comment)
-
-/*
- * 8 bit pseudo color --> 32 bit true color
- */
-void gen_8to32_1(RemapObject *ro)
-{
-  int i, j, l;
-  const unsigned char *src;
-  unsigned *dst;
-
-  src = ro->src_image + ro->src_start + ro->src_offset;
-  dst = (unsigned *) (ro->dst_image + ro->dst_start + ro->dst_offset);
-  l = (ro->src_x1 - ro->src_x0);
-
-  for(j = ro->src_y0; j < ro->src_y1; j++) {
-    for(i = 0; i < l; i++) {
-      dst[i] = ro->true_color_lut[src[i]];
-    }
-    dst += ro->dst_scan_len >> 2;
-    src += ro->src_scan_len;
-  }
-}
-
-
 /*
  * 8 bit pseudo color --> 32 bit true color
  * supports arbitrary scaling
@@ -2986,6 +2961,29 @@ void gen_8to32_all(RemapObject *ro)
   }
 }
 
+// sort position (temporary comment)
+
+/*
+ * 8 bit pseudo color --> 32 bit true color
+ */
+void gen_8to32_1(RemapObject *ro)
+{
+  int i, j, l;
+  const unsigned char *src;
+  unsigned *dst;
+
+  src = ro->src_image + ro->src_start + ro->src_offset;
+  dst = (unsigned *) (ro->dst_image + ro->dst_start + ro->dst_offset);
+  l = (ro->src_x1 - ro->src_x0);
+
+  for(j = ro->src_y0; j < ro->src_y1; j++) {
+    for(i = 0; i < l; i++) {
+      dst[i] = ro->true_color_lut[src[i]];
+    }
+    dst += ro->dst_scan_len >> 2;
+    src += ro->src_scan_len;
+  }
+}
 
 /*
  * 8 bit pseudo color --> 32 bit true color

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1719,6 +1719,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_1  | RFF_REMAP_LINES,
+    MODE_TRUE_15,
+    MODE_TRUE_32,
+    gen_15to32_1,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1774,14 +1782,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_TRUE_24,
     MODE_TRUE_32,
     gen_24to32_all,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_1  | RFF_REMAP_LINES,
-    MODE_TRUE_15,
-    MODE_TRUE_32,
-    gen_15to32_1,
     NULL
   ),
 
@@ -3150,6 +3150,38 @@ void gen_15to32_all(RemapObject *ro)
   }
 }
 
+/*
+ * 15 bit true color --> 32 bit true color
+ * Source format is BGR (see vesa.c:vbe_mode_info() )
+ */
+void gen_15to32_1(RemapObject *ro)
+{
+  int i, j;
+  const unsigned char *src;
+  unsigned char *dst;
+  const unsigned short *src_2;
+  unsigned *dst_4;
+
+  src = ro->src_image + ro->src_start + ro->src_offset;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+
+  for(i = ro->src_y0; i < ro->src_y1; i++) {
+    src_2 = (const unsigned short *)src;
+    dst_4 = (unsigned *) dst;
+
+    for(j = 0; j < ro->dst_width; j++) {
+      // get 5-bit color values
+      // (green channel is cut between two byte values)
+      //  [0] gggbbbbb
+      //  [1] 0rrrrrgg
+      *dst_4++ = bgr_2int(ro->dst_color_space, 5, 5, 5, *src_2++);
+    }
+
+    src += ro->src_scan_len;
+    dst += ro->dst_scan_len;
+  }
+}
+
 // sort position (temporary comment)
 
 /*
@@ -3308,39 +3340,6 @@ void gen_24to32_all(RemapObject *ro)
       dst_4[d_x++] = rgb_color_2int(ro->dst_color_space, 8, 8, 8, c);
       s_x += *(bre_x++);
     }
-  }
-}
-
-
-/*
- * 15 bit true color --> 32 bit true color
- * Source format is BGR (see vesa.c:vbe_mode_info() )
- */
-void gen_15to32_1(RemapObject *ro)
-{
-  int i, j;
-  const unsigned char *src;
-  unsigned char *dst;
-  const unsigned short *src_2;
-  unsigned *dst_4;
-
-  src = ro->src_image + ro->src_start + ro->src_offset;
-  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
-
-  for(i = ro->src_y0; i < ro->src_y1; i++) {
-    src_2 = (const unsigned short *)src;
-    dst_4 = (unsigned *) dst;
-
-    for(j = 0; j < ro->dst_width; j++) {
-      // get 5-bit color values
-      // (green channel is cut between two byte values)
-      //  [0] gggbbbbb
-      //  [1] 0rrrrrgg
-      *dst_4++ = bgr_2int(ro->dst_color_space, 5, 5, 5, *src_2++);
-    }
-
-    src += ro->src_scan_len;
-    dst += ro->dst_scan_len;
   }
 }
 

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1687,8 +1687,6 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
-  // sort position (temporary comment)
-
   REMAP_DESC(
     RFF_SCALE_1  | RFF_REMAP_RECT,
     MODE_PSEUDO_8,
@@ -1696,6 +1694,8 @@ static RemapFuncDesc remap_gen_list[] = {
     gen_8to32_1,
     NULL
   ),
+
+  // sort position (temporary comment)
 
   REMAP_DESC(
     RFF_SCALE_ALL  | RFF_REMAP_LINES | RFF_BILIN_FILT,
@@ -2961,8 +2961,6 @@ void gen_8to32_all(RemapObject *ro)
   }
 }
 
-// sort position (temporary comment)
-
 /*
  * 8 bit pseudo color --> 32 bit true color
  */
@@ -2984,6 +2982,8 @@ void gen_8to32_1(RemapObject *ro)
     src += ro->src_scan_len;
   }
 }
+
+// sort position (temporary comment)
 
 /*
  * 8 bit pseudo color --> 32 bit true color

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1775,6 +1775,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_1  | RFF_REMAP_LINES,
+    MODE_TRUE_24,
+    MODE_TRUE_32,
+    gen_24to32_1,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1790,14 +1798,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_TRUE_32,
     MODE_TRUE_32,
     gen_32to32_all,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_1  | RFF_REMAP_LINES,
-    MODE_TRUE_24,
-    MODE_TRUE_32,
-    gen_24to32_1,
     NULL
   ),
 
@@ -3320,6 +3320,36 @@ void gen_24to32_all(RemapObject *ro)
   }
 }
 
+/*
+ * 24 bit true color --> 32 bit true color
+ * Source format is BGR (see vesa.c:vbe_mode_info() )
+ */
+void gen_24to32_1(RemapObject *ro)
+{
+  int i, j;
+  const unsigned char *src, *src_1;
+  unsigned char *dst;
+  unsigned *dst_4;
+
+  src = ro->src_image + ro->src_start + ro->src_offset;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+
+  for(i = ro->src_y0; i < ro->src_y1; i++) {
+    src_1 = src;
+    dst_4 = (unsigned *) dst;
+
+    for(j = 0; j < ro->src_width; j++) {
+      RGBColor c = { src_1[2], src_1[1], src_1[0] };
+
+      *dst_4++ = rgb_color_2int(ro->dst_color_space, 8, 8, 8, c);
+      src_1 += 3;
+    }
+
+    src += ro->src_scan_len;
+    dst += ro->dst_scan_len;
+  }
+}
+
 // sort position (temporary comment)
 
 /*
@@ -3371,37 +3401,6 @@ void gen_32to32_all(RemapObject *ro)
       dst_4[d_x++] = rgb_color_2int(ro->dst_color_space, 8, 8, 8, c);
       s_x += *(bre_x++);
     }
-  }
-}
-
-
-/*
- * 24 bit true color --> 32 bit true color
- * Source format is BGR (see vesa.c:vbe_mode_info() )
- */
-void gen_24to32_1(RemapObject *ro)
-{
-  int i, j;
-  const unsigned char *src, *src_1;
-  unsigned char *dst;
-  unsigned *dst_4;
-
-  src = ro->src_image + ro->src_start + ro->src_offset;
-  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
-
-  for(i = ro->src_y0; i < ro->src_y1; i++) {
-    src_1 = src;
-    dst_4 = (unsigned *) dst;
-
-    for(j = 0; j < ro->src_width; j++) {
-      RGBColor c = { src_1[2], src_1[1], src_1[0] };
-
-      *dst_4++ = rgb_color_2int(ro->dst_color_space, 8, 8, 8, c);
-      src_1 += 3;
-    }
-
-    src += ro->src_scan_len;
-    dst += ro->dst_scan_len;
   }
 }
 

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1503,6 +1503,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
+    MODE_VGA_2,
+    MODE_PSEUDO_8,
+    gen_2to8p_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1726,14 +1734,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_TRUE_16,
     MODE_TRUE_32,
     gen_16to32_all,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL | RFF_REMAP_LINES,
-    MODE_VGA_2,
-    MODE_PSEUDO_8,
-    gen_2to8p_all,
     NULL
   ),
 
@@ -2040,6 +2040,47 @@ void gen_2to8_all(RemapObject *ro)
       c1 &= 1;
       c0 |= c1 << 1;
       dst[d_x++] = lut[4 * c0 + (k ^= 1)];
+      s_x += *(bre_x++);
+    }
+  }
+}
+
+/*
+ * 2 bit VGA pseudo color --> 8 bit pseudo color (private color map)
+ * supports arbitrary scaling
+ *
+ * -- very basic and slow --
+ */
+void gen_2to8p_all(RemapObject *ro)
+{
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+  unsigned char c0, c1;
+  int i;
+
+  const unsigned char *src, *src0;
+  unsigned char *dst;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+  d_x_len = ro->dst_width;
+
+  for (d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    for (s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len;) {
+      i = s_x >> 3;
+      c0 = src[i];
+      c1 = src[i + 0x20000];
+      i = (s_x & 7) ^ 7;
+      c0 >>= i;
+      c1 >>= i;
+      c0 &= 1;
+      c1 &= 1;
+      c0 |= c1 << 1;
+      dst[d_x++] = c0;
       s_x += *(bre_x++);
     }
   }
@@ -3082,45 +3123,6 @@ void gen_16to32_all(RemapObject *ro)
     }
   }
 }
-
-/*
- * 2 bit VGA pseudo color --> 8 bit pseudo color (private color map)
- * supports arbitrary scaling
- *
- * -- very basic and slow --
- */
-void gen_2to8p_all(RemapObject *ro)
-{
-  int d_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-  unsigned char c0, c1;
-  int i;
-
-  const unsigned char *src, *src0;
-  unsigned char *dst;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
-  d_x_len = ro->dst_width;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      i = s_x >> 3;
-      c0 = src[i]; c1 = src[i + 0x20000];
-      i = (s_x & 7) ^ 7;
-      c0 >>= i; c1 >>= i;
-      c0 &= 1; c1 &= 1;
-      c0 |= c1 << 1;
-      dst[d_x++] = c0;
-      s_x += *(bre_x++);
-    }
-  }
-}
-
 
 /*
  * 2 bit VGA pseudo color --> 15/16 bit true color

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1495,6 +1495,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
+    MODE_VGA_2,
+    MODE_TRUE_8,
+    gen_2to8_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1726,14 +1734,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_VGA_2,
     MODE_PSEUDO_8,
     gen_2to8p_all,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL | RFF_REMAP_LINES,
-    MODE_VGA_2,
-    MODE_TRUE_8,
-    gen_2to8_all,
     NULL
   ),
 
@@ -1997,6 +1997,49 @@ void gen_1to32_all(RemapObject *ro)
     for (s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len;) {
       c0 = (src[s_x >> 3] >> ((s_x & 7) ^ 7)) & 1;
       dst[d_x++] = ro->true_color_lut[c0];
+      s_x += *(bre_x++);
+    }
+  }
+}
+
+/*
+ * 2 bit VGA pseudo color --> 8 bit true color (shared color map)
+ * supports arbitrary scaling
+ *
+ * -- very basic and slow --
+ */
+void gen_2to8_all(RemapObject *ro)
+{
+  int k;
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+  const unsigned char *src, *src0;
+  unsigned char *dst;
+  unsigned char *lut = (unsigned char *)ro->true_color_lut;
+  unsigned char c0, c1;
+  int i;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+  d_x_len = ro->dst_width;
+
+  for (d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    k = (d_y & 1) << 1;
+    for (s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len;) {
+      i = s_x >> 3;
+      c0 = src[i];
+      c1 = src[i + 0x20000];
+      i = (s_x & 7) ^ 7;
+      c0 >>= i;
+      c1 >>= i;
+      c0 &= 1;
+      c1 &= 1;
+      c0 |= c1 << 1;
+      dst[d_x++] = lut[4 * c0 + (k ^= 1)];
       s_x += *(bre_x++);
     }
   }
@@ -3073,47 +3116,6 @@ void gen_2to8p_all(RemapObject *ro)
       c0 &= 1; c1 &= 1;
       c0 |= c1 << 1;
       dst[d_x++] = c0;
-      s_x += *(bre_x++);
-    }
-  }
-}
-
-
-/*
- * 2 bit VGA pseudo color --> 8 bit true color (shared color map)
- * supports arbitrary scaling
- *
- * -- very basic and slow --
- */
-void gen_2to8_all(RemapObject *ro)
-{
-  int k;
-  int d_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-  const unsigned char *src, *src0;
-  unsigned char *dst;
-  unsigned char *lut = (unsigned char*) ro->true_color_lut;
-  unsigned char c0, c1;
-  int i;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
-  d_x_len = ro->dst_width;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    k = (d_y & 1) << 1;
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      i = s_x >> 3;
-      c0 = src[i]; c1 = src[i + 0x20000];
-      i = (s_x & 7) ^ 7;
-      c0 >>= i; c1 >>= i;
-      c0 &= 1; c1 &= 1;
-      c0 |= c1 << 1;
-      dst[d_x++] = lut[4 * c0 + (k ^= 1)];
       s_x += *(bre_x++);
     }
   }

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1695,6 +1695,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL  | RFF_REMAP_LINES | RFF_LIN_FILT,
+    MODE_PSEUDO_8,
+    MODE_TRUE_32,
+    gen_8to32_lin,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1702,14 +1710,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_PSEUDO_8,
     MODE_TRUE_32,
     gen_8to32_bilin,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES | RFF_LIN_FILT,
-    MODE_PSEUDO_8,
-    MODE_TRUE_32,
-    gen_8to32_lin,
     NULL
   ),
 
@@ -2983,6 +2983,46 @@ void gen_8to32_1(RemapObject *ro)
   }
 }
 
+/*
+ * 8 bit pseudo color --> 32 bit true color
+ * supports arbitrary scaling
+ */
+void gen_8to32_lin(RemapObject *ro)
+{
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len >> 2;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+
+  const unsigned char *src, *src0;
+  unsigned *dst;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = (unsigned *) (ro->dst_image + ro->dst_start + ro->dst_offset);
+  d_x_len = ro->dst_width;
+
+  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
+      switch(*(bre_x + d_x_len)) {
+        case 0:
+          dst[d_x++] = ro->true_color_lut[src[s_x]];
+          break;
+        case 1:
+          dst[d_x++] = ro->true_color_lut[src[s_x] + LUT_OFS_67] + ro->true_color_lut[src[s_x + 1] + LUT_OFS_33];
+          break;
+        case 2:
+          dst[d_x++] = ro->true_color_lut[src[s_x] + LUT_OFS_33] + ro->true_color_lut[src[s_x + 1] + LUT_OFS_67];
+          break;
+        default:
+          fprintf(stderr, "***** oops\n");
+      }
+      s_x += *(bre_x++);
+    }
+  }
+}
+
 // sort position (temporary comment)
 
 /*
@@ -3079,47 +3119,6 @@ void gen_8to32_bilin(RemapObject *ro)
 
   }
 }
-
-/*
- * 8 bit pseudo color --> 32 bit true color
- * supports arbitrary scaling
- */
-void gen_8to32_lin(RemapObject *ro)
-{
-  int d_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len >> 2;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-
-  const unsigned char *src, *src0;
-  unsigned *dst;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = (unsigned *) (ro->dst_image + ro->dst_start + ro->dst_offset);
-  d_x_len = ro->dst_width;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      switch(*(bre_x + d_x_len)) {
-        case 0:
-          dst[d_x++] = ro->true_color_lut[src[s_x]];
-          break;
-        case 1:
-          dst[d_x++] = ro->true_color_lut[src[s_x] + LUT_OFS_67] + ro->true_color_lut[src[s_x + 1] + LUT_OFS_33];
-          break;
-        case 2:
-          dst[d_x++] = ro->true_color_lut[src[s_x] + LUT_OFS_33] + ro->true_color_lut[src[s_x + 1] + LUT_OFS_67];
-          break;
-        default:
-          fprintf(stderr, "***** oops\n");
-      }
-      s_x += *(bre_x++);
-    }
-  }
-}
-
 
 /*
  * 16 bit true color --> 16 bit true color

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1471,6 +1471,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
+    MODE_VGA_1 | MODE_CGA_1 | MODE_HERC,
+    MODE_TRUE_15 | MODE_TRUE_16,
+    gen_1to16_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1700,14 +1708,6 @@ static RemapFuncDesc remap_gen_list[] = {
   REMAP_DESC(
     RFF_SCALE_ALL | RFF_REMAP_LINES,
     MODE_VGA_1 | MODE_CGA_1 | MODE_HERC,
-    MODE_TRUE_15 | MODE_TRUE_16,
-    gen_1to16_all,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL | RFF_REMAP_LINES,
-    MODE_VGA_1 | MODE_CGA_1 | MODE_HERC,
     MODE_TRUE_24,
     gen_1to24_all,
     NULL
@@ -1897,6 +1897,38 @@ void gen_1to8p_all(RemapObject *ro)
       c0 >>= i;
       c0 &= 1;
       dst[d_x++] = c0;
+      s_x += *(bre_x++);
+    }
+  }
+}
+
+/*
+ * 1 bit pseudo color --> 15/16 bit true color
+ * supports arbitrary scaling
+ *
+ * -- very basic and slow --
+ */
+void gen_1to16_all(RemapObject *ro)
+{
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len >> 1;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+  unsigned char c0;
+
+  const unsigned char *src, *src0;
+  unsigned short *dst;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = (unsigned short *)(ro->dst_image + ro->dst_start + ro->dst_offset);
+  d_x_len = ro->dst_width;
+
+  for (d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    for (s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len;) {
+      c0 = (src[s_x >> 3] >> ((s_x & 7) ^ 7)) & 1;
+      dst[d_x++] = ro->true_color_lut[c0];
       s_x += *(bre_x++);
     }
   }
@@ -2939,39 +2971,6 @@ void gen_16to32_all(RemapObject *ro)
     }
   }
 }
-
-/*
- * 1 bit pseudo color --> 15/16 bit true color
- * supports arbitrary scaling
- *
- * -- very basic and slow --
- */
-void gen_1to16_all(RemapObject *ro)
-{
-  int d_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len >> 1;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-  unsigned char c0;
-
-  const unsigned char *src, *src0;
-  unsigned short *dst;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = (unsigned short *) (ro->dst_image + ro->dst_start + ro->dst_offset);
-  d_x_len = ro->dst_width;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      c0 = (src[s_x >> 3] >> ((s_x & 7) ^ 7)) & 1;
-      dst[d_x++] = ro->true_color_lut[c0];
-      s_x += *(bre_x++);
-    }
-  }
-}
-
 
 /*
  * 1 bit pseudo color --> 24 bit true color

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1743,6 +1743,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
+    MODE_TRUE_16,
+    MODE_TRUE_32,
+    gen_16to32_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1790,14 +1798,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_TRUE_16,
     MODE_TRUE_32,
     gen_16to32_1,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL | RFF_REMAP_LINES,
-    MODE_TRUE_16,
-    MODE_TRUE_32,
-    gen_16to32_all,
     NULL
   ),
 
@@ -3204,6 +3204,38 @@ void gen_16to16_1(RemapObject *ro)
   }
 }
 
+/*
+ * 16 bit true color --> 32 bit true color
+ * supports arbitrary scaling
+ */
+void gen_16to32_all(RemapObject *ro)
+{
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+
+  const unsigned char *src, *src0;
+  unsigned char *dst;
+  const unsigned short *src_2;
+  unsigned *dst_4;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+  d_x_len = ro->dst_width;
+
+  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    src_2 = (const unsigned short *) src;
+    dst_4 = (unsigned *) dst;
+    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
+      dst_4[d_x++] = bgr_2int(ro->dst_color_space, 5, 6, 5, src_2[s_x]);
+      s_x += *(bre_x++);
+    }
+  }
+}
+
 // sort position (temporary comment)
 
 /*
@@ -3371,38 +3403,6 @@ void gen_16to32_1(RemapObject *ro)
 
     src += ro->src_scan_len;
     dst += ro->dst_scan_len;
-  }
-}
-
-/*
- * 16 bit true color --> 32 bit true color
- * supports arbitrary scaling
- */
-void gen_16to32_all(RemapObject *ro)
-{
-  int d_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-
-  const unsigned char *src, *src0;
-  unsigned char *dst;
-  const unsigned short *src_2;
-  unsigned *dst_4;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
-  d_x_len = ro->dst_width;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    src_2 = (const unsigned short *) src;
-    dst_4 = (unsigned *) dst;
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      dst_4[d_x++] = bgr_2int(ro->dst_color_space, 5, 6, 5, src_2[s_x]);
-      s_x += *(bre_x++);
-    }
   }
 }
 

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1615,6 +1615,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL  | RFF_REMAP_LINES,
+    MODE_VGA_X | MODE_PSEUDO_8,
+    MODE_TRUE_8,
+    gen_8to8_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1638,14 +1646,6 @@ static RemapFuncDesc remap_gen_list[] = {
     MODE_PSEUDO_8,
     MODE_TRUE_8,
     gen_8to8_1,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL  | RFF_REMAP_LINES,
-    MODE_VGA_X | MODE_PSEUDO_8,
-    MODE_TRUE_8,
-    gen_8to8_all,
     NULL
   ),
 
@@ -2637,6 +2637,36 @@ void gen_4to32_all(RemapObject *ro)
   }
 }
 
+/*
+ * 8 bit pseudo color --> 8 bit true color (shared color map)
+ * supports arbitrary scaling
+ */
+void gen_8to8_all(RemapObject *ro)
+{
+  int k;
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+  const unsigned char *src, *src0;
+  unsigned char *dst;
+  unsigned char *lut = (unsigned char *)ro->true_color_lut;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+  d_x_len = ro->dst_width;
+
+  for (d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    k = (d_y & 1) << 1;
+    for (s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len;) {
+      dst[d_x++] = lut[4 * src[s_x] + (k ^= 1)];
+      s_x += *(bre_x++);
+    }
+  }
+}
+
 // sort position (temporary comment)
 
 
@@ -2713,38 +2743,6 @@ void gen_8to8_1(RemapObject *ro)
     src += ro->src_scan_len;
   }
 }
-
-
-/*
- * 8 bit pseudo color --> 8 bit true color (shared color map)
- * supports arbitrary scaling
- */
-void gen_8to8_all(RemapObject *ro)
-{
-  int k;
-  int d_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-  const unsigned char *src, *src0;
-  unsigned char *dst;
-  unsigned char *lut = (unsigned char*) ro->true_color_lut;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
-  d_x_len = ro->dst_width;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    k = (d_y & 1) << 1;
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      dst[d_x++] = lut[4 * src[s_x] + (k ^= 1)];
-      s_x += *(bre_x++);
-    }
-  }
-}
-
 
 /*
  * 8 bit pseudo color --> 15/16 bit true color

--- a/src/base/video/remap.c
+++ b/src/base/video/remap.c
@@ -1463,6 +1463,14 @@ static RemapFuncDesc remap_gen_list[] = {
     NULL
   ),
 
+  REMAP_DESC(
+    RFF_SCALE_ALL | RFF_REMAP_LINES,
+    MODE_VGA_1 | MODE_CGA_1 | MODE_HERC,
+    MODE_PSEUDO_8,
+    gen_1to8p_all,
+    NULL
+  ),
+
   // sort position (temporary comment)
 
   REMAP_DESC(
@@ -1692,14 +1700,6 @@ static RemapFuncDesc remap_gen_list[] = {
   REMAP_DESC(
     RFF_SCALE_ALL | RFF_REMAP_LINES,
     MODE_VGA_1 | MODE_CGA_1 | MODE_HERC,
-    MODE_PSEUDO_8,
-    gen_1to8p_all,
-    NULL
-  ),
-
-  REMAP_DESC(
-    RFF_SCALE_ALL | RFF_REMAP_LINES,
-    MODE_VGA_1 | MODE_CGA_1 | MODE_HERC,
     MODE_TRUE_15 | MODE_TRUE_16,
     gen_1to16_all,
     NULL
@@ -1860,6 +1860,43 @@ void gen_1to8_all(RemapObject *ro)
       c0 >>= i;
       c0 &= 1;
       dst[d_x++] = lut[4 * c0 + (k ^= 1)];
+      s_x += *(bre_x++);
+    }
+  }
+}
+
+/*
+ * 1 bit pseudo color --> 8 bit pseudo color (private color map)
+ * supports arbitrary scaling
+ *
+ * -- very basic and slow --
+ */
+void gen_1to8p_all(RemapObject *ro)
+{
+  int d_x_len;
+  int s_x, d_x, d_y;
+  int d_scan_len = ro->dst_scan_len;
+  int *bre_x;
+  int *bre_y = ro->bre_y;
+  unsigned char c0;
+  int i;
+
+  const unsigned char *src, *src0;
+  unsigned char *dst;
+
+  src0 = ro->src_image + ro->src_start;
+  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
+  d_x_len = ro->dst_width;
+
+  for (d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
+    src = src0 + bre_y[d_y++];
+    for (s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len;) {
+      i = s_x >> 3;
+      c0 = src[i];
+      i = (s_x & 7) ^ 7;
+      c0 >>= i;
+      c0 &= 1;
+      dst[d_x++] = c0;
       s_x += *(bre_x++);
     }
   }
@@ -2902,42 +2939,6 @@ void gen_16to32_all(RemapObject *ro)
     }
   }
 }
-
-/*
- * 1 bit pseudo color --> 8 bit pseudo color (private color map)
- * supports arbitrary scaling
- *
- * -- very basic and slow --
- */
-void gen_1to8p_all(RemapObject *ro)
-{
-  int d_x_len;
-  int s_x, d_x, d_y;
-  int d_scan_len = ro->dst_scan_len;
-  int *bre_x;
-  int *bre_y = ro->bre_y;
-  unsigned char c0;
-  int i;
-
-  const unsigned char *src, *src0;
-  unsigned char *dst;
-
-  src0 = ro->src_image + ro->src_start;
-  dst = ro->dst_image + ro->dst_start + ro->dst_offset;
-  d_x_len = ro->dst_width;
-
-  for(d_y = ro->dst_y0; d_y < ro->dst_y1; dst += d_scan_len) {
-    src = src0 + bre_y[d_y++];
-    for(s_x = d_x = 0, bre_x = ro->bre_x; d_x < d_x_len; ) {
-      i = s_x >> 3;
-      c0 = src[i];
-      i = (s_x & 7) ^ 7; c0 >>= i; c0 &= 1;
-      dst[d_x++] = c0;
-      s_x += *(bre_x++);
-    }
-  }
-}
-
 
 /*
  * 1 bit pseudo color --> 15/16 bit true color


### PR DESCRIPTION
Revisited the sorting suggested in PR #418 by @bolle732, recreated against current git and one change per commit for easier review. This was done on a textual basis only, tested for compilation only

**I notice that `gen_16to16_1()` is referenced twice in the struct definition, please confirm?**