### PR TITLE
simx86: replace use of O_MOVS_MovD without REP with O_MOVS_LodD/StoD

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2393,7 +2393,7 @@ void Gen_sim(int op, int mode, ...)
 		    e_VgaMovs(scp, op, (mode & DATA16) ? 1 : 0, df);
 		    AR1.d = _edi;
 		    AR2.d = _esi;
-		    if (mode&(MREP|MREPNE))	TR1.d = 0;
+		    TR1.d = 0;
 		    break;
 		}
 		if(mode & ADDR16) {
@@ -2456,7 +2456,7 @@ void Gen_sim(int op, int mode, ...)
 			while (i--) *AR1.pdu++ = *AR2.pdu++;
 		    }
 		}
-		if (mode&(MREP|MREPNE))	TR1.d = 0;
+		TR1.d = 0;
 		}
 		break;
 	case O_MOVS_LodD: {

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1869,13 +1869,12 @@ shrot0:
 
 	case O_MOVS_MovD:
 		GetDF(Cp);
-		if (mode&(MREP|MREPNE))	{ G3M(NOP,NOP,REP,Cp); }
+		G3M(NOP,NOP,REP,Cp);
 		if (mode&MBYTE)	{ G1(MOVSb,Cp); }
 		else {
 			Gen66(mode,Cp);
 			G1(MOVSw,Cp);
 		}
-		if (!(mode&(MREP|MREPNE))) { G4(0x90909090,Cp); }
 		G1(CLD,Cp);
 		break;
 	case O_MOVS_LodD:

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -813,9 +813,6 @@ void init_emu_cpu(void)
   TheCPU.stub_wri_32 = stub_wri_32;
   TheCPU.stub_stk_16 = stub_stk_16;
   TheCPU.stub_stk_32 = stub_stk_32;
-  TheCPU.stub_movsb = stub_movsb;
-  TheCPU.stub_movsw = stub_movsw;
-  TheCPU.stub_movsl = stub_movsl;
   TheCPU.stub_stosb = stub_stosb;
   TheCPU.stub_stosw = stub_stosw;
   TheCPU.stub_stosl = stub_stosl;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1240,7 +1240,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 
 /*a4*/	case MOVSb: {	int m = mode|(MBYTE|MOVSSRC|MOVSDST);
 			Gen(O_MOVS_SetA, m);
-			Gen(O_MOVS_MovD, m);
+			Gen(O_MOVS_LodD, m);
+			Gen(O_MOVS_StoD, m);
 			Gen(O_MOVS_SavA, m);
 			PC++;
 			} break;
@@ -1251,18 +1252,21 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			if (!(EFLAGS & TF)) {
 				int cnt = 3;
 				do {
-					Gen(O_MOVS_MovD, m);
+					Gen(O_MOVS_LodD, m);
+					Gen(O_MOVS_StoD, m);
 					m = UNPREFIX(m);
 					PC++;
 				} while (++cnt < NUMGENS && Fetch(PC) == MOVSw);
 				if (Fetch(PC) == MOVSb) {
-					Gen(O_MOVS_MovD, m|MBYTE);
+					Gen(O_MOVS_LodD, m|MBYTE);
+					Gen(O_MOVS_StoD, m|MBYTE);
 					PC++;
 				}
 			} else
 #endif
 			{
-				Gen(O_MOVS_MovD, m); PC++;
+				Gen(O_MOVS_LodD, m); PC++;
+				Gen(O_MOVS_StoD, m); PC++;
 			}
 			Gen(O_MOVS_SavA, m);
 			} break;
@@ -1759,13 +1763,23 @@ repag0:
 				case MOVSb:
 					repmod |= (MBYTE|MOVSSRC|MOVSDST);
 					Gen(O_MOVS_SetA, repmod);
-					Gen(O_MOVS_MovD, repmod);
+					if (repmod & (MREPNE|MREP)) {
+						Gen(O_MOVS_MovD, repmod);
+					} else {
+						Gen(O_MOVS_LodD, repmod);
+						Gen(O_MOVS_StoD, repmod);
+					}
 					Gen(O_MOVS_SavA, repmod);
 					PC++; break;
 				case MOVSw:
 					repmod |= (MOVSSRC|MOVSDST);
 					Gen(O_MOVS_SetA, repmod);
-					Gen(O_MOVS_MovD, repmod);
+					if (repmod & (MREPNE|MREP)) {
+						Gen(O_MOVS_MovD, repmod);
+					} else {
+						Gen(O_MOVS_LodD, repmod);
+						Gen(O_MOVS_StoD, repmod);
+					}
 					Gen(O_MOVS_SavA, repmod);
 					PC++; break;
 				case CMPSb:

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -310,14 +310,6 @@ int e_vgaemu_fault(sigcontext_t *scp, unsigned page_fault)
 		else
 			_eax = e_VgaRead(LINP(_edi),DATA32);
 		_rip = (long)(p+2); break;
-/*a4*/	case MOVSb: {
-		int d = (_eflags & EFLAGS_DF? -1:1);
-		e_VgaMovs(scp, 1, 0, d);
-		_rip = (long)(p+1); } break;
-/*a5*/	case MOVSw: {
-		int d = (_eflags & EFLAGS_DF? -1:1);
-		e_VgaMovs(scp, 0, w16, d*2);
-		_rip = (long)(p+1); } break;
 /*a6*/	case CMPSb:
 		mode = MBYTE;
 		goto CMPS_common;

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -150,9 +150,6 @@ typedef struct {
 	void (*stub_stosb)(void);
 	void (*stub_stosw)(void);
 	void (*stub_stosl)(void);
-	void (*stub_movsb)(void);
-	void (*stub_movsw)(void);
-	void (*stub_movsl)(void);
 
 	/* if not NULL, points to emulated FPU state
 	   if NULL, emulator uses FPU instructions, so flags that
@@ -232,9 +229,6 @@ extern union _SynCPU TheCPU_union;
 #define Ofs_stub_wri_32	(unsigned char)(offsetof(SynCPU,stub_wri_32)-SCBASE)
 #define Ofs_stub_stk_16	(unsigned char)(offsetof(SynCPU,stub_stk_16)-SCBASE)
 #define Ofs_stub_stk_32	(unsigned char)(offsetof(SynCPU,stub_stk_32)-SCBASE)
-#define Ofs_stub_movsb	(unsigned int)(offsetof(SynCPU,stub_movsb)-SCBASE)
-#define Ofs_stub_movsw	(unsigned int)(offsetof(SynCPU,stub_movsw)-SCBASE)
-#define Ofs_stub_movsl	(unsigned int)(offsetof(SynCPU,stub_movsl)-SCBASE)
 #define Ofs_stub_stosb	(unsigned int)(offsetof(SynCPU,stub_stosb)-SCBASE)
 #define Ofs_stub_stosw	(unsigned int)(offsetof(SynCPU,stub_stosw)-SCBASE)
 #define Ofs_stub_stosl	(unsigned int)(offsetof(SynCPU,stub_stosl)-SCBASE)


### PR DESCRIPTION
The use of LODS/STOS is temporary, they will be replaced with L_DI_R1
and S_DI later. This way there is no more MOVS in generated code without
REP, so the cpatch and sigsegv code can also be simplified. See also #1033
(not fixed completely for Jazz yet) and #156.