### PR TITLE
MEM_BASE32: change order of casts.

### DIFF
--- a/src/include/memory.h
+++ b/src/include/memory.h
@@ -191,7 +191,7 @@ extern unsigned char *mem_base;
 #define LINP(a) ((unsigned char *)(uintptr_t)(a))
 static inline unsigned char *MEM_BASE32(dosaddr_t a)
 {
-    uint32_t off = (uint32_t)(uintptr_t)(mem_base + a);
+    uint32_t off = (uint32_t)((uintptr_t)mem_base + a);
     return LINP(off);
 }
 static inline dosaddr_t DOSADDR_REL(const unsigned char *a)


### PR DESCRIPTION
This avoids undefined behaviour sanitizer (UBsan) generated messages such as
runtime error: pointer index expression with base 0x00000000 overflowed to 0x80000000
for 32-bit builds.