### PR TITLE
simx86: fix cs value pushed for 32-bit far call/jmp

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2993,7 +2993,7 @@ void Gen_sim(int op, int mode, ...)
 		P0 = va_arg(ap,unsigned int);
 		unsigned int d_nt = va_arg(ap,unsigned int);
 		if (cond == 0x11)
-			PUSH(mode, &d_nt);
+			PUSH(mode, d_nt);
 		if (debug_level('e')>2) {
 			if(cond == 0x11)
 				dbug_printf("CALL: ret=%08x\n",d_nt);

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -221,7 +221,7 @@ static __inline__ int FastLog2(register int v)
 
 /////////////////////////////////////////////////////////////////////////////
 
-static __inline__ void PUSH(int m, void *w)
+static __inline__ void PUSH(int m, uint32_t w)
 {
 	unsigned int sp;
 	unsigned int addr;
@@ -230,10 +230,10 @@ static __inline__ void PUSH(int m, void *w)
 	addr = LONG_SS + sp;
 	if (m&DATA16) {
 		e_invalidate(addr, 2);
-		WRITE_WORD(addr, *(short *)w);
+		WRITE_WORD(addr, w);
 	} else {
 		e_invalidate(addr, 4);
-		WRITE_DWORD(addr, *(int *)w);
+		WRITE_DWORD(addr, w);
 	}
 #ifdef KEEP_ESP
 	TheCPU.esp = (sp&TheCPU.StackMask) | (TheCPU.esp&~TheCPU.StackMask);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -631,7 +631,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    temp = EFLAGS & 0xdff;
 			    if (eVEFLAGS & VIF) temp |= EFLAGS_IF;
 			    temp |= (IOPL_MASK|eVEFLAGS) & eTSSMASK;
-			    PUSH(mode, &temp);
+			    PUSH(mode, temp);
 			    if (debug_level('e')>1)
 				e_printf("Pushed flags %08x fl=%08x vf=%08x\n",
 		    			temp,EFLAGS,eVEFLAGS);
@@ -1503,8 +1503,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			if (opc==CALLl) {
 			    /* ok, now push old cs:eip */
 			    oip = PC - xcs;
-			    PUSH(mode, &ocs);
-			    PUSH(mode, &oip);
+			    PUSH(mode, ocs);
+			    PUSH(mode, oip);
 			    if (debug_level('e')>2)
 				e_printf("CALL_FAR: ret=%04x:%08lx\n  calling:      %04x:%08lx\n",
 					ocs,oip,jcs,jip);
@@ -1564,15 +1564,16 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			ds = BT24(BitDATA16, mode);
 			sp = LONG_SS + ((rESP - ds) & TheCPU.StackMask);
 			bp = LONG_SS + (rEBP & TheCPU.StackMask);
-			PUSH(mode, &rEBP);
+			PUSH(mode, rEBP);
 			frm = sp - LONG_SS;
 			if (level) {
 				sp -= ds*level;
 				while (--level) {
 					bp -= ds;
-					PUSH(mode, MEM_BASE32(bp));
+					PUSH(mode, (mode&DATA16) ?
+					     READ_WORD(bp) : READ_DWORD(bp));
 				}
-				PUSH(mode, &frm);
+				PUSH(mode, frm);
 			}
 			if (mode&DATA16) rBP = frm; else rEBP = frm;
 			sp -= FetchW(PC+1);
@@ -2167,7 +2168,7 @@ repag0:
 						dp = DataGetWL_U(mode, TheCPU.mem_ref);
 					}
 					if (REG1==Ofs_DX) {
-						PUSH(mode, &TheCPU.eip);
+						PUSH(mode, TheCPU.eip);
 						if (debug_level('e')>2)
 							e_printf("CALL indirect: ret=%08x\n\tcalling: %08x\n",
 								TheCPU.eip,dp);
@@ -2201,8 +2202,8 @@ repag0:
 					if (REG1==Ofs_BX) {
 					    /* ok, now push old cs:eip */
 					    oip = PC - xcs;
-					    PUSH(mode, &ocs);
-					    PUSH(mode, &oip);
+					    PUSH(mode, ocs);
+					    PUSH(mode, oip);
 					    if (debug_level('e')>2)
 						e_printf("CALL_FAR indirect: ret=%04x:%08lx\n\tcalling: %04x:%08lx\n",
 							ocs,oip,jcs,jip);


### PR DESCRIPTION
The PUSH() inline function was passed &ocs where ocs is unsigned short,
but then cast it to *(int *), which could push garbage onto the 32bit
stack. Avoid this tricky behaviour by passing by value instead.

This caused buggy behaviour where cs could be >0xffff with the Causeway DOS
extender.