### PR TITLE
simx86: fix floating point flagging of nodes in JIT

### DIFF
--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -659,7 +659,7 @@ int _ModRM(unsigned char opc, unsigned int PC, int mode);
         CODE_FLUSH(); \
         goto illegal_op; \
     } \
-    if (V86MODE() && !((m) & (ADDR16 | MLEA)) && TR1.d > 0xffff) { \
+    if (CONFIG_CPUSIM && V86MODE() && !((m) & (ADDR16 | MLEA)) && TR1.d > 0xffff) { \
         CODE_FLUSH(); \
         goto not_permitted; \
     } \

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -4544,8 +4544,7 @@ $_ignore_djgpp_null_derefs = (off)
 
     def test_cpu_jit(self):
         """CPU test: JIT vm86 + JIT DPMI"""
-        self.skipTest("Fails")
-# FAIL        self._test_cpu("emulated", "emulated", "full")
+        self._test_cpu("emulated", "emulated", "full")
 
     def test_cpu_sim(self):
         """CPU test: simulated vm86 + simulated DPMI"""
@@ -4633,6 +4632,7 @@ class PPDOSGITTestCase(OurTestCase, unittest.TestCase):
         cls.version = "FDPP kernel"
         cls.prettyname = "PP-DOS-GIT"
         cls.actions = {
+            "test_cpu_jit": SKIP, # Still fails with GPF, passes with FD
             "test_floppy_img": SKIP,
             "test_floppy_vfs": SKIP,
         }

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -4632,7 +4632,6 @@ class PPDOSGITTestCase(OurTestCase, unittest.TestCase):
         cls.version = "FDPP kernel"
         cls.prettyname = "PP-DOS-GIT"
         cls.actions = {
-            "test_cpu_jit": SKIP, # Still fails with GPF, passes with FD
             "test_floppy_img": SKIP,
             "test_floppy_vfs": SKIP,
         }


### PR DESCRIPTION
test-i386 was randomly failing floating point tests where the FP environment
was not properly set restored. The cause was that for code sequences that use
FP that FP flag was not always set, which was the fault of the node linker.

The node linker needs to not only flag FP for the node that links to the new
sequence but also any other nodes that link to it, so I added a recursive
function to flag all back references. It can stop at any back reference that
was already flagged since those were treated earlier with all their back
references.

test-i386 now passes completely for "full" JIT cpuemu so I added it to the
Travis tests.