### PR TITLE
DPMI native: don't change fpregs pointer in sigcontext

### DIFF
--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -1161,9 +1161,9 @@ void dpmi_return(sigcontext_t *scp, int retcode)
   co_resume(co_handle);
   signal_return_to_dpmi();
   if (dpmi_ret_val == DPMI_RET_EXIT)
-    copy_context(scp, &emu_stack_frame, 0);
+    copy_context(scp, &emu_stack_frame, 1);
   else
-    copy_context(scp, &DPMI_CLIENT.stack_frame, 0);
+    copy_context(scp, &DPMI_CLIENT.stack_frame, 1);
 }
 
 static void dpmi_switch_sa(int sig, siginfo_t *inf, void *uc)
@@ -1173,7 +1173,7 @@ static void dpmi_switch_sa(int sig, siginfo_t *inf, void *uc)
 
   emu_stack_frame.fpregs = aligned_alloc(16, sizeof(*__fpstate));
   copy_context(&emu_stack_frame, scp, 1);
-  copy_context(scp, &DPMI_CLIENT.stack_frame, 0);
+  copy_context(scp, &DPMI_CLIENT.stack_frame, 1);
   sigaction(DPMI_TMP_SIG, &emu_tmp_act, NULL);
   deinit_handler(scp, &uct->uc_flags);
 }


### PR DESCRIPTION
At least on i386 kernel 4.19 is picky about the size of the area that fpregs
points to. We know for sure that what fpregs points to on signal entry is
fine so don't change and copy FPU state to it instead of setting the pointer.

Without this fix I got hard SIGSEGVs (no backtrace) on i386 native DPMI as
soon as a DPMI prog is started and dmesg messages such as
"dosemu.bin[32058] bad frame in rt_sigreturn frame:30e78129 ip:17a1 sp:7f0
 orax:ffffffff in memfd:dosemu_32058 (deleted)[0+b8000]"