### PR TITLE
mfs: Call int2f/120c for FCBs with DOS Stack #928

### DIFF
--- a/src/base/bios/x86/bios.s
+++ b/src/base/bios/x86/bios.s
@@ -130,20 +130,6 @@ ipx_handler:
 	int	$0x7a
 	lret
 
-/* ----------------------------------------------------------------- */
-		/* This is an int e7 used for FCB opens */
-	.globl FCB_HLP_OFF
-FCB_HLP_OFF:
-	pushw	%es
-	pushw	%di
-	pushw	%ax
-	movw	$0x120c,%ax
-	int	$0x2f
-	popw	%ax
-	popw	%di
-	popw	%es
-	iret
-
 /* This is installed after video init (helper fcn 0x9) when the internal
 	mouse driver is in use.  It watches for mouse set commands and
 	resets the mouse driver when it sees one. */

--- a/src/include/memory.h
+++ b/src/include/memory.h
@@ -79,10 +79,6 @@
  */
 #define INT10_WATCHER_SEG	BIOSSEG
 
-/* This inline interrupt is used for FCB open calls */
-#define FCB_HLP_SEG	BIOSSEG
-#define FCB_HLP_ADD	((INTE7_SEG << 4) + INTE7_OFF)
-
 #define DPMI_SEG	BIOSSEG
 #define DPMI_ADD	((DPMI_SEG << 4) + DPMI_OFF)
 


### PR DESCRIPTION
With this change Castle Wolfenstein doesn't complain about the control
file not opening and now reaches the splash screen.

I don't play games myself so I've no idea what's supposed to happen next. I pressed `<return>` but ended up with a blank screen. I see something similar reported in #920, but it'd be good if someone else could look this over, please?