### PR TITLE
Dosdebug 36

### DIFF
--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -286,12 +286,12 @@ static uint16_t lol_offset, sda_offset;
 int lol_dpbfarptr_off, lol_cdsfarptr_off, lol_last_drive_off, lol_nuldev_off,
     lol_njoined_off;
 
-int cds_current_path_off, cds_flags_off, cds_DBP_pointer_off,
+int cds_current_path_off, cds_flags_off, cds_DPB_pointer_off,
     cds_cur_cluster_off, cds_rootlen_off, cds_record_size;
 
 #define cds_current_path(cds)     ((char *)&cds[cds_current_path_off])
 #define cds_flags(cds)        (*(u_short *)&cds[cds_flags_off])
-#define cds_DBP_pointer(cds)    (*(far_t *)&cds[cds_DBP_pointer_off])
+#define cds_DPB_pointer(cds)    (*(far_t *)&cds[cds_DPB_pointer_off])
 #define cds_cur_cluster(cds)  (*(u_short *)&cds[cds_cur_cluster_off])
 #define cds_rootlen(cds)      (*(u_short *)&cds[cds_rootlen_off])
 
@@ -1374,7 +1374,7 @@ static int init_dos_offsets(int ver)
 
   cds_current_path_off = 0x0;
   cds_flags_off = 0x43;
-  cds_DBP_pointer_off = 0x45;
+  cds_DPB_pointer_off = 0x45;
   cds_cur_cluster_off = 0x49;
   cds_rootlen_off = 0x4f;
 
@@ -2619,7 +2619,7 @@ int ResetRedirection(int dsk)
 static void RemoveRedirection(int drive, cds_t cds)
 {
   char *path;
-  far_t DBPptr;
+  far_t DPBptr;
 
   /* reset information in the CDS for this drive */
   cds_flags(cds) = 0;		/* default to a "not ready" drive */
@@ -2634,9 +2634,9 @@ static void RemoveRedirection(int drive, cds_t cds)
   cds_cur_cluster(cds) = 0;	/* reset us at the root of the drive */
 
   /* see if there is a physical drive behind this redirection */
-  DBPptr = cds_DBP_pointer(cds);
-  if (DBPptr.offset | DBPptr.segment) {
-    /* if DBP_pointer is non-NULL, set the drive status to ready */
+  DPBptr = cds_DPB_pointer(cds);
+  if (DPBptr.offset | DPBptr.segment) {
+    /* if DPB_pointer is non-NULL, set the drive status to ready */
     cds_flags(cds) = CDS_FLAG_READY;
   }
 }

--- a/src/include/dos2linux.h
+++ b/src/include/dos2linux.h
@@ -41,6 +41,14 @@ struct PSP {
 	char		cmdline[0x100-0x81];	/* 0x81 */
 } __attribute__((packed));
 
+struct DDH {
+  FAR_PTR next;
+  uint16_t attr;
+  uint16_t strat;
+  uint16_t intr;
+  char name[8];
+} __attribute__((packed));
+
 struct DPB {
 	unsigned char drv_num;
 	unsigned char unit_num;

--- a/src/include/dos2linux.h
+++ b/src/include/dos2linux.h
@@ -50,24 +50,38 @@ struct DDH {
 } __attribute__((packed));
 
 struct DPB {
-	unsigned char drv_num;
-	unsigned char unit_num;
-	unsigned short bytes_per_sect;
-	unsigned char last_sec_in_clust;
-	unsigned char sec_shift;
-	unsigned short reserv_secs;
-	unsigned char num_fats;
-	unsigned short root_ents;
-	unsigned short data_start;
-	unsigned short max_clu;
-	unsigned short sects_per_fat;
-	unsigned short first_dir_off;
-	far_t ddh_ptr;
-	unsigned char media_id;
-	unsigned char accessed;
-	far_t next_DPB;
-	unsigned short first_free_clu;
-	unsigned short fre_clusts;
+  uint8_t drv_num;
+  uint8_t unit_num;
+  uint16_t bytes_per_sect;
+  uint8_t last_sec_in_clust;
+  uint8_t sec_shift;
+  uint16_t reserv_secs;
+  uint8_t num_fats;
+  uint16_t root_ents;
+  uint16_t data_start;
+  uint16_t max_clu;
+  union {
+    struct {
+      uint8_t sects_per_fat;
+      uint16_t first_dir_off;
+      far_t ddh_ptr;
+      uint8_t media_id;
+      uint8_t accessed;
+      far_t next_DPB;
+      uint16_t first_free_clu;
+      uint16_t fre_clusts;
+    } __attribute__((packed)) v3;
+    struct {
+      uint16_t sects_per_fat;
+      uint16_t first_dir_off;
+      far_t ddh_ptr;
+      uint8_t media_id;
+      uint8_t accessed;
+      far_t next_DPB;
+      uint16_t first_free_clu;
+      uint16_t fre_clusts;
+    } __attribute__((packed)) v4;
+  };
 } __attribute__((packed));
 
 struct DINFO {

--- a/src/plugin/debugger/dosdebug.c
+++ b/src/plugin/debugger/dosdebug.c
@@ -206,6 +206,8 @@ static COMMAND cmds[] = {
    "                  display MCBs by walking the chain\n"},
   {"devs", NULL,
    "                  display DEVICEs by walking the chain\n"},
+  {"dpbs", NULL,
+   "                  display DPBs by walking the chain\n"},
   {"kill", db_kill,
    "                  Kill the dosemu process\n"},
   {"quit", db_quit,

--- a/src/plugin/debugger/dosdebug.c
+++ b/src/plugin/debugger/dosdebug.c
@@ -204,6 +204,8 @@ static COMMAND cmds[] = {
    "[on | off | info | FLAGS ] get/set debug-log flags (e.g 'log +M-k')\n"},
   {"mcbs", NULL,
    "                  display MCBs by walking the chain\n"},
+  {"devs", NULL,
+   "                  display DEVICEs by walking the chain\n"},
   {"kill", db_kill,
    "                  Kill the dosemu process\n"},
   {"quit", db_quit,

--- a/src/plugin/debugger/mhpdbgc.c
+++ b/src/plugin/debugger/mhpdbgc.c
@@ -94,6 +94,7 @@ static void mhp_dump_to_file (int, char *[]);
 static void mhp_ivec    (int, char *[]);
 static void mhp_mcbs    (int, char *[]);
 static void mhp_devs    (int, char *[]);
+static void mhp_dpbs    (int, char *[]);
 static void mhp_bplog   (int, char *[]);
 static void mhp_bclog   (int, char *[]);
 static void print_log_breakpoints(void);
@@ -147,6 +148,7 @@ static const struct cmd_db cmdtab[] = {
    {"ivec",          mhp_ivec},
    {"mcbs",          mhp_mcbs},
    {"devs",          mhp_devs},
+   {"dpbs",          mhp_dpbs},
    {"",              NULL}
 };
 
@@ -1039,6 +1041,52 @@ static void mhp_devs(int argc, char *argv[])
 
     mhp_printf("  Routines: Strategy(%04x:%04x), Interrupt(%04x:%04x)\n",
         FP_SEG16(p), FP_OFF16(dev->strat), FP_SEG16(p), FP_OFF16(dev->intr));
+
+    mhp_printf("\n");
+  }
+}
+
+static void mhp_dpbs(int argc, char *argv[])
+{
+  struct DPB *dpbp;
+  far_t p;
+  int cnt;
+
+  if (!lol) {
+    mhp_printf("DOS's LOL not set\n");
+    return;
+  }
+
+#define DV v4
+  mhp_printf("DPBs (compiled for DOS v4+ format)\n\n");
+
+  for (p = lol_dpbfarptr(lol), cnt = 0; p.offset != 0xffff && cnt < 256; p = dpbp->DV.next_DPB, cnt++) {
+
+    dpbp = FARt_PTR(p);
+    if (!dpbp) {
+      mhp_printf("Null DPB pointer\n");
+      return;
+    }
+
+    mhp_printf("%04X:%04X (%c:)\n", p.segment, p.offset, 'A' + dpbp->drv_num);
+    mhp_printf("  driver unit: %d\n", dpbp->unit_num);
+    mhp_printf("  bytes_per_sect = 0x%x\n", dpbp->bytes_per_sect);
+    mhp_printf("  last_sec_in_clust = 0x%x\n", dpbp->last_sec_in_clust);
+    mhp_printf("  sec_shift = 0x%x\n", dpbp->sec_shift);
+    mhp_printf("  reserv_secs = 0x%x\n", dpbp->reserv_secs);
+    mhp_printf("  num_fats = 0x%x\n", dpbp->num_fats);
+    mhp_printf("  root_ents = 0x%x\n", dpbp->root_ents);
+    mhp_printf("  data_start = 0x%x\n", dpbp->data_start);
+    mhp_printf("  max_clu = 0x%x\n", dpbp->max_clu);
+
+    mhp_printf("  sects_per_fat = 0x%x\n", dpbp->DV.sects_per_fat);
+    mhp_printf("  first_dir_off = 0x%x\n", dpbp->DV.first_dir_off);
+    mhp_printf("  device driver = %04X:%04X\n", dpbp->DV.ddh_ptr.segment, dpbp->DV.ddh_ptr.offset);
+    mhp_printf("  media_id = 0x%x\n", dpbp->DV.media_id);
+    mhp_printf("  accessed = 0x%x\n", dpbp->DV.accessed);
+    mhp_printf("  next_DPB = %04X:%04X\n", dpbp->DV.next_DPB.segment, dpbp->DV.next_DPB.offset);
+    mhp_printf("  first_free_clu = 0x%x\n", dpbp->DV.first_free_clu);
+    mhp_printf("  fre_clusts = 0x%x\n", dpbp->DV.fre_clusts);
 
     mhp_printf("\n");
   }


### PR DESCRIPTION
1/ Add a couple of commands for dosdebug useful when writing block device drivers.
2/ Correct long standing DPB typo.

Mentioned in #815 
