### PR TITLE
Add CPU tests to the Travis framework.

### DIFF
--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -238,7 +238,7 @@ system -e\r
                 child.expect(['(system|unix) -e[\r\n]*'], timeout=10)
                 child.expect(['>[\r\n]*', pexpect.TIMEOUT], timeout=1)
                 child.send(cmd + '\r\n')
-                child.expect(['rem end'], timeout=5)
+                child.expect(['rem end'], timeout=20)
                 if outfile is None:
                     ret = child.before.decode('ASCII')
                 else:

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -14,3 +14,4 @@ git clone --depth 1 https://github.com/stsp/fdpp.git ${LOCALFDPP}
 )
 
 env PKG_CONFIG_PATH=${LOCALFDPPINST}/lib/pkgconfig ./default-configure -d && make
+make -C src/tests test-i386.exe


### PR DESCRIPTION
Most still fail, so this PR can be used to track various CPUEMU fixes to do.

(I never thought I'd be programming in Python for DOSEMU but here you go :)