### PR TITLE
vm86: allow pie-compiled 32-bit dosemu2 to run

### DIFF
--- a/src/arch/linux/async/sigsegv.c
+++ b/src/arch/linux/async/sigsegv.c
@@ -90,7 +90,7 @@ static void dosemu_fault1(int signal, sigcontext_t *scp)
       /* we can get to instremu from here, so unblock SIGALRM & friends.
        * It is needed to interrupt instremu when it runs for too long. */
       signal_unblock_async_sigs();
-      if (vga_emu_fault(scp, 0) == True)
+      if (vga_emu_fault(_cr2, _err, NULL) == True)
         return;
     }
     vm86_fault(_trapno, _err, _cr2);
@@ -112,7 +112,7 @@ static void dosemu_fault1(int signal, sigcontext_t *scp)
 #endif
 #endif
       signal_unblock_async_sigs();
-      rc = vga_emu_fault(scp, 1);
+      rc = vga_emu_fault(DOSADDR_REL(LINP(_cr2)), _err, scp);
       /* going for dpmi_fault() or deinit_handler(),
        * careful with async signals and sas_wa */
       signal_restore_async_sigs();

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -991,17 +991,15 @@ void vga_memsetl(dosaddr_t dst, unsigned val, size_t len)
  *
  */
 
-int vga_emu_fault(sigcontext_t *scp, int pmode)
+int vga_emu_fault(dosaddr_t lin_addr, unsigned err, sigcontext_t *scp)
 {
-  int i, j;
-  dosaddr_t lin_addr;
+  int i, j, pmode = scp != NULL;
   unsigned page_fault, vga_page = 0, u;
   unsigned char *cs_ip;
 #if DEBUG_MAP >= 1
   static const char *txt1[VGAEMU_MAX_MAPPINGS + 1] = { "bank", "lfb", "some" };
-  unsigned access_type = (_err >> 1) & 1;
+  unsigned access_type = (err >> 1) & 1;
 #endif
-  lin_addr = DOSADDR_REL(LINP(_cr2));
   page_fault = lin_addr >> 12;
 
   for(i = 0; i < VGAEMU_MAX_MAPPINGS; i++) {

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -1309,7 +1309,7 @@ int e_dpmi(sigcontext_t *scp)
     else if (xval==EXCP_GOBACK) {
         retval = DPMI_RET_DOSEMU;
     }
-    else if (xval == EXCP0E_PAGE && VGA_EMU_FAULT(scp,code,1)==True) {
+    else if (xval == EXCP0E_PAGE && vga_emu_fault(DOSADDR_REL(LINP(_cr2)),_err,scp)==True) {
 	retval = dpmi_check_return();
     } else {
 	if (debug_level('e')) TotalTime += (GETTSC() - tt0);

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -508,13 +508,14 @@ int e_emu_pagefault(sigcontext_t *scp, int pmode)
 	 * only faults from DOS code, and here we are with
 	 * the fault from jit-compiled code. But in !inst_emu
 	 * mode vga_emu_fault() just unprotects. */
-	if (!vga.inst_emu && vga_emu_fault(scp, pmode) == True)
+	dosaddr_t cr2 = DOSADDR_REL(LINP(_cr2));
+	if (!vga.inst_emu && vga_emu_fault(cr2, _err, scp) == True)
 	    return 1;
 	/* in (inst_emu mode || !vga) try cpatch first */
 	if (Cpatch(scp))
 	    return 1;
 	/* e_vgaemu_fault() is exceptionally expensive, so it goes last */
-	if (vga.inst_emu && e_vgaemu_fault(scp, DOSADDR_REL(LINP(_cr2)) >> 12) == 1)
+	if (vga.inst_emu && e_vgaemu_fault(scp, cr2 >> 12) == 1)
 	    return 1;
 
 #ifdef HOST_ARCH_X86

--- a/src/include/vgaemu.h
+++ b/src/include/vgaemu.h
@@ -474,8 +474,7 @@ int VGA_emulate_outb(ioport_t, Bit8u);
 int VGA_emulate_outw(ioport_t, Bit16u);
 Bit8u VGA_emulate_inb(ioport_t);
 Bit16u VGA_emulate_inw(ioport_t);
-int vga_emu_fault(sigcontext_t *, int pmode);
-#define VGA_EMU_FAULT(scp,code,pmode) vga_emu_fault(scp,pmode)
+int vga_emu_fault(dosaddr_t, unsigned, sigcontext_t *);
 int vga_emu_pre_init(void);
 int vga_emu_init(int src_modes, struct ColorSpaceDesc *);
 void vga_emu_done(void);


### PR DESCRIPTION
I had accidentally compiled dosemu2 for i386 without -no-pie (which means
pie on Debian), and got the mmap_min_addr error, which was confusing.

It can actually run if instead of this memory layout:

0   0x110000          ...           ... 1G
low dpmi_lin_rsv_base ... dpmi_base ...

you use this (as a fallback only!)

0   ...                             ... 1G
low ... dpmi_lin_rsv_base dpmi_base ...

the order hasn't changed, only the position of the hole. This helps pie
or the unlikely case when kernels/libcs allocate other things just above
0x110000 (as was done in the past with execshield).

(I'll explain the accident in another PR)