### PR TITLE
simx86: introduce write_byte/word/dword, use in sim mode.

### DIFF
--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -700,7 +700,6 @@ void init_emu_npu_x86(void);
 void init_emu_npu(void);
 
 unsigned e_VgaRead(unsigned char *ptr, int mode);
-void e_VgaWrite(unsigned char *ptr, unsigned u, int mode);
 void e_VgaMovs(unsigned char **rdi, unsigned char **rsi, unsigned int rep,
 	       int dp, unsigned int access);
 int e_vgaemu_fault(sigcontext_t *scp, unsigned page_fault);

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -231,7 +231,6 @@ int SetSegReal(unsigned short sel, int ofs);
 int e_larlsl(int mode, unsigned short sel);
 int hsw_verr(unsigned short sel);
 int hsw_verw(unsigned short sel);
-int emu_ldt_write(unsigned char *paddr, uint32_t op, int len);
 //
 
 #endif

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -68,21 +68,6 @@ unsigned e_VgaRead(unsigned char *a, int mode)
   return u;
 }
 
-void e_VgaWrite(unsigned char *a, unsigned u, int mode)
-{
-  dosaddr_t addr = DOSADDR_REL(a);
-#ifdef DEBUG_VGA
-  e_printf("eVGAEmuFault: VGA write %08x at %08x mode %x\n",u,addr,mode);
-#endif
-  if (mode&MBYTE) {
-    vga_write(addr, u);
-    return;
-  }
-  vga_write_word(addr, u);
-  if (mode&DATA16) return;
-  vga_write_word(addr+2, u>>16);
-}
-
 void e_VgaMovs(unsigned char **rdi, unsigned char **rsi, unsigned int rep,
 	       int dp, unsigned int access)
 {

--- a/src/base/misc/dos2linux.c
+++ b/src/base/misc/dos2linux.c
@@ -567,6 +567,42 @@ int change_config(unsigned item, void *buf, int grab_active, int kbd_grab_active
   return err;
 }
 
+void write_byte(dosaddr_t addr, uint8_t byte)
+{
+  if (emu_ldt_write(MEM_BASE32(addr), byte, 1))
+    return;
+  if (vga_write_access(addr)) {
+    if (vga_bank_access(addr))
+      vga_write(addr, byte);
+    return;
+  }
+  WRITE_BYTE(addr, byte);
+}
+
+void write_word(dosaddr_t addr, uint16_t word)
+{
+  if (emu_ldt_write(MEM_BASE32(addr), word, 2))
+    return;
+  if (vga_write_access(addr)) {
+    if (vga_bank_access(addr))
+      vga_write_word(addr, word);
+    return;
+  }
+  WRITE_WORD(addr, word);
+}
+
+void write_dword(dosaddr_t addr, uint32_t dword)
+{
+  if (emu_ldt_write(MEM_BASE32(addr), dword, 4))
+    return;
+  if (vga_write_access(addr)) {
+    if (vga_bank_access(addr))
+      vga_write_dword(addr, dword);
+    return;
+  }
+  WRITE_DWORD(addr, dword);
+}
+
 void memcpy_2unix(void *dest, dosaddr_t src, size_t n)
 {
   if (vga.inst_emu && src >= 0xa0000 && src < 0xc0000)

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -86,6 +86,9 @@ void e_invalidate_full(unsigned data, int cnt);
 #define e_invalidate_full(x,y)
 #endif
 
+/* called from dos2linux.c */
+int emu_ldt_write(unsigned char *paddr, uint32_t op, int len);
+
 /* called from cpu.c */
 void init_emu_cpu (void);
 void reset_emu_cpu (void);

--- a/src/include/dos2linux.h
+++ b/src/include/dos2linux.h
@@ -314,6 +314,10 @@ extern int run_unix_command (char *buffer);
 extern int change_config(unsigned item, void *buf, int grab_active, int kbd_grab_active);
 
 void show_welcome_screen(void);
+
+void write_byte(dosaddr_t addr, uint8_t byte);
+void write_word(dosaddr_t addr, uint16_t word);
+void write_dword(dosaddr_t addr, uint32_t dword);
 void memcpy_2unix(void *dest, unsigned src, size_t n);
 void memcpy_2dos(unsigned dest, const void *src, size_t n);
 void memmove_dos2dos(unsigned dest, unsigned src, size_t n);


### PR DESCRIPTION
I put the write_* functions in dos2linux.c since they are useful in other
places too, with a little modification (future work).
e_VgaWrite() has been eliminated.