### PR TITLE
simx86: move "rep scas"/"rep cmps" vgaemu handling to cpatch.c.

### DIFF
--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1820,7 +1820,7 @@ shrot0:
 		break;
 	case O_MOVS_LodD:
 		GetDF(Cp);
-		if (mode&(MREP|MREPNE))	{ G1(REP,Cp); }
+		G3M(NOP,NOP,REP,Cp);
 		if (mode&MBYTE)	{ G1(LODSb,Cp); }
 		else {
 			Gen66(mode,Cp);
@@ -1844,6 +1844,7 @@ shrot0:
 		// Pointer to the jecxz distance byte
 		CpTemp = Cp-1;
 		GetDF(Cp);
+		G2M(NOP,NOP,Cp);
 		G1((mode&MREP)?REP:REPNE,Cp);
 		if (mode&MBYTE)	{ G1(SCASb,Cp); }
 		else {
@@ -1886,6 +1887,7 @@ shrot0:
 		// Pointer to the jecxz distance byte
 		CpTemp = Cp-1;
 		GetDF(Cp);
+		G2M(NOP,NOP,Cp);
 		G1((mode&MREP)?REP:REPNE,Cp);
 		if (mode&MBYTE)	{ G1(CMPSb,Cp); }
 		else {

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -120,7 +120,7 @@ asmlinkage void rep_movs_stos(struct rep_stack *stack)
 		if (v) {
 			int df = ((EFLAGS & EFLAGS_DF) ? -size:size);
 			e_VgaMovs(&stack->edi, &stack->esi, ecx, df, v);
-			ecx = 0;
+			stack->ecx = 0;
 			goto done;
 		}
 		esi = LINEAR2UNIX(source);
@@ -140,7 +140,7 @@ asmlinkage void rep_movs_stos(struct rep_stack *stack)
 		else source += len;
 		stack->esi = MEM_BASE32(source);
 	}
-	else { /* stos */
+	else if ((op & 0xfe) == 0xaa) { /* stos */
 		unsigned int eax = stack->eax;
 		if (ecx == len) {
 			if (vga_write_access(addr)) {
@@ -176,11 +176,33 @@ asmlinkage void rep_movs_stos(struct rep_stack *stack)
 			else repstos(,l,);
 		}
 	}
+	else if ((op & 0xf6) == 0xa6) { /* cmps/scas */
+		int repmod = (size == 1 ? MBYTE : size == 2 ? DATA16 : 0);
+		AR1.pu = stack->edi;
+		TR1.d = stack->ecx;
+		repmod |= MOVSDST|MREPCOND|(eip[-1]==REPNE? MREPNE:MREP);
+		if ((op & 0xf6) == 0xa6) { /* cmps */
+			repmod |= MOVSSRC;
+			AR2.pu = stack->esi;
+			Gen_sim(O_MOVS_CmpD, repmod);
+			stack->esi = AR2.pu;
+		}
+		else { /* scas */
+			DR1.d = stack->eax;
+			Gen_sim(O_MOVS_ScaD, repmod);
+		}
+		FlagSync_All();
+		stack->edi = AR1.pu;
+		stack->ecx = TR1.d;
+		stack->eflags = (stack->eflags & ~EFLAGS_CC) |
+			(EFLAGS & EFLAGS_CC);
+		goto done;
+	}
 	if (EFLAGS & EFLAGS_DF) addr -= len;
 	else addr += len;
 	stack->edi = MEM_BASE32(addr);
-done:
 	stack->ecx = ecx;
+done:
 	InCompiledCode++;
 	in_cpatch--;
 }
@@ -427,8 +449,9 @@ int Cpatch(sigcontext_t *scp)
 	return 0;
 
     p = eip;
-    if (*p==0xf3 && p[-1] == 0x90 && p[-2] == 0x90) {	// rep movs, rep stos
-	if (debug_level('e')>1) e_printf("### REP movs/stos patch at %p\n",eip);
+    if ((*p==0xf3 || *p==0xf2) && p[-1] == 0x90 && p[-2] == 0x90) {
+	// rep movs, rep stos, rep lods, rep scas, rep cmps
+	if (debug_level('e')>1) e_printf("### REP patch at %p\n",eip);
 	p-=2;
 	G2M(0xff,0x13,p); /* call (%ebx) */
 	_rip -= 2; /* make sure call (%ebx) is performed the first time */


### PR DESCRIPTION
The expensive part of e_vgaemu_fault() is now completely eliminated.