### PR TITLE
simx86: jit: handle LDT writes via Cpatch

### DIFF
--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -41,6 +41,7 @@
 #include "codegen-arch.h"
 #include "trees.h"
 #include "dpmi.h"
+#include "../dosext/dpmi/msdos/msdos_ldt.h"
 
 #include "video.h"
 #include "bios.h"
@@ -297,6 +298,9 @@ int e_emu_pagefault(sigcontext_t *scp, int pmode)
 	if (e_handle_pagefault(scp))
 	    return 1;
 #endif
+	/* use CPatch for LDT page faults, which should not fail */
+	if (msdos_ldt_access((unsigned char *)_cr2) && Cpatch(scp))
+	    return 1;
 	TheCPU.scp_err = _err;
 	/* save eip, eflags, and do a "ret" out of compiled code */
 	TheCPU.err = EXCP0E_PAGE;

--- a/src/dosext/dpmi/msdos/msdos_ldt.h
+++ b/src/dosext/dpmi/msdos/msdos_ldt.h
@@ -4,6 +4,8 @@
 unsigned short msdos_ldt_init(void);
 void msdos_ldt_done(void);
 int msdos_ldt_fault(sigcontext_t *scp, uint16_t sel);
+int msdos_ldt_access(unsigned char *cr2);
+void msdos_ldt_write(sigcontext_t *scp, uint32_t op, int len);
 int msdos_ldt_pagefault(sigcontext_t *scp);
 void msdos_ldt_update(int entry, u_char *buf, int len);
 


### PR DESCRIPTION
Rather than double emulation, use Cpatch to deal with LDT writes in the same
way as VGA writes.