### PR TITLE
simx86: replace use of O_MOVS_CmpD without REP with LodS/custom.

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2608,7 +2608,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_MOVS_CmpD: {	// OSZAPC
-		int df = (CPUWORD(Ofs_FLAGS) & EFLAGS_DF? -1:1);
+		int df;
 		register unsigned int i;
 		char k, z;
 		i = TR1.d;
@@ -2616,6 +2616,26 @@ void Gen_sim(int op, int mode, ...)
 		if (i == 0) break; /* eCX = 0, no-op, no flags updated */
 		RFL.mode = mode;
 		RFL.valid = V_SUB;
+		if(!(mode & (MREP|MREPNE))) {
+			// assumes DR1=*AR2
+			if (vga_read_access(DOSADDR_REL(AR1.pu)))
+				DR2.d = e_VgaRead(AR1.pu, mode);
+			else if (mode&MBYTE)
+				DR2.b.bl = *AR1.pu;
+			else if (mode&DATA16)
+				DR2.w.l = *AR1.pwu;
+			else
+				DR2.d = *AR1.pdu;
+			if (mode&MBYTE)
+				RFL.RES.d = (S1=DR1.b.bl) - (S2=DR2.b.bl);
+			else if (mode&DATA16)
+				RFL.RES.d = (S1=DR1.w.l) - (S2=DR2.w.l);
+			else
+				RFL.RES.d = (S1=DR1.d) - (S2=DR2.d);
+			FlagHandleSub(S1, S2, RFL.RES.d, OPSIZE(mode)*8);
+			break;
+		}
+		df = (CPUWORD(Ofs_FLAGS) & EFLAGS_DF? -1:1);
 		z = k = (mode&MREP? 1:0);
 		if (vga_read_access(DOSADDR_REL(AR1.pu)) ||
 				vga_read_access(DOSADDR_REL(AR2.pu)))
@@ -2677,7 +2697,7 @@ void Gen_sim(int op, int mode, ...)
 		    }
 		    i--;
 		}
-		if (mode&(MREP|MREPNE))	TR1.d = i;
+		TR1.d = i;
 		// ! Warning DI,SI wrap	in 16-bit mode
 		}
 		break;

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1913,24 +1913,46 @@ shrot0:
 		*CpTemp = (Cp-(CpTemp+1));
 		break;
 	case O_MOVS_CmpD:
-		CpTemp = NULL;
-		if(mode & (MREP|MREPNE))
-		{
-			G2M(JCXZ,00,Cp);
-			// Pointer to the jecxz distance byte
-			CpTemp = Cp-1;
+		if(!(mode & (MREP|MREPNE))) {
+			// assumes eax=(%%esi)
+			// mov %%eax, %%edx
+			G2M(0x89,0xc2,Cp);
+			// mov (%%edi), %%{e}a[xl]
+			if (mode&MBYTE) {
+				G2(0x078a,Cp); G1(0x90,Cp);
+			}
+			else if (mode&DATA16) {
+				G1(0x66,Cp); G2(0x078b,Cp);
+			}
+			else {
+				G2(0x078b,Cp); G1(0x90,Cp);
+			}
+			G3(0x909090,Cp);
+			// cmp %%eax, %%edx
+			if (mode&MBYTE) {
+				G2M(0x38,0xc2,Cp);
+			}
+			else {
+				Gen66(mode,Cp);
+				G2M(0x39,0xc2,Cp);
+			}
+			// replace flags back on stack,eax=dummy
+			G2M(POPax,PUSHF,Cp);
+			break;
 		}
+		CpTemp = NULL;
+		G2M(JCXZ,00,Cp);
+		// Pointer to the jecxz distance byte
+		CpTemp = Cp-1;
 		GetDF(Cp);
-		if (mode&MREP) { G1(REP,Cp); }
-			else if	(mode&MREPNE) {	G1(REPNE,Cp); }
+		G1((mode&MREP)?REP:REPNE,Cp);
 		if (mode&MBYTE)	{ G1(CMPSb,Cp); }
 		else {
 			Gen66(mode,Cp);
 			G1(CMPSw,Cp);
 		}
 		G3M(CLD,POPax,PUSHF,Cp); // replace flags back on stack,eax=dummy
-		if(mode & (MREP|MREPNE))
-			*CpTemp = (Cp-(CpTemp+1));
+		*CpTemp = (Cp-(CpTemp+1));
 		break;
 
 	case O_MOVS_SavA:

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1275,11 +1275,13 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			} break;
 /*a6*/	case CMPSb: {	int m = mode|(MBYTE|MOVSSRC|MOVSDST);
 			Gen(O_MOVS_SetA, m);
+			Gen(O_MOVS_LodD, m);
 			Gen(O_MOVS_CmpD, m);
 			Gen(O_MOVS_SavA, m);
 			PC++; } break;
 /*a7*/	case CMPSw: {	int m = mode|(MOVSSRC|MOVSDST);
 			Gen(O_MOVS_SetA, m);
+			Gen(O_MOVS_LodD, m);
 			Gen(O_MOVS_CmpD, m);
 			Gen(O_MOVS_SavA, m);
 			PC++; } break;
@@ -1789,12 +1791,18 @@ repag0:
 				case CMPSb:
 					repmod |= (MBYTE|MOVSSRC|MOVSDST|MREPCOND);
 					Gen(O_MOVS_SetA, repmod);
+					if (!(repmod & (MREPNE|MREP))) {
+						Gen(O_MOVS_LodD, repmod);
+					}
 					Gen(O_MOVS_CmpD, repmod);
 					Gen(O_MOVS_SavA, repmod);
 					PC++; break;
 				case CMPSw:
 					repmod |= (MOVSSRC|MOVSDST|MREPCOND);
 					Gen(O_MOVS_SetA, repmod);
+					if (!(repmod & (MREPNE|MREP))) {
+						Gen(O_MOVS_LodD, repmod);
+					}
 					Gen(O_MOVS_CmpD, repmod);
 					Gen(O_MOVS_SavA, repmod);
 					PC++; break;

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -256,7 +256,7 @@ int e_vgaemu_fault(sigcontext_t *scp, unsigned page_fault)
   if (vga_page < vga.mem.pages) {
     unsigned char *p;
     unsigned long cxrep;
-    int w16, mode;
+    int w16;
     if (!vga.inst_emu) {
       /* Normal: make the display page writeable after marking it dirty */
       dosemu_error("simx86: should not be here\n");
@@ -307,23 +307,6 @@ int e_vgaemu_fault(sigcontext_t *scp, unsigned page_fault)
 		else
 			_eax = e_VgaRead(LINP(_edi),DATA32);
 		_rip = (long)(p+2); break;
-/*a6*/	case CMPSb:
-		mode = MBYTE;
-		goto CMPS_common;
-/*a7*/	case CMPSw:
-		mode = w16 ? DATA16 : 0;
-	CMPS_common:
-		mode |= MOVSSRC|MOVSDST;
-		AR1.d = _edi;
-		AR2.d = _esi;
-		TR1.d = 1;
-		Gen_sim(O_MOVS_CmpD, mode);
-		FlagSync_All();
-		_edi = AR1.d;
-		_esi = AR2.d;
-		_eflags = (_eflags & ~EFLAGS_CC) | (EFLAGS & EFLAGS_CC);
-		_rip = (long)(p+1);
-		break;
 /*ac*/	case LODSb: {
 		int d = (_eflags & EFLAGS_DF? -1:1);
 		if (_err&2) goto badrw;


### PR DESCRIPTION
This way there is no more cmps in generated code without rep, so
the sigsegv code can also be simplified.

(Next one from #156)