### PR TITLE
fatfs: Update RxDOS.COM loader to RxDOS.3 load protocol

### DIFF
--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -1761,6 +1761,8 @@ void mimic_boot_blk(void)
 
     case RXN_D: {
       char *string_pointer;
+      const uint32_t loadtop = SEGOFF2LINEAR(0x1FE0, 0x7C00 - 8192);
+				/* 1FE0h:7C00h -> BPB, -8192: stack reservation */
       struct {
 	uint32_t FirstCluster;	/* (all) first cluster of load file */
 	uint32_t FATSector;	/* (FAT32,FAT16) loaded sector-in-FAT, or -1 */
@@ -1782,8 +1784,8 @@ void mimic_boot_blk(void)
 
       read_boot(f, LINEAR2UNIX(SEGOFF2LINEAR(0x1FE0, 0x7C00)));	/* load BPB */
 
-      if ( ((seg << 4) + size) > SEGOFF2LINEAR(0x1FE0, 0x7C00 - 8192) ) {
-	/* (seg << 4) + size -> after end of load, -8192: stack reservation */
+      if ( ((seg << 4) + size) > loadtop ) {
+	/* (seg << 4) + size -> after end of load */
 	error("too large DOS system file %s\n", f->obj[1].full_name);
 	leavedos(99);
       }

--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -1786,8 +1786,7 @@ void mimic_boot_blk(void)
 
       if ( ((seg << 4) + size) > loadtop ) {
 	/* (seg << 4) + size -> after end of load */
-	error("too large DOS system file %s\n", f->obj[1].full_name);
-	leavedos(99);
+	size = loadtop - (seg << 4);		/* limit loaded size to max */
       }
       if (size < 0x600) {
 	error("too small DOS system file %s\n", f->obj[1].full_name);

--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -60,7 +60,7 @@
 #include <errno.h>
 #include <assert.h>
 #include <limits.h>
-#include <stdint.h>			/* RxDOS.2 lsv uses types */
+#include <stdint.h>			/* RxDOS.3 lsv uses types */
 
 #include "int.h"
 #include "disks.h"
@@ -1771,9 +1771,9 @@ void mimic_boot_blk(void)
 	uint32_t DataStart;	/* (all) data area start sector-in-partition */
       } __attribute__((packed)) *lsv;
 
-      seg = 0x0070;
-      ofs = 0x0400;				/* execute at 70h:400h */
-      load_offs = -ofs;				/* load to 70h:0 */
+      seg = 0x0200;
+      ofs = 0x0400;				/* execute at 200h:400h */
+      load_offs = -ofs;				/* load to 200h:0 */
       LWORD(ebx) = f->drive_num;
       LWORD(edx) = f->drive_num;
       SREG(ss) = 0x1FE0;
@@ -1783,6 +1783,14 @@ void mimic_boot_blk(void)
       LWORD(eip) = ofs;
 
       read_boot(f, LINEAR2UNIX(SEGOFF2LINEAR(0x1FE0, 0x7C00)));	/* load BPB */
+      /* RxDOS.3 load protocol note:
+	The top 20 KiB below LMA top, EBDA, and/or RPL space is assumed
+	 to be available to the iniload stage for its own stack and buffers.
+	 As we use the FreeDOS-derived fixed BPB address of 1FE0h:7C00h,
+	 we assume that these 20 KiB are left available.
+	If we did "auto-BPB" allocation like lDebug's BOOT command,
+	 we would have to insure to reserve the top 20 KiB.
+      */
 
       if ( ((seg << 4) + size) > loadtop ) {
 	/* (seg << 4) + size -> after end of load */

--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -1781,6 +1781,12 @@ void mimic_boot_blk(void)
       LWORD(eip) = ofs;
 
       read_boot(f, LINEAR2UNIX(SEGOFF2LINEAR(0x1FE0, 0x7C00)));	/* load BPB */
+
+      if ( ((seg << 4) + size) > SEGOFF2LINEAR(0x1FE0, 0x7C00 - 8192) ) {
+	/* (seg << 4) + size -> after end of load, -8192: stack reservation */
+	error("too large DOS system file %s\n", f->obj[1].full_name);
+	leavedos(99);
+      }
       if (size < 0x600) {
 	error("too small DOS system file %s\n", f->obj[1].full_name);
 	leavedos(99);


### PR DESCRIPTION
Please read the comments in the commit messages and in the source.

I am of the opinion that the FreeDOS load protocol's maximum size check should also be restored from https://github.com/stsp/dosemu2/commit/8b1889899e407948fc74326a5a2761c76c23df51 as currently dosemu2 crashes when given a too large KERNEL.SYS kernel file. FreeDOS does require us to load the whole file though, so the RxDOS.3 protocol's trick for trailing data doesn't work there.