### PR TITLE
lredir: Ask DOS if drive is free [fixes #768]

### DIFF
--- a/src/base/misc/dos2linux.c
+++ b/src/base/misc/dos2linux.c
@@ -248,37 +248,6 @@ int find_drive (char **plinux_path_resolved)
   return -26;
 }
 
-static int is_drive_used(int drv)
-{
-  int i;
-
-  FOR_EACH_HDISK(i, {
-    if (HDISK_NUM(i) == drv)
-      return 1;
-  });
-  return 0;
-}
-
-int find_free_drive(void)
-{
-  int drive;
-
-  for (drive = 2; drive < 26; drive++) {
-    char *drive_linux_root;
-    int drive_ro, ret;
-
-    ret = GetRedirectionRoot(drive, &drive_linux_root, &drive_ro);
-    if (ret != 0) {
-      if (is_drive_used(drive))
-        continue;
-      return drive;
-    }
-    free(drive_linux_root);
-  }
-
-  return -1;
-}
-
 static int pty_fd;
 static int pty_done;
 static int cbrk;

--- a/src/dosext/builtins/builtins.c
+++ b/src/dosext/builtins/builtins.c
@@ -318,6 +318,34 @@ int com_dossetcurrentdir(char *path)
         return 0;
 }
 
+static int is_valid_drive(int drv)
+{
+  uint16_t ret;
+
+  pre_msdos();
+
+  HI(ax) = 0x36; // get free disk space
+  LO(dx) = drv;
+  call_msdos();
+  ret = LWORD(eax);
+
+  post_msdos();
+  return ret != 0xffff;
+}
+
+int com_FindFreeDrive(void)
+{
+  int drive;
+
+  for (drive = 2; drive < 26; drive++) {
+    if (is_valid_drive(drive + 1))  // 0 = default, 1 = A etc
+      continue;
+    return drive;
+  }
+
+  return -1;
+}
+
 /********************************************
  * com_RedirectDevice - redirect a device to a remote resource
  * ON ENTRY:

--- a/src/dosext/builtins/builtins.h
+++ b/src/dosext/builtins/builtins.h
@@ -70,6 +70,7 @@ char *skip_white_and_delim(char *s, int delim);
 struct REGPACK regs_to_regpack(struct vm86_regs *regs);
 struct vm86_regs regpack_to_regs(struct REGPACK *regpack);
 
+int com_FindFreeDrive(void);
 uint16_t com_RedirectDevice(char *, char *, uint8_t, uint16_t);
 uint16_t com_CancelRedirection(char *);
 uint16_t com_GetRedirection(uint16_t, char *, char *, uint8_t *, uint16_t *);

--- a/src/dosext/builtins/lredir.c
+++ b/src/dosext/builtins/lredir.c
@@ -389,10 +389,10 @@ static int fill_dev_str(char *deviceStr, char *argv,
 	strcpy(deviceStr, argv);
     } else {
 	int nextDrive;
-	nextDrive = find_free_drive();
+	nextDrive = com_FindFreeDrive();
 	if (nextDrive < 0) {
-		printf("Cannot redirect (maybe no drives available).");
-		return 1;
+	    printf("Cannot redirect (maybe no drives available).");
+	    return 1;
 	}
 	deviceStr[0] = nextDrive + 'A';
 	deviceStr[1] = ':';

--- a/src/dosext/builtins/system.c
+++ b/src/dosext/builtins/system.c
@@ -153,7 +153,7 @@ static int setupDOSCommand(const char *linux_path, int n_up, char *r_drv)
   char *path1, *p;
   char drvStr[3];
 
-  drive = find_free_drive();
+  drive = com_FindFreeDrive();
   if (drive < 0) {
     com_fprintf (com_stderr,
                      "ERROR: Cannot find a free DOS drive to use for LREDIR\n");

--- a/src/include/dos2linux.h
+++ b/src/include/dos2linux.h
@@ -260,7 +260,6 @@ extern char *misc_e6_options (void);
 extern void misc_e6_store_options(char *str);
 
 extern int find_drive (char **linux_path_resolved);
-extern int find_free_drive(void);
 
 extern int run_unix_command (char *buffer);
 extern int change_config(unsigned item, void *buf, int grab_active, int kbd_grab_active);


### PR DESCRIPTION
Lredir needs to know what the next unused drive is for its '-n' map next
free drive etc. The best way to find out whether a drive is in use is to
ask DOS because examining the drives array is not sufficient when disk
images are used with multiple partitions(#768).

The log below shows the difference, prior to this patch the 'I:' would
be chosen, whereas afterwards it is 'M:'

~~~
FDPP kernel 0.1beta7 [GIT: beta-7-6-g05bf29d] (compiled Jul  8 2019)
Kernel compatibility 7.10 - GNUC - 80386 CPU required - FAT32 support

Written by Stas Sergeev, FDPP project.
Based on FreeDOS sources (C) Pasquale J. Villani and The FreeDOS Project.

This program is free software: you can redistribute it and/or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation, either version 3 of the License, or
(at your option) any later version.

C: HD1, Pri[ 1], CHS=    0-1-1, start=     0 MB, size=    10 MB
D: HD2, Pri[ 1], CHS=    0-32-33, start=     1 MB, size=    12 MB
E: HD3, Pri[ 1], CHS=    0-32-33, start=     1 MB, size=    12 MB
F: HD4, Pri[ 1], CHS=    0-1-1, start=     0 MB, size=  2000 MB
G: HD5, Pri[ 1], CHS=    0-1-1, start=     0 MB, size=  2000 MB
H: HD6, Pri[ 1], CHS=    0-1-1, start=     0 MB, size=  2000 MB
I: HD2, Pri[ 2], CHS=    1-167-39, start=    13 MB, size=   128 MB
J: HD2, Pri[ 3], CHS=   17-248-40, start=   141 MB, size=   371 MB
K: HD3, Pri[ 2], CHS=    1-167-39, start=    13 MB, size=   128 MB
L: HD3, Pri[ 3], CHS=   17-248-40, start=   141 MB, size=   371 MB
EMUFS host file and print access available
dosemu XMS 3.0 & UMB support enabled
dosemu EMS driver rev 0.8 installed.
Process 0 starting: C:\command.com /P /E:256

FreeCom version 0.84-pre2 XMS_Swap [Aug 28 2006 00:29:00]
C:\>prompt $P$G
C:\>path c:\bin;c:\gnu;c:\dosemu
C:\>system -s DOSEMU_VERSION
C:\>system -e
C:\>lredir -n /tmp
M: = \\LINUX\FS/TMP attrib = READ/WRITE
C:\>
~~~