### PR TITLE
simx86: handle bitops to memory via load/store

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2870,13 +2870,9 @@ void Gen_sim(int op, int mode, ...)
 		    default: flg = 2;
 		    }
 		} else {
-		    switch (o1) {
-		    case 0x03: flg = test_bit(DR2.d, AR1.pdu); break;
-		    case 0x0b: flg = set_bit(DR2.d, AR1.pdu); break;
-		    case 0x13: flg = clear_bit(DR2.d, AR1.pdu); break;
-		    case 0x1b: flg = change_bit(DR2.d, AR1.pdu); break;
-		    default: flg = 2;
-		    }
+		    /* add bit offset to effective address */
+		    AR1.pu += (mode&DATA16) ? 2*(DR2.d>>4) : 4*(DR2.d>>5);
+		    break;
 		}
 		if (flg != 2)
 			SET_CF(flg&1);

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -2059,15 +2059,31 @@ shrot0:
 		case 0x0b: /* BTS */
 		case 0x13: /* BTR */
 		case 0x1b: /* BTC */
-			// mov{wl} offs(%%ebx),%%{e}dx
-			Gen66(mode,Cp);	G3M(0x8b,0x53,IG->p1,Cp);
+			if (mode&DATA16) {
+				// movzwl offs(%%ebx),%%edx
+				G4M(0x0f,0xb7,0x53,IG->p1,Cp);
+			}
+			else {
+				// movl offs(%%ebx),%%edx
+				G3M(0x8b,0x53,IG->p1,Cp);
+			}
 			if (mode & RM_REG) {
 				// OP{wl} %%{e}dx,%%{e}ax
 				Gen66(mode,Cp);	G3M(0x0f,(n+0xa0),0xd0,Cp);
 			}
 			else {
-				// OP{wl} %%{e}dx,(%%edi)
-				Gen66(mode,Cp);	G3M(0x0f,(n+0xa0),0x17,Cp);
+				/* add bit offset to effective address */
+				if (mode&DATA16) {
+					// shrl $4, %%edx
+					G3M(0xc1,0xea,0x04,Cp);
+					// leal (%%edi,%%edx,2), %%edi
+					G3M(0x8d,0x3c,0x57,Cp);
+				} else {
+					// shrl $5, %%edx
+					G3M(0xc1,0xea,0x05,Cp);
+					// leal (%%edi,%%edx,4), %%edi
+					G3M(0x8d,0x3c,0x97,Cp);
+				}
 			}
 			break;
 		case 0x1c: /* BSF */

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2777,10 +2777,18 @@ repag0:
 				if (TheCPU.mode & RM_REG) {
 				    Gen(L_REG, mode, REG3);
 				}
-				mode |= (TheCPU.mode & RM_REG);
-				Gen(O_BITOP, mode, (opc2-0xa0), REG1);
-				if (opc2 != 0xa3 && (TheCPU.mode & RM_REG)) {
-				    Gen(S_REG, mode, REG3);
+				else {
+				    /* add bit offset to effective address,
+				       then load and store from there */
+				    Gen(O_BITOP, mode, (opc2-0xa0), REG1);
+				    Gen(L_DI_R1, mode);
+				}
+				Gen(O_BITOP, mode|RM_REG, (opc2-0xa0), REG1);
+				if (opc2 != 0xa3) {
+				    if (TheCPU.mode & RM_REG)
+					Gen(S_REG, mode, REG3);
+				    else
+					Gen(S_DI, mode);
 				}
 				break;
 			case 0xbc: /* BSF */


### PR DESCRIPTION
This can be done by adding the bit offset to the effective address, and
this way Cpatch, VGAEMU etc can work correctly on these instructions.