### PR TITLE
KVM: remove RF from RETURN_MASK.

### DIFF
--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -47,7 +47,8 @@
                    X86_EFLAGS_TF|X86_EFLAGS_DF|X86_EFLAGS_OF| \
                    X86_EFLAGS_RF| \
                    X86_EFLAGS_NT|X86_EFLAGS_AC|X86_EFLAGS_ID) // 0x254dd5
-#define RETURN_MASK (SAFE_MASK | 0x28 | X86_EFLAGS_FIXED) // 0x244dff
+#define RETURN_MASK ((SAFE_MASK | 0x28 | X86_EFLAGS_FIXED) & \
+                     ~X86_EFLAGS_RF) // 0x244dff
 
 extern char kvm_mon_start[];
 extern char kvm_mon_hlt[];


### PR DESCRIPTION
Commit e340b209 accidentally also added RF to the RETURN_MASK but it should
not be there as pushfd needs to clear RF in the stack image (see e.g.
https://www.felixcloutier.com/x86/pushf:pushfd:pushfq
)

This fixes the test-i386.exe tests that use KVM.