### PR TITLE
Travis: Install and configure KVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: c
 
+sudo: true
 dist:  bionic
 
 addons:
@@ -42,6 +43,7 @@ addons:
       - libstdc++-5-dev
       - python3-pexpect
       - djgpp
+      - qemu-kvm
     update: true
 
 env: FDPP_KERNEL_DIR="$(pwd)/localfdpp/share/fdpp"
@@ -53,7 +55,8 @@ install:
   - ./travis_build.sh
 
 before_script:
-  - echo "before_script"
+  - sudo usermod -a -G kvm ${USER}
 
 script:
-  - ./travis_test.sh
+  # launch the test this way to collect the new kvm group membership
+  - sudo -E su ${USER} -c ./travis_test.sh


### PR DESCRIPTION
This enables the KVM CPU tests to run as intended, rather than fallback
to emulation. [#1026]