### PR TITLE
Dosdebug 31

### DIFF
--- a/src/base/bios/bios.S
+++ b/src/base/bios/bios.S
@@ -386,6 +386,8 @@ INT70_dummy_end:
 
 /* COMPAS FE3FE		jmp to INT13 HD */
 	.org	((INT41_SEG - BIOSSEG) << 4) + INT41_OFF
+	.globl	HD_parameter_table0
+HD_parameter_table0:
 /* COMPAS FE401-FE6F0	HD parameter table */
 	.word	50	/* cyl */
 	.byte	255	/* heads */
@@ -402,6 +404,8 @@ INT70_dummy_end:
 
 /* COMPAS FE3FE		jmp to INT13 HD */
 	.org	((INT46_SEG - BIOSSEG) << 4) + INT46_OFF
+	.globl	HD_parameter_table1
+HD_parameter_table1:
 /* COMPAS FE401-FE6F0	HD parameter table */
 	.word	50	/* cyl */
 	.byte	255	/* heads */

--- a/src/tools/debugger/dosdebug.c
+++ b/src/tools/debugger/dosdebug.c
@@ -158,7 +158,7 @@ static COMMAND cmds[] = {
    "ADDR SIZE         dump memory (limit 256 bytes)\n"},
   {"dump", NULL,
    "ADDR SIZE FILE    dump memory to file (binary)\n"},
-  {"displayivec", NULL,
+  {"ivec", NULL,
    "[hexnum]          display interrupt vector hexnum (default whole table)\n"},
   {"u", NULL,
    "ADDR SIZE         unassemble memory (limit 256 bytes)\n"},

--- a/src/tools/debugger/mhpdbgc.c
+++ b/src/tools/debugger/mhpdbgc.c
@@ -809,7 +809,7 @@ static void mhp_dump_to_file(int argc, char * argv[])
 
 static void mhp_ivec(int argc, char *argv[])
 {
-  unsigned int i, dmin, dmax;
+  unsigned int i, j, dmin, dmax;
   uint16_t sseg, soff;
   struct {
     unsigned char jmp_to_code[2];
@@ -847,7 +847,11 @@ static void mhp_ivec(int argc, char *argv[])
         mhp_printf("\n");
 
       // See if this handler follows the IBM shared interrupt specification
-      while (sseg || soff) {
+      for (j = 0; (sseg || soff); j++) {
+        if (j > 255) {
+          mhp_printf("Hops exceeded, possible circular reference\n");
+          break;
+        }
         c = MK_FP32(sseg, soff);
         if (c && c->sig == 0x424b && c->jmp_to_code[0] == 0xeb && c->jmp_to_hrst[0] == 0xeb) {
           sseg = c->oseg;

--- a/src/tools/debugger/mhpdbgc.c
+++ b/src/tools/debugger/mhpdbgc.c
@@ -89,7 +89,7 @@ static void mhp_memset  (int, char *[]);
 static void mhp_print_ldt       (int, char *[]);
 static void mhp_debuglog (int, char *[]);
 static void mhp_dump_to_file (int, char *[]);
-static void mhp_displayivec (int, char *[]);
+static void mhp_ivec    (int, char *[]);
 static void mhp_bplog   (int, char *[]);
 static void mhp_bclog   (int, char *[]);
 static void print_log_breakpoints(void);
@@ -140,7 +140,7 @@ static const struct cmd_db cmdtab[] = {
    {"ldt",           mhp_print_ldt},
    {"log",           mhp_debuglog},
    {"dump",          mhp_dump_to_file},
-   {"displayivec",   mhp_displayivec},
+   {"ivec",          mhp_ivec},
    {"",              NULL}
 };
 
@@ -807,7 +807,7 @@ static void mhp_dump_to_file(int argc, char * argv[])
    close(fd);
 }
 
-static void mhp_displayivec(int argc, char *argv[])
+static void mhp_ivec(int argc, char *argv[])
 {
   unsigned int i, dmin, dmax;
   uint16_t sseg, soff;


### PR DESCRIPTION
I added a couple of symbols to bios.S for the fixed disk parameter table for display with `ivec` I was trying to correct the duplicate comment for the second entry but I'm not sure the second one is in the right place. According to [rbil](http://www.delorie.com/djgpp/doc/rbinter/id/54/61.html) the second entry should immediately follow the first.
So
First entry is at `f000:e401`
Second should be at `f000:e411` but is at `F800:6420(HD_parameter_table1)`

I also checked seabios source and they have an array
https://git.seabios.org/cgit/seabios.git/tree/src/std/bda.h#n153

