### PR TITLE
simx86: fixup ESP in case POP [memory] page faults

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2244,13 +2244,15 @@ void Gen_sim(int op, int mode, ...)
 		if (mode & DATA16) {
 			SR1.d &= stackm;
 			DR1.w.l = *((short *)(uintptr_t)(AR2.d + SR1.d));
-			CPUWORD(o) = DR1.w.l;
+			if (!(mode & MPOPRM))
+				CPUWORD(o) = DR1.w.l;
 			SR1.d += 2;
 		}
 		else {
 			SR1.d &= stackm;
 			DR1.d = *((int *)(uintptr_t)(AR2.d + SR1.d));
-			CPULONG(o) = DR1.d;
+			if (!(mode & MPOPRM))
+				CPULONG(o) = DR1.d;
 			SR1.d += 4;
 #ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
 			SR1.d |= (CPULONG(Ofs_ESP) & ~stackm);

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -172,6 +172,7 @@
 #define MBYTX	0x00002000
 #define MOVSSRC	0x00004000
 #define MOVSDST	0x00008000
+#define MPOPRM	0x00010000
 
 #define CKSIGN	0x00100000	// check signal: for jumps
 #define SKIPOP	0x00200000

--- a/src/base/emu-i386/simx86/modrm-gen.c
+++ b/src/base/emu-i386/simx86/modrm-gen.c
@@ -134,6 +134,9 @@ int _ModRM(unsigned char opc, unsigned int PC, int mode)
 		if (mod==1) {
 			dsp=(signed char)Fetch(PC+l); l++;
 		}
+		/* for POPrm use the new ESP */
+		if (base == Ofs_ESP && (mode & MPOPRM))
+			dsp+=OPSIZE(mode);
 		if (index == Ofs_ESP)
 			AddrGen(A_DI_1, mode|IMMED, overr, dsp, base);
 		else


### PR DESCRIPTION
The dpmi/msdos LDT emulation code emulates POP on memory which got the wrong
value of ESP for page faults in full JIT and fullsim mode, so it needs to be
adjusted back to the original value before writing to memory.

This allows Windows 3.1 to run in full JIT and fullsim mode, although the
double CPU emulation is quite expensive!