### PR TITLE
dosdebug: Don't repeat 'tc' command

### DIFF
--- a/src/plugin/debugger/dosdebug.c
+++ b/src/plugin/debugger/dosdebug.c
@@ -358,7 +358,8 @@ static void handle_console_input(char *line)
 #endif
     snprintf(last_line, sizeof(last_line), "%s", line);
     if ((strncmp(last_line, "d ", 2) == 0) ||
-        (strncmp(last_line, "u ", 2) == 0) ){
+        (strncmp(last_line, "u ", 2) == 0) ||
+        (strncmp(last_line, "tc", 2) == 0) ){
       last_line[1] = '\0';
     }
     p = line;      // line okay to execute


### PR DESCRIPTION
Since the 'tc' command runs until keypress, we don't want to repeat
that command upon empty line. In the case of 'tc' command store just 't'
for its subsequent repeat.