### PR TITLE
kvm: use native IDT for speed-up [fixes #982]

### DIFF
--- a/src/base/emu-i386/kvmmon.S
+++ b/src/base/emu-i386/kvmmon.S
@@ -27,7 +27,7 @@
 kvm_mon_start:
 
         i = 0
-        .rept 0x21
+        .rept 0x100
         .if i == 8 || (i >= 0xa && i <= 0xe) || i == 0x11 || i == 0x1e
         /* these exceptions already pushed an error code */
         nop

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -28,4 +28,7 @@ void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect);
 void mmap_kvm(int cap, void *addr, size_t mapsize, int protect);
 void set_kvm_memory_regions(void);
 
+void kvm_set_idt_default(int i);
+void kvm_set_idt(int i, uint16_t sel, uint32_t offs, int is_32);
+
 #endif

--- a/src/plugin/debugger/mhpdbgc.c
+++ b/src/plugin/debugger/mhpdbgc.c
@@ -59,6 +59,7 @@
 #include "bios_sym.h"
 #include "dis8086.h"
 #include "dos2linux.h"
+#include "kvm.h"
 
 #define MHP_PRIVATE
 #include "mhpdbg.h"
@@ -2102,6 +2103,8 @@ static void mhp_bpintd(int argc, char * argv[])
    if (v1) {
      if (mhp_addaxlist_value(v1)) dpmi_mhp_intxxtab[i1] |= 0x80;
    }
+   if (config.cpu_vm_dpmi == CPUVM_KVM)
+	 kvm_set_idt_default(i1);
 #endif
 }
 


### PR DESCRIPTION
This is my patch adapted to Stas' notation.

I'm still not sure about 0x70-0x77, 0x1c, 0x23, 0x24 so kept excluding them just to be cautious.
