### PR TITLE
KVM: use DPL=3 for IDT even in non-debug default case

### DIFF
--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -142,7 +142,7 @@ static void set_idt_default(dosaddr_t mon, int i)
     monitor->idt[i].offs_hi = offs >> 16;
     monitor->idt[i].seg = 0x8; // FLAT_CODE_SEL
     monitor->idt[i].type = 0xe;
-    /* DPL is 0 so that software ints < 0x11 or 255 from DPMI clients will GPF.
+    /* DPL is 0 so that software ints < 0x11 from DPMI clients will GPF.
        Exceptions are int3 (BP) and into (OF): matching the Linux kernel
        they must generate traps 3 and 4, and not GPF.
        Exceptions > 0x10 cannot be triggered with the VM's settings of CR0/CR4
@@ -170,8 +170,7 @@ static void set_idt(int i, uint16_t sel, uint32_t offs, int is_32)
 
 void kvm_set_idt(int i, uint16_t sel, uint32_t offs, int is_32)
 {
-    /* don't change IDT for exceptions and special entry that interrupts
-       the VM */
+    /* don't change IDT for exceptions */
     if (i < 0x11)
         return;
     set_idt(i, sel, offs, is_32);

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -1553,9 +1553,6 @@ void dpmi_set_interrupt_vector(unsigned char num, DPMI_INTDESC desc)
             kvm_set_idt_default(num);
         else
 #endif
-        if (desc.selector == dpmi_sel())
-            kvm_set_idt_default(num);
-        else
             kvm_set_idt(num, desc.selector, desc.offset32, DPMI_CLIENT.is_32);
     }
 }


### PR DESCRIPTION
Now by default for DPMI ints > 0x10 go via the IDT to a HLT at
DPMI_SEL_OFF(DPMI_interrupt) + i in dpmi_sel.
We still need DPL=0 for dosdebug (where it is similar to the use
of the int_revectored bitmap for real mode ints) and exceptions.