### PR TITLE
builtins: Add check for default drive to lredir [fixes #844]

### DIFF
--- a/src/dosext/builtins/doserror.h
+++ b/src/dosext/builtins/doserror.h
@@ -10,6 +10,7 @@
 #define DOS_EPERM	EACCES
 #define DOS_EBADF	0x06
 #define DOS_ENOMEM	0x08
+#define DOS_EDISK_DRIVE_INVALID 0x0f
 #define DOS_EBUSY	0x15
 #define DOS_EGENERAL	0x1F
 


### PR DESCRIPTION
1/ Previously it was possible to delete the current drive from underneath
DOS. Add a check to prevent the user doing this.

##### before:
~~~
C:\>lredir g: /tmp
G: = \\LINUX\FS/TMP attrib = READ/WRITE
C:\>g:
G:\>lredir -d g:
Redirection for drive G: was deleted.
G:\>dir
File not found. - '.'
G:\>
~~~

##### after:
~~~
C:\>lredir g: /tmp
G: = \\LINUX\FS/TMP attrib = READ/WRITE
C:\>g:
G:\>lredir -d g:
Error G: is the default drive, aborting
G:\>
~~~

2/ In addition the error code for lredir delete is now returned