### PR TITLE
simx86: Make e_VgaMovs less cumbersome to use and clean it up.

### DIFF
--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -794,6 +794,13 @@ unsigned short vga_read_word(dosaddr_t addr)
   return vga_read(addr) | vga_read(addr + 1) << 8;
 }
 
+unsigned vga_read_dword(dosaddr_t addr)
+{
+  if (!vga.inst_emu)
+    return READ_DWORD(addr);
+  return vga_read_word(addr) | vga_read_word(addr + 2) << 16;
+}
+
 void vga_mark_dirty(dosaddr_t s_addr, int len)
 {
   unsigned vga_page, abeg, aend, addr;

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2378,24 +2378,13 @@ void Gen_sim(int op, int mode, ...)
 		    break;
 		v = vga_access(DOSADDR_REL(AR2.pu), DOSADDR_REL(AR1.pu));
 		if (v) {
-		    int op;
-		    sigcontext_t s, *scp = &s;
-		    _err = v;
-		    _rdi = AR1.d;
-		    _rsi = AR2.d;
-		    _rcx = i;
-		    op = 2 | (v == 3 ? 4 : 0);
-		    if (mode & MBYTE) {
-			op |= 1;
-		    } else {
+		    if (!(mode & MBYTE)) {
 			df *= 2;
-			if ((mode & DATA32)) {
+			if (!(mode & DATA16)) {
 			    df *= 2;
 			}
 		    }
-		    e_VgaMovs(scp, op, (mode & DATA16) ? 1 : 0, df);
-		    AR1.d = _edi;
-		    AR2.d = _esi;
+		    e_VgaMovs(&AR1.pu, &AR2.pu, i, df, v);
 		    TR1.d = 0;
 		    break;
 		}

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -701,7 +701,8 @@ void init_emu_npu(void);
 
 unsigned e_VgaRead(unsigned char *ptr, int mode);
 void e_VgaWrite(unsigned char *ptr, unsigned u, int mode);
-void e_VgaMovs(sigcontext_t *scp, char op, int w16, int dp);
+void e_VgaMovs(unsigned char **rdi, unsigned char **rsi, unsigned int rep,
+	       int dp, unsigned int access);
 int e_vgaemu_fault(sigcontext_t *scp, unsigned page_fault);
 
 #endif // _EMU86_EMU86_H

--- a/src/include/vgaemu.h
+++ b/src/include/vgaemu.h
@@ -507,6 +507,7 @@ unsigned char vga_read(unsigned addr);
 void vga_write(unsigned addr, unsigned char val);
 unsigned short vga_read_word(unsigned addr);
 void vga_write_word(unsigned addr, unsigned short val);
+unsigned vga_read_dword(unsigned addr);
 void vga_write_dword(dosaddr_t addr, unsigned val);
 void memcpy_to_vga(unsigned dst, const void *src, size_t len);
 void memcpy_dos_to_vga(unsigned dst, unsigned src, size_t len);


### PR DESCRIPTION
This needed the definition of vga_read_dword that was missing in
vgaemu.c.