### PR TITLE
Dosdebug 33

### DIFF
--- a/src/plugin/debugger/mhpdbgc.c
+++ b/src/plugin/debugger/mhpdbgc.c
@@ -809,6 +809,17 @@ static void mhp_dump_to_file(int argc, char * argv[])
    close(fd);
 }
 
+static int is_valid_program_name(const char *s)
+{
+  const char *p;
+
+  for (p = s; *p; p++) {
+    if (iscntrlDOS(*p))
+      return 0;
+  }
+  return 1;
+}
+
 static const char *get_mcb_name2(uint16_t seg, uint16_t off)
 {
   char *target = MK_FP32(seg, off);
@@ -829,7 +840,7 @@ static const char *get_mcb_name2(uint16_t seg, uint16_t off)
       if (mcb->owner_psp == 8)
         return dos;
       snprintf(name, sizeof name, "%s", mcb->name);
-      return name;
+      return is_valid_program_name(name) ? name : NULL;
     }
 
     mcb = (struct MCB *)end;
@@ -854,7 +865,7 @@ static const char *get_mcb_name(uint16_t seg) {
     return NULL;
 
   snprintf(name, sizeof name, "%s", mcb->name);
-  return name;
+  return is_valid_program_name(name) ? name : NULL;
 }
 
 static void mhp_ivec(int argc, char *argv[])


### PR DESCRIPTION
As per your suggestion in #750 here's a tweak to Dosdebug's ivec that displays the handler's owning program. I implemented it half as you suggested (looking up the PSP at the start of the handler's segment) and half by walking the MCB chain, which turned out to be not so difficult and had the added benefit of being able to display DOS and FREE MCB's too.