### PR TITLE
LFN: Fall through if the drive isn't ours

### DIFF
--- a/src/base/async/int.c
+++ b/src/base/async/int.c
@@ -1658,32 +1658,23 @@ static int msdos_chainrevect(int stk_offs)
 
 static int msdos_xtra(int old_ax)
 {
-    di_printf("int_rvc 0x21 call for ax=0x%04x %x\n", LWORD(eax), old_ax);
-    switch (HI_BYTE_d(old_ax)) {
+  di_printf("msdos_xtra call for ax=0x%04x 0x%04x\n", LWORD(eax), old_ax);
+  switch (HI_BYTE_d(old_ax)) {
     case 0x71:
-	CARRY;
-	if (LWORD(eax) != 0x7100)
-	    break;
-	if (config.lfn) {
-	    LWORD(eax) = old_ax;
-	    /* mfs_lfn() clears CF on success */
-	    return mfs_lfn();
-	}
-	break;
+      if (LWORD(eax) == 0x7100)
+        return mfs_lfn();
+      break;
     case 0x73:
-	CARRY;
-	if (LWORD(eax) != 0x7300)
-	    break;
-	LWORD(eax) = old_ax;
-	return mfs_fat32();
+      show_regs();
+      if (LWORD(eax) == 0x7300 || isset_CF()) // didn't exist or failed
+        return mfs_fat32(old_ax);
+      break;
     case 0x6c:
-	CARRY;
-	if (LWORD(eax) != 0x6c00)
-	    break;
-	LWORD(eax) = old_ax;
-	return msdos_remap_extended_open();
-    }
-    return 0;
+      if (LWORD(eax) == 0x6c00)
+        return msdos_remap_extended_open();
+      break;
+  }
+  return 0;
 }
 
 void int42_hook(void)

--- a/src/dosext/mfs/lfn.c
+++ b/src/dosext/mfs/lfn.c
@@ -863,6 +863,8 @@ static int mfs_lfn_(void)
 		drive = build_truename(fpath, src, 0);
 		if (drive < 0)
 			return drive + 2;
+		if (!drives[drive].root) // not MFS, fall back to another LFN driver
+			return 0;
 		rc = (_AL == 0x39 ? dos_mkdir : dos_rmdir)(fpath, drive, 1);
 		if (rc)
 			return lfn_error(rc);
@@ -875,6 +877,8 @@ static int mfs_lfn_(void)
 		drive = build_posix_path(fpath, src, 0);
 		if (drive < 0)
 			return drive + 2;
+		if (!drives[drive].root) // not MFS, fall back to another LFN driver
+			return 0;
 		if (!find_file(fpath, &st, drive, NULL)|| !S_ISDIR(st.st_mode))
 			return lfn_error(PATH_NOT_FOUND);
 		make_unmake_dos_mangled_path(d, fpath, drive, 1);
@@ -886,6 +890,8 @@ static int mfs_lfn_(void)
 		drive = build_posix_path(fpath, src, _SI);
 		if (drive < 0)
 			return drive + 2;
+		if (!drives[drive].root) // not MFS, fall back to another LFN driver
+			return 0;
 		if (drives[drive].read_only)
 			return lfn_error(ACCESS_DENIED);
 		if (is_dos_device(fpath))
@@ -903,6 +909,8 @@ static int mfs_lfn_(void)
 		drive = build_posix_path(fpath, src, 0);
 		if (drive < 0)
 			return drive + 2;
+		if (!drives[drive].root) // not MFS, fall back to another LFN driver
+			return 0;
 		if (drives[drive].read_only && (_BL < 8) && (_BL & 1))
 			return lfn_error(ACCESS_DENIED);
 		if (!find_file(fpath, &st, drive, &doserrno) ||
@@ -958,7 +966,7 @@ static int mfs_lfn_(void)
 			drive = _DL - 1;
 		if (drive < 0 || drive >= MAX_DRIVE)
 			return lfn_error(DISK_DRIVE_INVALID);
-		if (!drives[drive].root)
+		if (!drives[drive].root) // not MFS, fall back to another LFN driver
 			return 0;
 
 		cwd = drives[drive].curpath;
@@ -976,6 +984,8 @@ static int mfs_lfn_(void)
 		drive = build_posix_path(fpath, src, 1);
 		if (drive < 0)
 			return drive + 2;
+		if (!drives[drive].root) // not MFS, fall back to another LFN driver
+			return 0;
 		slash = strrchr(fpath, '/');
 		d_printf("LFN: posix:%s\n", fpath);
 		*slash++ = '\0';
@@ -1067,10 +1077,14 @@ static int mfs_lfn_(void)
 		drive = build_truename(fpath2, d, 0);
 		if (drive < 0)
 			return drive + 2;
+		if (!drives[drive].root) // not MFS, fall back to another LFN driver
+			return 0;
 		d_printf("LFN: rename from %s\n", src);
 		drive2 = build_truename(fpath, src, 0);
 		if (drive2 < 0)
 			return drive2 + 2;
+		if (!drives[drive2].root) // not MFS, fall back to another LFN driver
+			return 0;
 		if (drive != drive2)
 			return lfn_error(NOT_SAME_DEV);
 		rc = dos_rename_lfn(fpath, fpath2, drive);
@@ -1097,6 +1111,8 @@ static int mfs_lfn_(void)
 		drive = build_truename(filename, src, !_CL);
 		if (drive < 0)
 			return drive + 2;
+		if (!drives[drive].root) // not MFS, fall back to another LFN driver
+			return 0;
 
 		d_printf("LFN: %s %s\n", fpath, drives[drive].root);
 
@@ -1120,6 +1136,8 @@ static int mfs_lfn_(void)
 		drive = build_posix_path(fpath, src, 0);
 		if (drive < 0)
 			return drive + 2;
+		if (!drives[drive].root) // not MFS, fall back to another LFN driver
+			return 0;
 		if (is_dos_device(fpath)) {
 			strcpy(d, strrchr(fpath, '/') + 1);
 		} else {
@@ -1146,9 +1164,8 @@ static int mfs_lfn_(void)
 	case 0xa0: /* get volume info */
 		if (!get_drive_from_path(src, &drive))
 			return lfn_error(DISK_DRIVE_INVALID);
-
-		if (!drives[drive].root)		// not MFS
-			return lfn_error(FUNCTION_NOT_SUPPORTED);
+		if (!drives[drive].root) // not MFS, fall back to another LFN driver
+			return 0;
 
 		size = _CX;
 		_AX = 0;

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -354,7 +354,7 @@ extern void real_run_int(int);
 #define run_int real_run_int
 extern void mfs_reset(void);
 extern int mfs_redirector(void);
-extern int mfs_fat32(void);
+extern int mfs_fat32(uint16_t);
 extern int mfs_lfn(void);
 extern int int10(void);
 extern int int13(void);


### PR DESCRIPTION
In the case that we don't own the drive in question, for example it's
FAT, we should fall through to a further LFN handler (even though we
may be the last) instead of authoritively returning a drive error to
the caller. The caller may choose to see this lack of LFN support as
an indication to fallback to SFNs as required.

[fixes #770] [#539]