### PR TITLE
fix autoemu.bat similar to autoexec.bat

### DIFF
--- a/src/bindist/autoemu.bat
+++ b/src/bindist/autoemu.bat
@@ -5,7 +5,7 @@ path c:\dos;c:\windows\command;e:\dosemu
 set TEMP=c:\tmp
 emusound /e
 prompt $P$G
-unix -s DOSDRIVE_EXTRA
+system -s DOSDRIVE_EXTRA
 if "%DOSDRIVE_EXTRA%" == "" goto nodrived
 lredir -n \\linux\fs%DOSDRIVE_EXTRA%
 :nodrived
@@ -13,7 +13,10 @@ rem uncomment to load another bitmap font
 rem mode con codepage prepare=((850) c:\dos\ega.cpi)
 rem mode con codepage select 850
 rem chcp 850
-lredir -nC \\linux\fs/media/cdrom
+system -s CDROM_PATH
+if "%CDROM_PATH%" == "" goto nocdrom
+lredir -nC \\linux\fs%CDROM_PATH%
+:nocdrom
 system -s DOSEMU_VERSION
 echo "Welcome to dosemu2 %DOSEMU_VERSION%!"
 system -ep


### PR DESCRIPTION
Not sure why this was not kept in sync, but now it works properly again. I tested it with MS DOS 6.22.