### PR TITLE
dosdebug: Allow user to specify DPB start address

### DIFF
--- a/src/plugin/debugger/dosdebug.c
+++ b/src/plugin/debugger/dosdebug.c
@@ -207,7 +207,7 @@ static COMMAND cmds[] = {
   {"devs", NULL,
    "                  display DEVICEs by walking the chain\n"},
   {"dpbs", NULL,
-   "                  display DPBs by walking the chain\n"},
+   "[ADDR]            display DPBs by walking the chain from LOL or ADDR\n"},
   {"kill", db_kill,
    "                  Kill the dosemu process\n"},
   {"quit", db_quit,

--- a/src/plugin/debugger/mhpdbgc.c
+++ b/src/plugin/debugger/mhpdbgc.c
@@ -1140,15 +1140,27 @@ static void mhp_dpbs(int argc, char *argv[])
   far_t p;
   int cnt;
 
-  if (!lol) {
-    mhp_printf("DOS's LOL not set\n");
-    return;
+  if (argc > 1) {
+    dosaddr_t val;
+    unsigned int seg, off, limit;
+
+    if (!mhp_getadr(argv[1], &val, &seg, &off, &limit)) {
+      mhp_printf("Invalid DPB address\n");
+      return;
+    }
+    p = MK_FARt(seg, off);
+  } else {
+    if (!lol) {
+      mhp_printf("DOS's LOL not set and no DPB address given\n");
+      return;
+    }
+    p = lol_dpbfarptr(lol);
   }
 
 #define DV v4
   mhp_printf("DPBs (compiled for DOS v4+ format)\n\n");
 
-  for (p = lol_dpbfarptr(lol), cnt = 0; p.offset != 0xffff && cnt < 256; p = dpbp->DV.next_DPB, cnt++) {
+  for (cnt = 0; p.offset != 0xffff && cnt < 26; p = dpbp->DV.next_DPB, cnt++) {
 
     dpbp = FARt_PTR(p);
     if (!dpbp) {


### PR DESCRIPTION
1/ During the boot process Dosemu's LOL pointer may not be set,
    so allow the user to supply an address to start printing the DPB
    entries.

2/ Limit the number of DPBs displayed to 26

Use:
  If using FDPP you can get the address from GDB as follows:
~~~
    (gdb) p/x  LoL->_CDSp[0].cdsDpb
    $32 = {ptr = {off = 0x19e8, seg = 0xd9}}
~~~

  Here the chain is displayed starting at F: address, not the A:
    address above.
~~~
dosdebug> dpbs 00D9:1B19
dosdebug>
DPBs (compiled for DOS v4+ format)

00D9:1B19 (F:)
  driver unit: 5
  bytes_per_sect = 0x200
  last_sec_in_clust = 0x3f
  sec_shift = 0x6
  reserv_secs = 0x1
  num_fats = 0x2
  root_ents = 0x200
  data_start = 0x217
  max_clu = 0xfa00
  sects_per_fat = 0xfb
  first_dir_off = 0x1f7
  device driver = 0070:0618
  media_id = 0xf8
  accessed = 0x0
  next_DPB = 02C0:0000
  first_free_clu = 0x0
  fre_clusts = 0xffff

02C0:0000 (G:)
  driver unit: 0
  bytes_per_sect = 0x200
  last_sec_in_clust = 0x3f
  sec_shift = 0x6
  reserv_secs = 0x1
  num_fats = 0x2
  root_ents = 0x200
  data_start = 0x217
  max_clu = 0xfa00
  sects_per_fat = 0xfb
  first_dir_off = 0x1f7
  device driver = 02B2:0000
  media_id = 0xf8
  accessed = 0x0
  next_DPB = FFFF:FFFF
  first_free_clu = 0x0
  fre_clusts = 0xffff
~~~