### PR TITLE
simx86: replace use of O_MOVS_ScaD without REP with L_DI_R1/O_CMP_FR.

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2603,7 +2603,7 @@ void Gen_sim(int op, int mode, ...)
 		    }
 		    i--;
 		}
-		if (mode&(MREP|MREPNE))	TR1.d = i;
+		TR1.d = i;
 		// ! Warning DI,SI wrap	in 16-bit mode
 		}
 		break;

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1899,23 +1899,18 @@ shrot0:
 		break;
 	case O_MOVS_ScaD:
 		CpTemp = NULL;
-		if(mode & (MREP|MREPNE))
-		{
-			G2M(JCXZ,00,Cp);
-			// Pointer to the jecxz distance byte
-			CpTemp = Cp-1;
-		}
+		G2M(JCXZ,00,Cp);
+		// Pointer to the jecxz distance byte
+		CpTemp = Cp-1;
 		GetDF(Cp);
-		if (mode&MREP) { G1(REP,Cp); }
-			else if	(mode&MREPNE) {	G1(REPNE,Cp); }
+		G1((mode&MREP)?REP:REPNE,Cp);
 		if (mode&MBYTE)	{ G1(SCASb,Cp); }
 		else {
 			Gen66(mode,Cp);
 			G1(SCASw,Cp);
 		}
 		G3M(CLD,POPsi,PUSHF,Cp); // replace flags back on stack,esi=dummy
-		if(mode & (MREP|MREPNE))
-			*CpTemp = (Cp-(CpTemp+1));
+		*CpTemp = (Cp-(CpTemp+1));
 		break;
 	case O_MOVS_CmpD:
 		CpTemp = NULL;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1339,14 +1339,14 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			} break;
 /*ae*/	case SCASb: {	int m = mode|(MBYTE|MOVSDST);
 			Gen(O_MOVS_SetA, m);
-			Gen(L_REG, m, Ofs_AL);
-			Gen(O_MOVS_ScaD, m);
+			Gen(L_DI_R1, m);		// mov al,[edi]
+			Gen(O_CMP_FR, m, Ofs_AL);	// cmp [ebx+reg],al
 			Gen(O_MOVS_SavA, m);
 			PC++; } break;
 /*af*/	case SCASw: {	int m = mode|MOVSDST;
 			Gen(O_MOVS_SetA, m);
-			Gen(L_REG, m, Ofs_EAX);
-			Gen(O_MOVS_ScaD, m);
+			Gen(L_DI_R1, m);		// mov ax,[edi]
+			Gen(O_CMP_FR, m, Ofs_EAX);	// cmp [ebx+reg],ax
 			Gen(O_MOVS_SavA, m);
 			PC++; } break;
 
@@ -1826,14 +1826,26 @@ repag0:
 					repmod |= (MBYTE|MOVSDST|MREPCOND);
 					Gen(O_MOVS_SetA, repmod);
 					Gen(L_REG, repmod|MBYTE, Ofs_AL);
-					Gen(O_MOVS_ScaD, repmod);
+					if (repmod & (MREPNE|MREP)) {
+						Gen(O_MOVS_ScaD, repmod);
+					}
+					else {
+						Gen(L_DI_R1, repmod);
+						Gen(O_CMP_FR, repmod, Ofs_AL);
+					}
 					Gen(O_MOVS_SavA, repmod);
 					PC++; break;
 				case SCASw:
 					repmod |= MOVSDST|MREPCOND;
 					Gen(O_MOVS_SetA, repmod);
 					Gen(L_REG, repmod, Ofs_EAX);
-					Gen(O_MOVS_ScaD, repmod);
+					if (repmod & (MREPNE|MREP)) {
+						Gen(O_MOVS_ScaD, repmod);
+					}
+					else {
+						Gen(L_DI_R1, repmod);
+						Gen(O_CMP_FR, repmod, Ofs_AL);
+					}
 					Gen(O_MOVS_SavA, repmod);
 					PC++; break;
 				case SEGes:

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -341,22 +341,6 @@ int e_vgaemu_fault(sigcontext_t *scp, unsigned page_fault)
 		    _eax = e_VgaRead(LINP(_esi),DATA32);
 		_esi+=d;
 		_rip = (long)(p+1); } break;
-/*ae*/	case SCASb:
-		mode = MBYTE;
-		goto SCAS_common;
-/*af*/	case SCASw:
-		mode = w16 ? DATA16 : 0;
-	SCAS_common:
-		mode |= MOVSDST;
-		AR1.d = _edi;
-		DR1.d = _eax;
-		TR1.d = 1;
-		Gen_sim(O_MOVS_ScaD, mode);
-		FlagSync_All();
-		_edi = AR1.d;
-		_eflags = (_eflags & ~EFLAGS_CC) | (EFLAGS & EFLAGS_CC);
-		_rip = (long)(p+1);
-		break;
 /*f2*/	case REPNE:
 /*f3*/	case REP: {
 		int repmod;


### PR DESCRIPTION
This way there is no more scas in generated code without rep, so
the sigsegv code can also be simplified.

(Next cherry pick from #156)