### PR TITLE
Speed up e_invalidate and use it in memmove/memcpy functions

### DIFF
--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -679,7 +679,7 @@ void Cpu2Reg (void);
 int e_debug_check(unsigned int PC);
 int e_mprotect(unsigned int addr, size_t len);
 int e_munprotect(unsigned int addr, size_t len);
-int e_querymprotrange(unsigned int al, unsigned int ah);
+int e_querymprotrange(unsigned int addr, size_t len);
 int e_markpage(unsigned int addr, size_t len);
 int e_querymark(unsigned int addr, size_t len);
 void e_resetpagemarks(unsigned int addr, size_t len);

--- a/src/base/emu-i386/simx86/memory.c
+++ b/src/base/emu-i386/simx86/memory.c
@@ -125,23 +125,22 @@ static inline int e_querymprot(unsigned int addr)
 	return test_bit(a2&255, M->pagemap);
 }
 
-int e_querymprotrange(unsigned int al, unsigned int ah)
+int e_querymprotrange(unsigned int addr, size_t len)
 {
-	int a2l, a2h, res = 0;
-	tMpMap *M = FindM(al);
+	int a2l, a2h;
+	tMpMap *M = FindM(addr);
 
-	a2l = al >> PAGE_SHIFT;
-	a2h = ah >> PAGE_SHIFT;
+	a2l = addr >> PAGE_SHIFT;
+	a2h = (addr+len-1) >> PAGE_SHIFT;
 
 	while (M && a2l <= a2h) {
-		res = (res<<1) | (test_bit(a2l&255, M->pagemap) & 1);
+		if (test_bit(a2l&255, M->pagemap))
+			return 1;
 		a2l++;
-		if ((a2l&255)==0 && a2l <= a2h) {
+		if ((a2l&255)==0)
 			M = M->next;
-			res = 0;
-		}
 	}
-	return res;
+	return 0;
 }
 
 

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1284,6 +1284,10 @@ void e_invalidate(unsigned data, int cnt)
 {
 	if (config.cpuemu <= 1)
 		return;
+	/* nothing to invalidate if there are no page protections */
+	if (!e_querymprotrange(data, cnt))
+		return;
+	/* for low mappings only invalidate if code, not if data */
 	if (LINEAR2UNIX(data) != MEM_BASE32(data) && !e_querymark(data, cnt))
 		return;
 	e_invalidate_full(data, cnt);

--- a/src/base/misc/dos2linux.c
+++ b/src/base/misc/dos2linux.c
@@ -587,13 +587,16 @@ void memcpy_2dos(dosaddr_t dest, const void *src, size_t n)
 {
   if (vga.inst_emu && dest >= 0xa0000 && dest < 0xc0000)
     memcpy_to_vga(dest, src, n);
-  else while (n) {
-    dosaddr_t bound = (dest & PAGE_MASK) + PAGE_SIZE;
-    size_t to_copy = min(n, bound - dest);
-    MEMCPY_2DOS(dest, src, to_copy);
-    src += to_copy;
-    dest += to_copy;
-    n -= to_copy;
+  else {
+    e_invalidate(dest, n);
+    while (n) {
+      dosaddr_t bound = (dest & PAGE_MASK) + PAGE_SIZE;
+      size_t to_copy = min(n, bound - dest);
+      MEMCPY_2DOS(dest, src, to_copy);
+      src += to_copy;
+      dest += to_copy;
+      n -= to_copy;
+    }
   }
 }
 
@@ -606,15 +609,18 @@ void memmove_dos2dos(dosaddr_t dest, dosaddr_t src, size_t n)
     memcpy_dos_from_vga(dest, src, n);
   else if (vga.inst_emu && dest >= 0xa0000 && dest < 0xc0000)
     memcpy_dos_to_vga(dest, src, n);
-  else while (n) {
-    dosaddr_t bound1 = (src & PAGE_MASK) + PAGE_SIZE;
-    dosaddr_t bound2 = (dest & PAGE_MASK) + PAGE_SIZE;
-    size_t to_copy1 = min(bound1 - src, bound2 - dest);
-    size_t to_copy = min(n, to_copy1);
-    MEMMOVE_DOS2DOS(dest, src, to_copy);
-    src += to_copy;
-    dest += to_copy;
-    n -= to_copy;
+  else {
+    e_invalidate(dest, n);
+    while (n) {
+      dosaddr_t bound1 = (src & PAGE_MASK) + PAGE_SIZE;
+      dosaddr_t bound2 = (dest & PAGE_MASK) + PAGE_SIZE;
+      size_t to_copy1 = min(bound1 - src, bound2 - dest);
+      size_t to_copy = min(n, to_copy1);
+      MEMMOVE_DOS2DOS(dest, src, to_copy);
+      src += to_copy;
+      dest += to_copy;
+      n -= to_copy;
+    }
   }
 }
 
@@ -625,15 +631,18 @@ void memcpy_dos2dos(unsigned dest, unsigned src, size_t n)
     memcpy_dos_from_vga(dest, src, n);
   else if (vga.inst_emu && dest >= 0xa0000 && dest < 0xc0000)
     memcpy_dos_to_vga(dest, src, n);
-  else while (n) {
-    dosaddr_t bound1 = (src & PAGE_MASK) + PAGE_SIZE;
-    dosaddr_t bound2 = (dest & PAGE_MASK) + PAGE_SIZE;
-    size_t to_copy1 = min(bound1 - src, bound2 - dest);
-    size_t to_copy = min(n, to_copy1);
-    MEMCPY_DOS2DOS(dest, src, to_copy);
-    src += to_copy;
-    dest += to_copy;
-    n -= to_copy;
+  else {
+    e_invalidate(dest, n);
+    while (n) {
+      dosaddr_t bound1 = (src & PAGE_MASK) + PAGE_SIZE;
+      dosaddr_t bound2 = (dest & PAGE_MASK) + PAGE_SIZE;
+      size_t to_copy1 = min(bound1 - src, bound2 - dest);
+      size_t to_copy = min(n, to_copy1);
+      MEMCPY_DOS2DOS(dest, src, to_copy);
+      src += to_copy;
+      dest += to_copy;
+      n -= to_copy;
+    }
   }
 }
 

--- a/src/dosext/dpmi/msdos/msdos.c
+++ b/src/dosext/dpmi/msdos/msdos.c
@@ -1539,7 +1539,7 @@ void msdos_post_extender(sigcontext_t *scp, int intr,
 	len = min((int) (GetSegmentLimit(_ds) + 1), 0x10000);
 	D_printf("MSDOS: DS seg at %x copy back at %x for %#x\n",
 		 src, dst, len);
-	MEMCPY_DOS2DOS(dst, src, len);
+	memcpy_dos2dos(dst, src, len);
     }
 
     if (need_copy_eseg(intr, ax)) {
@@ -1552,7 +1552,7 @@ void msdos_post_extender(sigcontext_t *scp, int intr,
 	len = min((int) (GetSegmentLimit(_es) + 1), 0x10000);
 	D_printf("MSDOS: ES seg at %x copy back at %x for %#x\n",
 		 src, dst, len);
-	MEMCPY_DOS2DOS(dst, src, len);
+	memcpy_dos2dos(dst, src, len);
     }
 
     switch (intr) {


### PR DESCRIPTION
This follows up from #1039 to eliminate the `ERROR: touched jit-protected page` errors from Jazz Jackrabbit.
