### PR TITLE
pic: run_irqs: "while"->"if", set VIP if other IRQs pending

### DIFF
--- a/src/base/dev/pic/pic.c
+++ b/src/base/dev/pic/pic.c
@@ -640,9 +640,12 @@ static void do_irq(int ilevel)
 
     intr=pic_iinfo[ilevel].ivec;
 
-     if (pic_iinfo[ilevel].callback)
-        pic_iinfo[ilevel].callback();
-     else {
+     if (pic_iinfo[ilevel].callback) {
+       if(in_dpmi_pm())
+         fake_pm_int();
+       fake_int_to(BIOSSEG, EOI_OFF);
+       pic_iinfo[ilevel].callback();
+     } else {
        if (dpmi_active()) run_pm_int(intr);
        else {
  /* schedule the requested interrupt, then enter the vm86() loop */

--- a/src/dosext/net/ipx.c
+++ b/src/dosext/net/ipx.c
@@ -476,13 +476,6 @@ static void ipx_esr_call(far_t ECBPtr, u_char AXVal)
   n_printf("IPX: ESR callback ended\n");
 }
 
-static void ipx_esr_irq_begin(void)
-{
-  if(in_dpmi_pm())
-    fake_pm_int();
-  fake_int_to(BIOSSEG, EOI_OFF);
-}
-
 static void ipx_recv_esr_call_thr(void *arg)
 {
   n_printf("IPX: Calling receive ESR\n");
@@ -491,7 +484,6 @@ static void ipx_recv_esr_call_thr(void *arg)
 
 static void ipx_recv_esr_call(void)
 {
-  ipx_esr_irq_begin();
   coopth_start(recv_tid, ipx_recv_esr_call_thr, NULL);
 }
 
@@ -503,7 +495,6 @@ static void ipx_aes_esr_call_thr(void *arg)
 
 static void ipx_aes_esr_call(void)
 {
-  ipx_esr_irq_begin();
   coopth_start(aes_tid, ipx_aes_esr_call_thr, NULL);
 }
 

--- a/src/dosext/net/pktnew.c
+++ b/src/dosext/net/pktnew.c
@@ -557,9 +557,6 @@ Remove_Type(int handle)
 static void pkt_receiver_callback(void)
 {
     assert(p_helper_size);
-    if(in_dpmi_pm())
-	fake_pm_int();
-    fake_int_to(BIOSSEG, EOI_OFF);
     coopth_start(PKTRcvCall_TID, pkt_receiver_callback_thr, NULL);
 }
 


### PR DESCRIPTION
…pending

Ever since commit 8bf6af908 from 2005 the while loop to run do_irq() no longer
makes sense, since the ints are now run via the main loop. Mostly that doesn't
matter since outside special mask mode (through the priority mechanism)
only one IRQ can be scheduled at the same time anyway, so the while loop would
only run once.

However if special mask mode is enabled, lower priority IRQs can still be
scheduled but are blocked as long as interrupts are disabled. So to make them
run asap once interrupts are enabled, set VIP.

do_irq() may also use a callback which will do a fake int to a HLT (VIF not
reset) so will return asap anyway even without VIP.