### PR TITLE
SDL/keyboard: add some keynums for multimedia/misc keys

### DIFF
--- a/src/base/kbd_unicode/keynum.c
+++ b/src/base/kbd_unicode/keynum.c
@@ -104,6 +104,18 @@ t_keynum validate_keynum(t_keynum key)
 	case NUM_F10:
 	case NUM_F11:
 	case NUM_F12:
+	case NUM_F13:
+	case NUM_F14:
+	case NUM_F15:
+	case NUM_F16:
+	case NUM_F17:
+	case NUM_F18:
+	case NUM_F19:
+	case NUM_F20:
+	case NUM_F21:
+	case NUM_F22:
+	case NUM_F23:
+	case NUM_F24:
 
 	/* cursor block */
 
@@ -122,6 +134,12 @@ t_keynum validate_keynum(t_keynum key)
 	case NUM_LWIN:
 	case NUM_RWIN:
 	case NUM_MENU:
+
+	/* Multimedia/misc keys */
+	case NUM_MUTE:
+	case NUM_VOLUMEDOWN:
+	case NUM_VOLUMEUP:
+	case NUM_AC_BOOKMARKS:
 
 	/* Dual scancode keys */
 	case NUM_PRTSCR_SYSRQ:

--- a/src/include/keyboard/keynum.h
+++ b/src/include/keyboard/keynum.h
@@ -12,6 +12,9 @@
  *
  * Most applications should use keysyms, not keynums,
  * so the code still works when the keyboard is remapped.
+ *
+ * Check https://github.com/qemu/keycodemapdb/blob/master/data/keymaps.csv
+ * for reference (see "AT set1 keycode" column)
  */
 #include "keyboard.h"
 
@@ -117,6 +120,18 @@
 #define NUM_F10		0x44
 #define NUM_F11		0x57
 #define NUM_F12		0x58
+#define NUM_F13		0x5d
+#define NUM_F14		0x5e
+#define NUM_F15		0x5f
+#define NUM_F16		0x55
+#define NUM_F17		(0x03 | 0x80)
+#define NUM_F18		(0x77 | 0x80)
+#define NUM_F19		(0x04 | 0x80)
+#define NUM_F20		0x5a
+#define NUM_F21		0x74
+#define NUM_F22		(0x79 | 0x80)
+#define NUM_F23		0x6d
+#define NUM_F24		0x6f
 
 /* cursor block */
 
@@ -135,6 +150,12 @@
 #define NUM_LWIN	(0x5b | 0x80)
 #define NUM_RWIN	(0x5c | 0x80)
 #define NUM_MENU	(0x5d | 0x80)
+
+/* Multimedia/misc keys */
+#define NUM_MUTE	(0x20 | 0x80)
+#define NUM_VOLUMEDOWN	(0x2e | 0x80)
+#define NUM_VOLUMEUP	(0x30 | 0x80)
+#define NUM_AC_BOOKMARKS (0x66 | 0x80)
 
 /* Dual scancode keys */
 #define NUM_PRTSCR_SYSRQ	0x54

--- a/src/plugin/sdl/keyb_SDL.c
+++ b/src/plugin/sdl/keyb_SDL.c
@@ -103,7 +103,8 @@ void SDL_process_key_press(SDL_KeyboardEvent keyevent)
 	SDL_Scancode scan = keysym.scancode;
 	t_keynum keynum = sdl2_scancode_to_keynum[scan];
 
-	k_printf("SDL: non-text key pressed: %c\n", keysym.sym);
+	k_printf("SDL: non-text key pressed: %c (scancode=%d)\n",
+		 keysym.sym, scan);
 	assert(keyevent.state == SDL_PRESSED);
 	SDL_sync_shiftstate(1, keysym.sym, keysym.mod);
 	move_keynum(1, keynum, DKY_VOID);

--- a/src/plugin/sdl/sdl2-keymap.h
+++ b/src/plugin/sdl/sdl2-keymap.h
@@ -110,6 +110,7 @@ static const int sdl2_scancode_to_keynum[SDL_NUM_SCANCODES] = {
 #if 0
     [SDL_SCANCODE_POWER]             = NUM_POWER,
     [SDL_SCANCODE_KP_EQUALS]         = NUM_KP_EQUALS,
+#endif
 
     [SDL_SCANCODE_F13]               = NUM_F13,
     [SDL_SCANCODE_F14]               = NUM_F14,
@@ -124,6 +125,7 @@ static const int sdl2_scancode_to_keynum[SDL_NUM_SCANCODES] = {
     [SDL_SCANCODE_F23]               = NUM_F23,
     [SDL_SCANCODE_F24]               = NUM_F24,
 
+#if 0
     [SDL_SCANCODE_EXECUTE]           = NUM_EXECUTE,
 #endif
 //    [SDL_SCANCODE_HELP]              = NUM_HELP,
@@ -137,10 +139,12 @@ static const int sdl2_scancode_to_keynum[SDL_NUM_SCANCODES] = {
     [SDL_SCANCODE_COPY]              = NUM_COPY,
     [SDL_SCANCODE_PASTE]             = NUM_PASTE,
     [SDL_SCANCODE_FIND]              = NUM_FIND,
+#endif
     [SDL_SCANCODE_MUTE]              = NUM_MUTE,
     [SDL_SCANCODE_VOLUMEUP]          = NUM_VOLUMEUP,
     [SDL_SCANCODE_VOLUMEDOWN]        = NUM_VOLUMEDOWN,
 
+#if 0
     [SDL_SCANCODE_KP_COMMA]          = NUM_KP_COMMA,
     [SDL_SCANCODE_KP_EQUALSAS400]    = NUM_KP_EQUALSAS400,
 
@@ -249,7 +253,9 @@ static const int sdl2_scancode_to_keynum[SDL_NUM_SCANCODES] = {
     [SDL_SCANCODE_AC_FORWARD]        = NUM_AC_FORWARD,
     [SDL_SCANCODE_AC_STOP]           = NUM_AC_STOP,
     [SDL_SCANCODE_AC_REFRESH]        = NUM_AC_REFRESH,
+#endif
     [SDL_SCANCODE_AC_BOOKMARKS]      = NUM_AC_BOOKMARKS,
+#if 0
     [SDL_SCANCODE_BRIGHTNESSDOWN]    = NUM_BRIGHTNESSDOWN,
     [SDL_SCANCODE_BRIGHTNESSUP]      = NUM_BRIGHTNESSUP,
     [SDL_SCANCODE_DISPLAYSWITCH]     = NUM_DISPLAYSWITCH,


### PR DESCRIPTION
This avoids an assert crash as in #1045 for volume up/down, mute, bookmark,
f13-f24, though it's not complete. Using
https://github.com/qemu/keycodemapdb/blob/master/data/keymaps.csv
the list could be completed.