### PR TITLE
Replace MAP_32BIT by mmap_second_gb() using mapping_find_hole()

### DIFF
--- a/src/dosext/dpmi/memory.c
+++ b/src/dosext/dpmi/memory.c
@@ -556,7 +556,7 @@ dpmi_pm_block *DPMI_mallocShared(dpmi_pm_block_root *root,
     if (!(flags & SHM_NOEXEC))
         prot |= PROT_EXEC;
     addr = mmap_file_ux(MAPPING_DPMI | MAPPING_IMMEDIATE,
-            NULL, size, prot, MAP_SHARED | MAP_32BIT, fd);
+            NULL, size, prot, MAP_SHARED, fd);
     close(fd);
     if (addr == MAP_FAILED) {
         perror("mmap()");


### PR DESCRIPTION
MAP_32BIT actually allocates a randomized piece of memory between 0x40000000
and 0x80000000, see e.g.
http://timetobleed.com/digging-out-the-craziest-bug-you-never-heard-about-from-2008-a-linux-threading-regression/
for its history.

This is useful for us as you never need to deal with negative pointers this
way but if mem_base > some other mmap you wrap around and get "negative"
dosaddr_t values. Without randomization mem_base is the lowest of the
allocations though and this won't happen.

On 32-bit MAP_32BIT does not exist which then got allocations all over the
place; it's nicer to have the allocations also under 2GB there. Also on
32-bit using e.g. MEM_BASE(0x80000000) invokes the Undefined Behavior
Sanitizer (ubsan) which is spurious since we use unsigned arithmetic but
it's still too easy to make mistakes.

So eliminating MAP_32BIT in favour of manual allocation always gives positive
dosaddr_t values, positive pointers, no more complaints from ubsan, and
consistent memory behaviour for 32-bit vs 64-bit.