### PR TITLE
Mfs25

### DIFF
--- a/src/base/core/int.c
+++ b/src/base/core/int.c
@@ -1922,7 +1922,7 @@ static int int19(void)
 }
 
 uint16_t RedirectDevice(char *dStr, char *sStr,
-                        uint8_t deviceType, uint16_t deviceParameter)
+                        uint8_t deviceType, uint16_t deviceOptions)
 {
   uint16_t ret;
 
@@ -1933,8 +1933,8 @@ uint16_t RedirectDevice(char *dStr, char *sStr,
   LWORD(esi) = DOSEMU_LMHEAP_OFFS_OF(dStr);
   SREG(es) = DOSEMU_LMHEAP_SEG;
   LWORD(edi) = DOSEMU_LMHEAP_OFFS_OF(sStr);
-  LWORD(ecx) = 0;
-  LWORD(edx) = deviceParameter;
+  LWORD(edx) = deviceOptions;
+  LWORD(ecx) = REDIR_CLIENT_SIGNATURE;
   LWORD(ebx) = deviceType;
   LWORD(eax) = DOS_REDIRECT_DEVICE;
 

--- a/src/dosext/builtins/builtins.h
+++ b/src/dosext/builtins/builtins.h
@@ -73,7 +73,7 @@ struct vm86_regs regpack_to_regs(struct REGPACK *regpack);
 int com_FindFreeDrive(void);
 uint16_t com_RedirectDevice(char *, char *, uint8_t, uint16_t);
 uint16_t com_CancelRedirection(char *);
-uint16_t com_GetRedirection(uint16_t, char *, char *, uint8_t *, uint16_t *);
+uint16_t com_GetRedirection(uint16_t, char *, char *, uint8_t *, uint16_t *, uint16_t *);
 
 extern int com_errno;
 

--- a/src/dosext/builtins/lredir.c
+++ b/src/dosext/builtins/lredir.c
@@ -350,6 +350,10 @@ static int lredir_parse_opts(int argc, char *argv[],
 
 	case 'C':
 	    opts->cdrom = (optarg ? atoi(optarg) : 1);
+	    if (opts->cdrom < 1 || opts->cdrom > 4) {
+		printf("Invalid CDROM unit (%d)\n", opts->cdrom);
+		return 1;
+	    }
 	    break;
 
 	case 'r':
@@ -494,7 +498,7 @@ int lredir2_main(int argc, char **argv)
 	printf("  Redirect drive X: to C:\\tmp\n");
 	printf("  If -f is specified, the redirection is forced even if already redirected.\n");
 	printf("  If -R is specified, the drive will be read-only\n");
-	printf("  If -C is specified, (read-only) CDROM n is used (n=1 by default)\n");
+	printf("  If -C is specified, (read-only) CDROM n is used (n=1..4, default=1)\n");
 	printf("  If -n is specified, the next available drive will be used.\n");
 	printf("LREDIR -d drive:\n");
 	printf("  delete a drive redirection\n");
@@ -568,7 +572,7 @@ int lredir_main(int argc, char **argv)
 	printf("  Redirect drive X: to /tmp of Linux file system for read/write\n");
 	printf("  If -f is specified, the redirection is forced even if already redirected.\n");
 	printf("  If -R is specified, the drive will be read-only\n");
-	printf("  If -C is specified, (read-only) CDROM n is used (n=1 by default)\n");
+	printf("  If -C is specified, (read-only) CDROM n is used (n=1..4, default=1)\n");
 	printf("  If -n is specified, the next available drive will be used.\n");
 	printf("LREDIR -d drive:\n");
 	printf("  delete a drive redirection\n");

--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -2506,9 +2506,9 @@ path_to_dos(char *path)
     *s = '\\';
 }
 
-static int
-GetRedirection(struct vm86_regs *state, u_short index)
+static int GetRedirection(struct vm86_regs *state)
 {
+  u_short index = WORD(state->ebx);
   int dd;
   u_short returnBX;		/* see notes below */
   u_short returnCX;
@@ -4334,7 +4334,7 @@ do_create_truncate:
           /* XXXTRB - need to support redirection index pass-thru */
         case GET_REDIRECTION:
         case EXTENDED_GET_REDIRECTION:
-          return GetRedirection(state, WORD(state->ebx));
+          return GetRedirection(state);
         case REDIRECT_DEVICE:
           return DoRedirectDevice(state);
         case CANCEL_REDIRECTION:

--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -2526,39 +2526,39 @@ static int GetRedirection(struct vm86_regs *state)
   for (dd = 0; dd < num_drives; dd++) {
     if (drives[dd].root) {
       if (index == 0) {
-	/* return information for this drive */
-	Debug0((dbg_fd, "redirection root =%s\n", drives[dd].root));
+        /* return information for this drive */
+        Debug0((dbg_fd, "redirection root =%s\n", drives[dd].root));
 
-	deviceName = Addr(state, ds, esi);
-	snprintf(deviceName, 16, "%c:", 'A' + dd);
-	Debug0((dbg_fd, "device name =%s\n", deviceName));
+        deviceName = Addr(state, ds, esi);
+        snprintf(deviceName, 16, "%c:", 'A' + dd);
+        Debug0((dbg_fd, "device name =%s\n", deviceName));
 
-	resourceName = Addr(state, es, edi);
-	snprintf(resourceName, 128, LINUX_RESOURCE "%s", drives[dd].root);
-	path_to_dos(resourceName);
-	Debug0((dbg_fd, "resource name =%s\n", resourceName));
+        resourceName = Addr(state, es, edi);
+        snprintf(resourceName, 128, LINUX_RESOURCE "%s", drives[dd].root);
+        path_to_dos(resourceName);
+        Debug0((dbg_fd, "resource name =%s\n", resourceName));
 
-	/* have to return BX, and CX on the user return stack */
-	/* return a "valid" disk redirection */
-	returnBX = 4;		/*BH=0, BL=4 */
+        /* have to return BX, and CX on the user return stack */
+        /* return a "valid" disk redirection */
+        returnBX = 4; /*BH=0, BL=4 */
 
-	/* set the high bit of the return CL so that */
-	/* NetWare shell doesn't get confused */
-	returnCX = drives[dd].user_param | 0x80;
-	returnDX = drives[dd].options;
+        /* set the high bit of the return CL so that */
+        /* NetWare shell doesn't get confused */
+        returnCX = drives[dd].user_param | 0x80;
+        returnDX = drives[dd].options;
 
-	Debug0((dbg_fd, "GetRedirection CX=%04x\n", returnCX));
+        Debug0((dbg_fd, "GetRedirection CX=%04x\n", returnCX));
 
-	userStack = (u_short *) sda_user_stack(sda);
-	userStack[1] = returnBX;
-	userStack[2] = returnCX;
-	userStack[3] = returnDX;
-	/* XXXTRB - should set session number in returnBP if */
-	/* we are doing an extended getredirection */
-	return TRUE;
+        userStack = (u_short *)sda_user_stack(sda);
+        userStack[1] = returnBX;
+        userStack[2] = returnCX;
+        userStack[3] = returnDX;
+        /* XXXTRB - should set session number in returnBP if */
+        /* we are doing an extended getredirection */
+        return TRUE;
       } else {
-	/* count down until the index is exhausted */
-	index--;
+        /* count down until the index is exhausted */
+        index--;
       }
     }
   }

--- a/src/include/redirect.h
+++ b/src/include/redirect.h
@@ -25,6 +25,10 @@
 
 #define REDIR_PRINTER_TYPE    3
 #define REDIR_DISK_TYPE       4
+#define REDIR_CLIENT_SIGNATURE 0x5544             /* 'DU' */
+#define REDIR_DEVICE_READ_ONLY 0b0000000000000001 /* Same as NetWare Lite */
+                            /* 0b0000000000001110    CDROM unit number */
+#define REDIR_DEVICE_DISABLED  0b1000000000000000
 
 #define DOS_GET_REDIRECTION    0x5F02
 #define DOS_REDIRECT_DEVICE    0x5F03


### PR DESCRIPTION
Fix for #695, larger than I hoped as we need to be safe using dosemu specific options via DX register extension in these cases:
- lredir talks to 3rd party redirector
- 3rd party client tool talks to mfs redirector.
                                                                                
##### Test run, with CDS flags on G: altered in memory via dosdebug              
~~~                                                                             
C:\>lredir                                                                      
Current Drive Redirections:                                                     
C: = \\LINUX\FS\clients\common\dosemu2.git\test-imagedir\dXXXXs\c\ attrib = READ/WRITE
E: = \\LINUX\FS\clients\common\dosemu2.git\test-libdir\dosemu2-cmds-0.2\ attrib = READ/WRITE
F: = \\LINUX\FS\clients\common\dosemu2.git\..\fdpp.git\fdpp\ attrib = READ/WRITE
G: = \\LINUX\FS\usr\share\comcom32\ attrib = READ/WRITE, DISABLED               
H: = \\LINUX\FS\tmp\      attrib = CDROM:1, READ/WRITE                          
I: = \\LINUX\FS\bin\      attrib = CDROM:2, READ/WRITE                          
~~~                                                                             
