### PR TITLE
mkfatimage16: Dates year field width wrong

### DIFF
--- a/src/plugin/periph/mkfatimage16.c
+++ b/src/plugin/periph/mkfatimage16.c
@@ -151,7 +151,7 @@ static void put_root_directory(int n, struct input_file *f)
   unsigned char *p = &root_directory[n*32];
   struct tm *tm;
   tm = localtime(&f->mtime);
-  put_word(&p[24], (((tm->tm_year - 80) & 0x1f) << 9) |
+  put_word(&p[24], (((tm->tm_year - 80) & 0b01111111) << 9) |
     (((tm->tm_mon + 1) & 0xf) << 5) |
     (tm->tm_mday & 0x1f));
   put_word(&p[22], ((tm->tm_hour & 0x1f) << 11) |


### PR DESCRIPTION
Year fields are 7 bits not 5 wide

Previously dates would roll over after 2012 i.e. 2019 became 1987,
whereas the proper date year range on FAT should be 1980 -> 2107

See https://en.wikipedia.org/wiki/Design_of_the_FAT_file_system#Directory_entry
at offset 0x10