### PR TITLE
Use $CC -dumpmachine to determine default target machine.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,7 +135,7 @@ AC_DEFINE_DIR([SYSTEM_XFONTS_PATH], [x11fontdir], [ Directory for x11 fonts ])
 CONFIG_HOST='linux'
 AC_SUBST(CONFIG_HOST)
 
-machine=`uname -m`
+machine=`"$CC" -dumpmachine | cut -d- -f1`
 
 DOSEMU_CFLAGS="-Wall -Wstrict-prototypes -Wmissing-declarations \
 -Wnested-externs -fms-extensions -pthread -imacros config.hh \


### PR DESCRIPTION
This was useful for me as I have a mostly 32-bit userspace but often
run with a 64-bit kernel, and the default target for gcc is then -m32.

The compilation should then choose between -no-pie and -pie depending on
GCC's (or Clang's) default target instead of the kernel's arch `uname -m`
that is running during compilation.