### PR TITLE
MFS: Display disabled drive state in lredir

### DIFF
--- a/src/env/builtins/lredir.c
+++ b/src/env/builtins/lredir.c
@@ -72,6 +72,7 @@
 #define MAX_DEVICE_STRING_LENGTH     5  /* enough for printer strings */
 
 #define READ_ONLY_DRIVE_ATTRIBUTE 1  /* same as NetWare Lite */
+#define DISABLED_DRIVE_ATTRIBUTE  2
 
 #define KEYWORD_DEL   "DELETE"
 #define KEYWORD_DEL_COMPARE_LENGTH  3
@@ -171,14 +172,10 @@ ShowMyRedirections(void)
         printf("%-2s = %-20s ", deviceStr, resourceStr);
 
         /* read attribute is returned in the device parameter */
-        if (deviceParam & 0x80) {
-	  if ((deviceParam & 0x7f) > 1)
-	    printf("CDROM:%d ", (deviceParam & 0x7f) - 1);
-          if (((deviceParam & 0x7f) != 0) == READ_ONLY_DRIVE_ATTRIBUTE)
-	    printf("attrib = READ ONLY\n");
-	  else
-	    printf("attrib = READ/WRITE\n");
-        }
+        printf("attrib = %s", deviceParam & READ_ONLY_DRIVE_ATTRIBUTE ? "READ ONLY" : "READ/WRITE");
+        if (deviceParam & DISABLED_DRIVE_ATTRIBUTE)
+          printf(", DISABLED");
+        printf("\n");
       }
 
       redirIndex++;


### PR DESCRIPTION
If Dosemu has a drive configured for redirection, but the CDS flags are
not set for DOS to recognise it, have lredir display the DISABLED
attribute.

Note: This patch removes the CDROM unit number display code from lredir,
as it was ineffective because the corresponding bits were never set in
mfs:GetRedirection().

[Fixes #695]