### PR TITLE
dpmi: msdos: use dosaddr_t for io_buffer and memcpy_dos2dos.

### DIFF
--- a/src/dosext/dpmi/msdos/callbacks.c
+++ b/src/dosext/dpmi/msdos/callbacks.c
@@ -31,12 +31,12 @@
 #include "msdos_priv.h"
 #include "callbacks.h"
 
-static uint8_t *io_buffer;
+static dosaddr_t io_buffer;
 static int io_buffer_size;
 static int io_error;
 static uint16_t io_error_code;
 
-void set_io_buffer(uint8_t *ptr, unsigned int size)
+void set_io_buffer(dosaddr_t ptr, unsigned int size)
 {
     io_buffer = ptr;
     io_buffer_size = size;
@@ -263,7 +263,7 @@ static void rmcb_handler(sigcontext_t *scp,
 	    D_printf("MSDOS: read %x %x\n", offs, size);
 	    /* need to use copy function that takes VGA mem into account */
 	    if (offs + size <= io_buffer_size)
-		memcpy_2unix(io_buffer + offs, dos_ptr, size);
+		memcpy_dos2dos(io_buffer + offs, dos_ptr, size);
 	    else
 		error("MSDOS: bad read (%x %x %x)\n", offs, size,
 		      io_buffer_size);
@@ -277,7 +277,7 @@ static void rmcb_handler(sigcontext_t *scp,
 	    D_printf("MSDOS: write %x %x\n", offs, size);
 	    /* need to use copy function that takes VGA mem into account */
 	    if (offs + size <= io_buffer_size)
-		memcpy_2dos(dos_ptr, io_buffer + offs, size);
+		memcpy_dos2dos(dos_ptr, io_buffer + offs, size);
 	    else
 		error("MSDOS: bad write (%x %x %x)\n", offs, size,
 		      io_buffer_size);

--- a/src/dosext/dpmi/msdos/callbacks.h
+++ b/src/dosext/dpmi/msdos/callbacks.h
@@ -10,7 +10,7 @@ void xms_call(const sigcontext_t *scp,
 void xms_ret(sigcontext_t *scp,
 	const struct RealModeCallStructure *rmreg);
 
-void set_io_buffer(uint8_t *ptr, unsigned int size);
+void set_io_buffer(dosaddr_t ptr, unsigned int size);
 void unset_io_buffer(void);
 int is_io_error(uint16_t *r_code);
 

--- a/src/dosext/dpmi/msdos/msdos.c
+++ b/src/dosext/dpmi/msdos/msdos.c
@@ -1116,7 +1116,7 @@ int msdos_pre_extender(sigcontext_t *scp, int intr,
 	    break;
 	case 0x3f: {		/* dos read */
 	    far_t rma = get_lr_helper(MSDOS_CLIENT.rmcbs[RMCB_IO]);
-	    set_io_buffer(SEL_ADR_CLNT(_ds, _edx, MSDOS_CLIENT.is_32),
+	    set_io_buffer(GetSegmentBase(_ds) + D_16_32(_edx),
 		    D_16_32(_ecx));
 	    SET_RMREG(ds, trans_buffer_seg());
 	    SET_RMLWORD(dx, 0);
@@ -1128,7 +1128,7 @@ int msdos_pre_extender(sigcontext_t *scp, int intr,
 	}
 	case 0x40: {		/* DOS Write */
 	    far_t rma = get_lw_helper(MSDOS_CLIENT.rmcbs[RMCB_IO]);
-	    set_io_buffer(SEL_ADR_CLNT(_ds, _edx, MSDOS_CLIENT.is_32),
+	    set_io_buffer(GetSegmentBase(_ds) + D_16_32(_edx),
 		    D_16_32(_ecx));
 	    SET_RMREG(ds, trans_buffer_seg());
 	    SET_RMLWORD(dx, 0);


### PR DESCRIPTION
Some programs read directly to VGA memory (e.g. Jazz Jackrabbit),
so we must use memcpy_dos2dos and not memcpy_2dos/memcpy_2unix.
This fixes its display of sprites.

Partially reverts commit 13c4180a.