### PR TITLE
Dosdebug 38

### DIFF
--- a/src/include/dos2linux.h
+++ b/src/include/dos2linux.h
@@ -18,6 +18,23 @@ struct MCB {
 	char name[8];			/* 8 */
 } __attribute__((packed));
 
+struct DSCB {
+  char stype;           /* 0 (subsegment type)
+                          'D'  device driver
+                          'E'  device driver appendage
+                          'I'  Installable File System driver
+                          'F'  FILES= control block storage area (for FILES>5)
+                          'X'  FCBS= control block storage area, if present
+                          'C'  BUFFERS EMS workspace area if BUFFERS /X is used
+                          'B'  BUFFERS= storage area
+                          'L'  LASTDRIVE= current directory structure array
+                          'S'  STACKS= code/data area, if present (see below) */
+  uint16_t start;       /* 1 (segment) */
+  uint16_t size;        /* 3 (paragraphs) */
+  char padding[3];      /* 5 */
+  char fname[8];        /* 8 (types "D" and "I" filename of driver) */
+} __attribute__((packed));
+
 struct PSP {
 	unsigned short	opint20;	/* 0x00 */
 	unsigned short	memend_frame;	/* 0x02 */


### PR DESCRIPTION
dosdebug: Tidy up display of MCBs
 
    1/ Use single loop and logic for MCB display
    2/ Add display of DOS data subsegments
~~~
    dosdebug> mcbs
    dosdebug>
    
    ADDR(LOW) PARAS  OWNER
    0290:0000 0x000d [DOS]
      => ADDR      PARAS TYPE USAGE
         0291:0000 0x000c [F] Files
    029e:0000 0x9d60 [FREE] (END)
    
    ADDR(UMA) PARAS  OWNER
    9fff:0000 ------ [LINK]
    c300:0000 0x0215 [DOS]
      => ADDR      PARAS TYPE USAGE
         c301:0000 0x0009 [D] Driver (EMS)
         c30b:0000 0x0008 [D] Driver (EMUFS)
         c314:0000 0x0020 [B] Buffers
         c335:0000 0x00cf [F] Files
         c405:0000 0x008f [L] CDS Array
         c495:0000 0x0080 [S] Stacks
    c516:0000 0x0006 [FREE]
    c51d:0000 0x12c1 [COMMAND]
    d7df:0000 0x081f [FREE]
    dfff:0000 ------ [LINK]
    f000:0000 0x0513 [FREE]
    f514:0000 0x0619 [COMMAND]
    fb2e:0000 0x0090 [COMMAND]
    fbbf:0000 0x0040 [COMMAND] (END)
~~~
