### PR TITLE
dosdebug: Add command to display device driver request

### DIFF
--- a/src/include/dos2linux.h
+++ b/src/include/dos2linux.h
@@ -66,6 +66,55 @@ struct DDH {
   char name[8];
 } __attribute__((packed));
 
+struct DDRH {
+  uint8_t length;
+  uint8_t unit;
+  uint8_t command;
+  uint16_t status;
+  uint8_t reserved[8];
+
+  // RH 6, 7, 10, 11, 13, 14, 15  (inputstatus, inputflush, outputstatus,
+  //                               outputflush, open, close, removable)
+  // have no unique portions, the variables above fully describe them
+
+  union {
+    struct { // RH 0
+      uint8_t nunits;
+      FAR_PTR brk;
+      union {
+        FAR_PTR cmdline;
+        FAR_PTR bpb;
+      };
+      uint8_t first_drv;
+    } __attribute__((packed)) init;
+
+    struct { // RH 1
+      uint8_t id;
+      int8_t status;
+    } __attribute__((packed)) media_check;
+
+    struct { // RH 2
+      uint8_t id;
+      FAR_PTR buf;
+      FAR_PTR bpb;
+    } __attribute__((packed)) get_bpb;
+
+    struct { // RH 3, 4, 8, 9, 12
+        /* ioctlread, read, write, write_verify, ioctlwrite */
+      uint8_t id;
+      FAR_PTR buf;
+      uint16_t count;
+      uint16_t start;
+      FAR_PTR volumeid; // not ioctlread
+    } __attribute__((packed)) io;
+
+    struct { // RH 5
+      uint8_t retval;
+    } __attribute__((packed)) nd_input;
+
+  };
+} __attribute__((packed));
+
 struct DPB {
   uint8_t drv_num;
   uint8_t unit_num;

--- a/src/plugin/debugger/dosdebug.c
+++ b/src/plugin/debugger/dosdebug.c
@@ -210,6 +210,8 @@ static COMMAND cmds[] = {
    "                  display MCBs by walking the chain\n"},
   {"devs", NULL,
    "                  display DEVICEs by walking the chain\n"},
+  {"ddrh", NULL,
+   "ADDR              display the Device Driver Request Header at ADDR\n"},
   {"dpbs", NULL,
    "[ADDR]            display DPBs by walking the chain from LOL or ADDR\n"},
   {"kill", db_kill,


### PR DESCRIPTION
Procedure:
  1/ Find the addresses of the driver's strategy and interrupt routines using the 'devs' command.
  2/ Review the strategy routine to see where the address of the request header will be stored each time it's called.
  3/ Set breakpoints at entry and exit of the interrupt routine
  4/ Run until first breakpoint is hit 'entry'
  5/ Display the request header pointer
  6/ Display header on entry with the new command like 'ddrh ADDR' using
the address held in the pointer above

~~~
xmsdsk_interrupt:
02c5:00b2 9C               pushf
dosdebug> ddrh 00d8:037c
dosdebug>
Request
  length 30
  unit   0
  command 'Media Check'
    media id 0xf8
    status 1
  status 0x0000
~~~

  7/ Run until stop on 'exit' break point set
~~~
xmsdsk_interrupt_return:
02c5:00d9 CB               retf
dosdebug> ddrh 00d8:037c
dosdebug>
Request
  length 30
  unit   0
  command 'Media Check'
    media id 0xf8
    status 1
  status 0x0100
~~~

  8/ Repeat steps 4..7 as required, note the rh_pointer contents will very probably move.