### PR TITLE
simx86: fix UBSAN for shifting signed int quitting Win3x

### DIFF
--- a/src/base/emu-i386/simx86/memory.c
+++ b/src/base/emu-i386/simx86/memory.c
@@ -99,7 +99,7 @@ static int AddMpMap(unsigned int addr, unsigned int aend, int onoff)
 		M->mega = (page>>8);
 	    }
 	    if (bp < 32) {
-		bs |= (((onoff? set_bit(page&255, M->pagemap) :
+		bs |= (((unsigned)(onoff? set_bit(page&255, M->pagemap) :
 			    clear_bit(page&255, M->pagemap)) & 1) << bp);
 		bp++;
 	    }


### PR DESCRIPTION
Fixes
src/base/emu-i386/simx86/memory.c:103:46: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'