### PR TITLE
simx86: mostly revert acee39e (extensive use of Cpatch)

### DIFF
--- a/src/base/emu-i386/simx86/memory.c
+++ b/src/base/emu-i386/simx86/memory.c
@@ -356,6 +356,12 @@ int e_handle_pagefault(sigcontext_t *scp)
 			e_printf("DATA node hit at %08x\n",addr);
 		}
 	}
+	/* the page is not unprotected here, the code
+	 * linked by Cpatch will do it */
+	/* ACH: we can set up a data patch for code
+	 * which has not yet been executed! */
+	if (InCompiledCode && Cpatch(scp))
+		return 1;
 	/* We HAVE to invalidate all the code in the page
 	 * if the page is going to be unprotected */
 	codehit = 0;

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -266,6 +266,13 @@ int e_vgaemu_fault(sigcontext_t *scp, unsigned page_fault)
 
 /**/  e_printf("eVGAEmuFault: trying %08x, a=%08"PRI_RG"\n",*((int *)_rip),_rdi);
 
+    /* try CPatch, and if that fails, the exceptionally expensive route */
+#if 0
+    // Disable for now, produces glitches in Jazz Jackrabbit */
+    if (Cpatch(scp))
+      return 1;
+#endif
+
     p = (unsigned char *)_rip;
     if (*p==0x66) w16=1,p++; else w16=0;
 
@@ -509,13 +516,8 @@ int e_emu_pagefault(sigcontext_t *scp, int pmode)
 	 * the fault from jit-compiled code. But in !inst_emu
 	 * mode vga_emu_fault() just unprotects. */
 	dosaddr_t cr2 = DOSADDR_REL(LINP(_cr2));
-	if (!vga.inst_emu && vga_emu_fault(cr2, _err, scp) == True)
-	    return 1;
-	/* in (inst_emu mode || !vga) try cpatch first */
-	if (Cpatch(scp))
-	    return 1;
-	/* e_vgaemu_fault() is exceptionally expensive, so it goes last */
-	if (vga.inst_emu && e_vgaemu_fault(scp, cr2 >> 12) == 1)
+	if ((!vga.inst_emu && vga_emu_fault(cr2, _err, scp) == True) ||
+	    e_vgaemu_fault(scp, cr2 >> 12) == 1)
 	    return 1;
 
 #ifdef HOST_ARCH_X86


### PR DESCRIPTION
Cpatch can't be used for DPMI page faults (e.g. with DJGPP null pointer
protection as tested in test-i386.exe: that test is fixed with this change),
so we must check if the address is either VGA memory or protected by cpuemu.

Using Cpatch is a strategic place in e_vgaemu_fault allows using Cpatch
on VGA memory then but unfortunately that still produces glitches in Jazz
Jackrabbit (which are also there without the revert).

The one thing left from acee39e is to allow Cpatch for code hits.