### PR TITLE
KVM IDT changes (part 2)

### DIFF
--- a/src/base/emu-i386/kvmmon.S
+++ b/src/base/emu-i386/kvmmon.S
@@ -28,8 +28,9 @@ kvm_mon_start:
 
         i = 0
         .rept 0x100
-        .if i == 8 || (i >= 0xa && i <= 0xe) || i == 0x11 || i == 0x1e
-        /* these exceptions already pushed an error code */
+        .if i == 8 || (i >= 0xa && i <= 0xe)
+        /* these exceptions already pushed an error code
+           (exception 0x11 (alignment) and 0x1e (security) cannot occur) */
         nop
         nop
         .else


### PR DESCRIPTION
Here are some of the requested IDT changes:
1. DPMI in KVM will now use IDTs > 0x10 directly for software interrupts.
2. Extended direct IDT use to ints 0x11-0x1f (since those exceptions can never happen)
3. Eliminate the special 0xff hw int injection, by using ioctls to get and set registers. I'm not using the kvm_sync_regs structures since that requires new-ish kernels (4.18+) and the speed is not affected much since the ioctls only apply for signals, and sets only if the registers have changed (which either means a hardware int or some kind of callback / coopthread magic).
Ideally I'd inject hardware ints into KVM, and maybe even use its builtin PIC but that's for another day (then hardware ints go via the IDT and must then be reflected to the vm86 IVT).