### PR TITLE
macros: Rename SEG2LINEAR to reflect its use

### DIFF
--- a/src/base/core/int.c
+++ b/src/base/core/int.c
@@ -2183,7 +2183,7 @@ static int int2f(int stk_offs)
 	    if (!psp_seg)
 		break;
 	    do_run_cmd(str, cmd);
-	    mcb = (struct MCB *) SEG2LINEAR(psp_seg - 1);
+	    mcb = (struct MCB *) SEG2UNIX(psp_seg - 1);
 	    if (!mcb)
 		break;
 
@@ -2844,7 +2844,7 @@ void update_xtitle(void)
     psp_seg = sda_cur_psp(sda);
     if (!psp_seg)
 	return;
-    mcb = (struct MCB *) SEG2LINEAR(psp_seg - 1);
+    mcb = (struct MCB *) SEG2UNIX(psp_seg - 1);
     if (!mcb)
 	return;
     force_update = !title_hint[0];

--- a/src/dosext/builtins/builtins.c
+++ b/src/dosext/builtins/builtins.c
@@ -68,7 +68,7 @@ static void com_strfree(char *s);
 char *com_getenv(const char *keyword)
 {
 	struct PSP  *psp = COM_PSP_ADDR;
-	char *env = SEG2LINEAR(psp->envir_frame);
+	char *env = SEG2UNIX(psp->envir_frame);
 	char key[128];
 	int len;
 
@@ -548,7 +548,7 @@ void register_com_program(const char *name, com_program_type *program)
 
 static char *com_getarg0(void)
 {
-	char *env = SEG2LINEAR(((struct PSP *)SEG2LINEAR(COM_PSP_SEG))->envir_frame);
+	char *env = SEG2UNIX(((struct PSP *)SEG2UNIX(COM_PSP_SEG))->envir_frame);
 	return memchr(env, 1, 0x10000) + 2;
 }
 
@@ -639,8 +639,8 @@ int commands_plugin_inte6(void)
 	    return 0;
 	}
 
-	psp = SEG2LINEAR(COM_PSP_SEG);
-	mcb = SEG2LINEAR(COM_PSP_SEG - 1);
+	psp = SEG2UNIX(COM_PSP_SEG);
+	mcb = SEG2UNIX(COM_PSP_SEG - 1);
 	arg0 = com_getarg0();
 	/* see if we have valid asciiz name in MCB */
 	err = 0;

--- a/src/dosext/builtins/msetenv.c
+++ b/src/dosext/builtins/msetenv.c
@@ -28,7 +28,7 @@ static char *envptr(int *size, int parent_p)
     unsigned mcbseg;
     struct MCB *mcb;
 
-    parent_psp = (struct PSP *)SEG2LINEAR(parent_p);
+    parent_psp = (struct PSP *)SEG2UNIX(parent_p);
     if (parent_psp->envir_frame == 0) {
         error("no env pointer in PSP\n");
         return NULL;
@@ -136,7 +136,7 @@ int mresize_env(int size_plus)
         error("cannot realloc env to %i bytes\n", size + size_plus);
         return -1;
     }
-    memcpy(SEG2LINEAR(new_env), env, size);
+    memcpy(SEG2UNIX(new_env), env, size);
     /* DOS resize (0x4a) can't move :( */
     if (psp->envir_frame)
         err = com_dosfreemem(psp->envir_frame);

--- a/src/dosext/misc/xms.c
+++ b/src/dosext/misc/xms.c
@@ -179,7 +179,7 @@ static void umb_free(int segbase)
   int umb = umb_find(segbase);
 
   if (umb != UMB_NULL)
-    smfree(&umbs[umb], SEG2LINEAR(segbase));
+    smfree(&umbs[umb], SEG2UNIX(segbase));
 }
 
 static int

--- a/src/include/cpu.h
+++ b/src/include/cpu.h
@@ -213,7 +213,7 @@ union g_reg {
 /* alternative SEG:OFF to linear conversion macro */
 #define SEGOFF2LINEAR(seg, off)  ((((unsigned)(seg)) << 4) + (off))
 
-#define SEG2LINEAR(seg)		LINEAR2UNIX(SEGOFF2LINEAR(seg, 0))
+#define SEG2UNIX(seg)		LINEAR2UNIX(SEGOFF2LINEAR(seg, 0))
 
 typedef unsigned int FAR_PTR;	/* non-normalized seg:off 32 bit DOS pointer */
 typedef struct {

--- a/src/plugin/fdpp/fdpp.c
+++ b/src/plugin/fdpp/fdpp.c
@@ -198,7 +198,7 @@ static int fdpp_pre_boot(void)
     uint16_t ofs = 0x0000;
     dosaddr_t loadaddress = SEGOFF2LINEAR(seg, ofs);
     uint16_t env_seg = bprm_seg + 8;
-    char *env = SEG2LINEAR(env_seg);
+    char *env = SEG2UNIX(env_seg);
     int env_len = 0;
     int warn_legacy_conf = 0;
 


### PR DESCRIPTION
The macro SEG2LINEAR was incorrectly named as in fact it returns a unix
pointer rather than linear address value, so rename it to SEG2UNIX and
change all its callers. Mentioned in #763