### PR TITLE
simx86: do LDT writes without faulting in sim mode

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -536,6 +536,10 @@ void Gen_sim(int op, int mode, ...)
 		break;
 	case S_DI_IMM: {
 		int v = va_arg(ap,int);
+		if (emu_ldt_write(AR1.pu, v, OPSIZE(mode))) {
+			GTRACE0("S_DI_IMM_LDT");
+			break;
+		}
 		if (vga_write_access(DOSADDR_REL(AR1.pu))) {
 			GTRACE0("S_DI_IMM_VGA");
 			if (!vga_bank_access(DOSADDR_REL(AR1.pu))) break;
@@ -648,6 +652,10 @@ void Gen_sim(int op, int mode, ...)
 		if (debug_level('e')>3) dbug_printf("(V) %08x\n",DR1.d);
 		break;
 	case S_DI:
+		if (emu_ldt_write(AR1.pu, DR1.d, OPSIZE(mode))) {
+			GTRACE0("S_DI_LDT");
+			break;
+		}
 		if (vga_write_access(DOSADDR_REL(AR1.pu))) {
 			GTRACE0("L_S_DI");
 			if (!vga_bank_access(DOSADDR_REL(AR1.pu))) break;

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -36,7 +36,6 @@
 #include "trees.h"
 #include "codegen-arch.h"
 #include "cpatch.h"
-#include "../dosext/dpmi/msdos/msdos_ldt.h"
 
 #ifdef HOST_ARCH_X86
 
@@ -236,27 +235,6 @@ asmlinkage void stk_32(unsigned char *paddr, Bit32u value)
 	WRITE_DWORD(addr, value);
 	InCompiledCode++;
 	in_cpatch--;
-}
-
-static int emu_ldt_write(unsigned char *paddr, uint32_t op, int len)
-{
-	static sigcontext_t sc = {0};
-	sigcontext_t *scp = &sc;
-
-	if (!(msdos_ldt_access(paddr)))
-		return 0;
-
-	_cr2 = (uintptr_t)paddr;
-	_ds = TheCPU.ds;
-	_es = TheCPU.es;
-	_fs = TheCPU.fs;
-	_gs = TheCPU.gs;
-	msdos_ldt_write(scp, op, len);
-	if (_ds == 0) { TheCPU.ds = 0; SetSegProt(0,Ofs_DS,NULL,0); }
-	if (_es == 0) { TheCPU.es = 0; SetSegProt(0,Ofs_ES,NULL,0); }
-	if (_fs == 0) { TheCPU.fs = 0; SetSegProt(0,Ofs_FS,NULL,0); }
-	if (_gs == 0) { TheCPU.gs = 0; SetSegProt(0,Ofs_GS,NULL,0); }
-	return 1;
 }
 
 asmlinkage void wri_8(unsigned char *paddr, Bit8u value, unsigned char *eip)

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -231,6 +231,7 @@ int SetSegReal(unsigned short sel, int ofs);
 int e_larlsl(int mode, unsigned short sel);
 int hsw_verr(unsigned short sel);
 int hsw_verw(unsigned short sel);
+int emu_ldt_write(unsigned char *paddr, uint32_t op, int len);
 //
 
 #endif


### PR DESCRIPTION
in combination with #1064 this allows running Windows 3.x without page faults