### PR TITLE
mfs: CancelRedirection now checks for current drive

### DIFF
--- a/src/dosext/builtins/doserror.h
+++ b/src/dosext/builtins/doserror.h
@@ -11,6 +11,7 @@
 #define DOS_EBADF	0x06
 #define DOS_ENOMEM	0x08
 #define DOS_EDISK_DRIVE_INVALID 0x0f
+#define DOS_EATT_REM_CUR_DIR    0x10
 #define DOS_EBUSY	0x15
 #define DOS_EGENERAL	0x1F
 

--- a/src/dosext/builtins/lredir.c
+++ b/src/dosext/builtins/lredir.c
@@ -193,16 +193,13 @@ static int DeleteDriveRedirection(char *deviceStr)
     /* convert device string to upper case */
     strupperDOS(deviceStr);
 
-    /* Check we aren't removing the default drive from under us */
-    if (deviceStr[0] - 'A' == com_dosgetdrive()) {
-      printf("Error %c: is the default drive, aborting\n", deviceStr[0]);
-      return DOS_EDISK_DRIVE_INVALID;
-    }
-
     ccode = com_CancelRedirection(deviceStr);
     if (ccode) {
-      printf("Error %x (%s) canceling redirection on drive %s\n",
-             ccode, decode_DOS_error(ccode), deviceStr);
+      if (ccode == DOS_EATT_REM_CUR_DIR)
+        printf("Error %c: is the default drive, aborting\n", deviceStr[0]);
+      else
+        printf("Error %x (%s) canceling redirection on drive %s\n",
+               ccode, decode_DOS_error(ccode), deviceStr);
       return ccode;
     }
 

--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -184,6 +184,7 @@ TODO:
 #include "doshelpers.h"
 /* For passing through GetRedirection Status */
 #include "memory.h"
+#include "lowmem.h"
 #include "redirect.h"
 #include "mangle.h"
 #include "utilities.h"
@@ -370,6 +371,58 @@ static uint16_t GetDataSegment(void)
   ds = _DS;
   REGS = saved_regs;
   return ds;
+}
+
+/*****************************
+ * GetCurrentDriveInDOS
+ * on entry:
+ *   drv: For the result (0=A, 1=B etc)
+ * on exit:
+ *   Returns 1 on success, 0 on fail
+ * notes:
+ *   This function can be used only whilst InDOS, in essence that means from
+ *   redirector int2f/11 function. It relies on being able to run int2f/12
+ *   functions which need to use the DOS stack. Outside of DOS use int21/19
+ *   which is much easier in any case
+ *****************************/
+static int GetCurrentDriveInDOS(uint8_t *drv)
+{
+  struct vm86_regs saved_regs = REGS;
+  char *buf;
+  uint8_t dd;
+  int ret = 0;
+
+  if (!(buf = lowmem_heap_alloc(2 + 128)))
+    return 0;
+
+  /* Ask DOS to canonicalize '\' which should give us 'X:\' back */
+  memcpy(buf, "\\", 2);
+  _DS = DOSEMU_LMHEAP_SEG;	// DS:SI -> file name to be fully qualified
+  _SI = DOSEMU_LMHEAP_OFFS_OF(buf);
+  memset(buf + 2, 0, 128);
+  _ES = _DS;			// ES:DI -> canonical file name result
+  _DI = _SI + 2;
+
+  _AX = 0x1221;
+  do_int_call_back(0x2f);
+
+  REGS = saved_regs;
+
+  Debug0((dbg_fd, "GetCurrentDriveInDOS() '\\' -> '%s'\n", buf + 2));
+
+  // Sanity checks
+  if (!buf[2] || buf[3] != ':')
+    goto done;
+  dd = toupper(buf[2]) - 'A';
+  if (dd >= 26)
+    goto done;
+
+  *drv = dd;
+  ret = 1;
+
+done:
+  lowmem_heap_free(buf);
+  return ret;
 }
 
 /*****************************
@@ -2616,10 +2669,17 @@ int ResetRedirection(int dsk)
   return 0;
 }
 
+/* See if there is a physical drive behind any redirection */
+static int hasPhysical(cds_t cds)
+{
+  far_t DPBptr = cds_DPB_pointer(cds);
+
+  return (DPBptr.offset != 0 || DPBptr.segment != 0);
+}
+
 static void RemoveRedirection(int drive, cds_t cds)
 {
   char *path;
-  far_t DPBptr;
 
   /* reset information in the CDS for this drive */
   cds_flags(cds) = 0;		/* default to a "not ready" drive */
@@ -2633,12 +2693,8 @@ static void RemoveRedirection(int drive, cds_t cds)
   cds_rootlen(cds) = CDS_DEFAULT_ROOT_LEN;
   cds_cur_cluster(cds) = 0;	/* reset us at the root of the drive */
 
-  /* see if there is a physical drive behind this redirection */
-  DPBptr = cds_DPB_pointer(cds);
-  if (DPBptr.offset | DPBptr.segment) {
-    /* if DPB_pointer is non-NULL, set the drive status to ready */
+  if (hasPhysical(cds))
     cds_flags(cds) = CDS_FLAG_READY;
-  }
 }
 
 /*****************************
@@ -2652,7 +2708,7 @@ static int
 CancelRedirection(struct vm86_regs *state)
 {
   char *deviceName;
-  int drive;
+  uint8_t drive, curdrv;
   cds_t cds;
 
   /* first, see if this is one of our current redirections */
@@ -2661,7 +2717,7 @@ CancelRedirection(struct vm86_regs *state)
   Debug0((dbg_fd, "CancelRedirection on %s\n", deviceName));
 
   /* we only handle drive redirections, pass it through */
-  if (deviceName[1] != ':') {
+  if (!deviceName[0] || deviceName[1] != ':') {
     return REDIRECT;
   }
   drive = toupperDOS(deviceName[0]) - 'A';
@@ -2669,6 +2725,16 @@ CancelRedirection(struct vm86_regs *state)
   /* see if drive is in range of valid drives */
   if (!GetCDSInDOS(drive, &cds)) {
     SETWORD(&(state->eax), DISK_DRIVE_INVALID);
+    return FALSE;
+  }
+
+  // Don't remove drive from under us unless we revert to FATFS
+  if (!GetCurrentDriveInDOS(&curdrv)) {
+    SETWORD(&(state->eax), GENERAL_FAILURE);
+    return FALSE;
+  }
+  if (drive == curdrv && !hasPhysical(cds)) {
+    SETWORD(&(state->eax), ATT_REM_CUR_DIR);
     return FALSE;
   }
 


### PR DESCRIPTION
Removing the default drive is generally a bad idea, see #844, but in
the case that deleting the redirection would reveal the FATFS drive
underneath it's still a valid operation.

1/ Move the lredir test for default drive up into the redirector itself.
2/ Introduce a new function that can determine the current drive whilst
   running inside DOS.
3/ Split out the test for underlying physical drive from
   RemoveRedirection() so that we may use it elsewhere.

Tests:

* Non FATFS backed current drive
C:\>lredir g: /tmp
G: = \\LINUX\FS/TMP attrib = READ/WRITE
C:\>g:
G:\>lredir -d g:
Error G: is the default drive, aborting

* FATFS backed current drive
G:\>c:
C:\>lredir -d c:
Redirection for drive C: was deleted.

* FATFS backed non current drive
C:\>lredir -d f:
Redirection for drive F: was deleted.