### PR TITLE
dosdebug: Avoid trace handler on ints 21/2f/28/33

### DIFF
--- a/src/plugin/debugger/mhpdbgc.c
+++ b/src/plugin/debugger/mhpdbgc.c
@@ -840,6 +840,8 @@ static void mhp_trace(int argc, char *argv[])
     switch (csp[0]) {
       case 0xcd:
         if (mhpdbgc.trapcmd != 1) { // plain 't'
+          if (csp[1] == 0x21 || csp[1] == 0x2f || csp[1] == 0x28 || csp[1] == 0x33)
+            break;
           LWORD(eip) += 2;
           trace_stack_push(_CS, _IP);
 


### PR DESCRIPTION
Noticed in https://github.com/stsp/fdpp/issues/112 tracing `t` can give
incorrect DOS execution, whereas tracing in `ti` behaves properly. It
has been isolated to the trace handler added in 158fe96, for now avoid
using that code on likely problem interrupts.