### PR TITLE
Foffset01

### DIFF
--- a/src/include/disks.h
+++ b/src/include/disks.h
@@ -13,12 +13,6 @@
 #define PART_NOBOOT	0
 #define PART_BOOT	0x80
 
-#ifndef __linux__
-#define off64_t  off_t
-#define open64   open
-#define lseek64  lseek
-#endif
-
 #include <stdint.h>
 #include <sys/types.h>
 #include <fcntl.h>

--- a/src/include/disks.h
+++ b/src/include/disks.h
@@ -116,7 +116,7 @@ struct disk {
   int drive_num;
   unsigned long serial;		/* serial number */
   disk_t type;			/* type of file: image, partition, disk */
-  loff_t header;		/* compensation for opt. pre-disk header */
+  off_t header;			/* compensation for opt. pre-disk header */
   int fdesc;			/* file descriptor */
   int removeable;		/* real removable drive, can disappear */
   int floppy;			/* emulating floppy */


### PR DESCRIPTION
Some changes to make filesystem operations less specific. The existing autoconf macros already action the promotion of off_t to off64_t etc on LFS systems, so remove the specific types and calls.

The third commit (mfs) I'm less sure about as it's 32/64bit locking. I've tested it on my 32bit Ubuntu 18.04 and struct conversion is not needed, as struct flock and struct flock64 are identical.

Thoughts?

