### PR TITLE
CPUEMU fix error code for exceptions 3 and 4

### DIFF
--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1601,7 +1601,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 #ifdef ASM_DUMP
 			fprintf(aLog,"%08x:\t\tint %02x\n", P0, inum);
 #endif
-			TheCPU.scp_err = (inum << 3) | 2;
 			switch(inum) {
 			case 0x03:
 				TheCPU.err=EXCP03_INT3;
@@ -1615,6 +1614,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				InvalidateSegs();
 				break;
 			}
+			TheCPU.scp_err = (inum << 3) | 2;
 			goto not_permitted;
 			break;
 		}


### PR DESCRIPTION
int3 (BP) and into (OF) are special: matching the Linux kernel they must generate
traps 3 and 4, and not GPF, and therefore not set an error code.

This fixes the test-i386.exe test completely for the simulator, and partly
for the JIT.