### PR TITLE
dosdebug: Display the interrupt table

### DIFF
--- a/src/tools/debugger/dosdebug.c
+++ b/src/tools/debugger/dosdebug.c
@@ -158,6 +158,8 @@ static COMMAND cmds[] = {
    "ADDR SIZE         dump memory (limit 256 bytes)\n"},
   {"dump", NULL,
    "ADDR SIZE FILE    dump memory to file (binary)\n"},
+  {"displayivec", NULL,
+   "[hexnum]          display interrupt vector hexnum (default whole table)\n"},
   {"u", NULL,
    "ADDR SIZE         unassemble memory (limit 256 bytes)\n"},
   {"g", NULL,


### PR DESCRIPTION
Add command to display the interrupt table and follow the chain for
each if the handlers referenced support the IBM Interrupt Sharing
Protocol. See the following link:
https://web.archive.org/web/20100403220515/http://www.simtel.net/product/view/id/46893
for the document INTSHARE.DOC

Example 1 (Ralf Brown's FASTMOUS and NOLPT loaded):
dosdebug> displayivec 2d
dosdebug>
Interrupt vector table:
  2d  101B:0039
   => 9FF8:0017
   => 003E:40D2

Example 2 (if there's a debugger symbol in place):
dosdebug> displayivec
dosdebug>
Interrupt vector table:
  00  003E:9257
  01  0070:06F4
<snip>
  20  003E:40CC
  21  F000:F500(int_rvc_start_21)
  22  0ED1:017E
<snip>